### PR TITLE
Install OpenShift Data Foundation (ODF, née OCS)

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-storage/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-storage/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-storage/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-storage/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage

--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.10
+    installPlanApproval: Automatic
+    name: odf-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/odf/kustomization.yaml
+++ b/cluster-scope/bundles/odf/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/openshift-storage
+- ../../base/operators.coreos.com/operatorgroups/openshift-storage
+- ../../base/operators.coreos.com/subscriptions/odf-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - ../common
 - ../../bundles/openshift-gitops
 - ../../bundles/acm
+- ../../bundles/odf
 - clusterversion.yaml


### PR DESCRIPTION
We need ODF in order to support persistent volumes.

This PR only installs the operator, but does not configure storage.