### PR TITLE
feature/argocd rbac

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-allow-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-allow-all
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-allow-all
+rules:
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - nonResourceURLs:
+    - '*'
+    verbs:
+    - '*'

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-gitops/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
+- ../../base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../common
-- ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/openshift-gitops-openshift-gitops-argocd-application-controller
+- ../../bundles/openshift-gitops
 - clusterversion.yaml


### PR DESCRIPTION
This includes three commits:

- Add argocd-allow-all cluster role and binding
- Move all openshift-gitops related config into a bundle
- Enable openshift-gitopts bundle on nerc-ocp-infra

The real purpose is:

Add argocd-allow-all cluster role and binding

This is an attempt to work around [GITOPS-1777][] (aka
redhat-developer/gitops-operator#255). Instead of modifying the rbac
installed by the cluster operator, we're adding our own to avoid triggering
a reconcile.

[GITOPS-1777]: https://issues.redhat.com/browse/GITOPS-1777
