### PR TITLE
Apply some minor cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/overlays/*-local/

--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: open-cluster-management
 resources:
 - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
@@ -2,7 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
     name: acm
-    namespace: open-cluster-management
 spec:
     channel: release-2.5
     installPlanApproval: Automatic

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-operators
 resources:
 - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
@@ -1,10 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-    labels:
-        operators.coreos.com/ocs-operator.cert-manager: ""
     name: cert-manager
-    namespace: openshift-operators
 spec:
     channel: stable
     installPlanApproval: Automatic

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-operators
 resources:
     - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
@@ -1,10 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/openshift-gitops-operator.openshift-operators: ""
   name: openshift-gitops-operator
-  namespace: openshift-operators
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - machineconfigs/99-master-ssh.yaml
 - machineconfigs/99-worker-ssh.yaml
+- ../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
 - ../common
 - ../../bundles/openshift-gitops
 - ../../bundles/acm
-- ../../base/operators.coreos.com/subscriptions/cert-manager
 - clusterversion.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
 resources:
 - ../common
 - ../../bundles/openshift-gitops


### PR DESCRIPTION
This PR includes a number of small changes:

1. Be more consistent about where we're managing the namespace for operator subscriptions
2. Move cert-manager into the common overlay, since we're going to want that on all of our clusters
3. Add a `.gitignore` file that will ignore overlays with a `-local` suffix
4. Apply a common label to all kustomized manifests