### PR TITLE
Configure GitHub IDP and cluster-admin access

### DIFF
--- a/cluster-scope/base/config.openshift.io/oauths/cluster/kustomization.yaml
+++ b/cluster-scope/base/config.openshift.io/oauths/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - oauth.yaml

--- a/cluster-scope/base/config.openshift.io/oauths/cluster/oauth.yaml
+++ b/cluster-scope/base/config.openshift.io/oauths/cluster/oauth.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  name: cluster

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admins-nerc-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: cluster-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admins-nerc-sudoer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sudoer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: cluster-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/clusterrolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "false"
+  name: self-provisioners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: self-provisioner
+subjects: []

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/user.openshift.io/groups/cluster-admins/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cluster-admins/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cluster-admins
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/cluster-admins/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cluster-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader
+- ../../base/user.openshift.io/groups/cluster-admins

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
+- ../../bundles/cluster-admin-rbac/

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - machineconfigs/99-master-ssh.yaml
 - machineconfigs/99-worker-ssh.yaml
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
+- ../../base/config.openshift.io/oauths/cluster
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners

--- a/cluster-scope/overlays/nerc-ocp-infra/groups/cluster-admins_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/groups/cluster-admins_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cluster-admins
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+users:
+- jtriley
+- larsks
+- tzumainn
+- chrisstafford
+- knikolla
+- aabaris
+- naved001
+- joachimweyl
+- mikthoma

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
 - ../../bundles/acm
 - ../../base/operators.coreos.com/subscriptions/cert-manager
 - clusterversion.yaml
+
+patches:
+  - path: oauths/cluster_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patches:
   - path: oauths/cluster_patch.yaml
+  - path: groups/cluster-admins_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/oauths/cluster_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - name: github
+      mappingMethod: claim
+      type: GitHub
+      github:
+        clientID: 77915cd4cdb5c4df7723
+        clientSecret:
+          name: github-client-secret
+        teams:
+          - ocp-on-nerc/nerc-ops


### PR DESCRIPTION
Enable non-kubeadmin access to the nerc-ocp-infra cluster:

## Configure GitHub IDP

This commit adds a GitHub identity provider, and disables the
self-provisioner role for all counts. Currently, GitHub auth access is
limited to the ocp-on-nerc/nerc-ops group.

## Configure RBAC for cluster admin access

Grant members of the `cluster-admins` group both `cluster-reader` and
`sudoer` access. This permits members of this group to see most
cluster resources, and to impersonate other users, including the
`system:admin` user for full cluster-admin access.

From the command line, you can use the `--as` option to impersonate
the admin user:

   oc --as system:admin create ns example

