### PR TITLE
Sync ocp groups with github team membership

### DIFF
--- a/cluster-scope/base/core/namespaces/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/group-sync-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/group-sync-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/group-sync-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: group-sync-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: group-sync-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: group-sync-operator
+spec:
+  targetNamespaces:
+    - group-sync-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: group-sync-operator
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: group-sync-operator
+spec:
+    channel: alpha
+    installPlanApproval: Automatic
+    name: group-sync-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admins-nerc-portforward
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-portforward-all
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: cluster-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-portforward-all
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "pods/portforward"
+    verbs:
+    - "*"

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader
 - ../../base/user.openshift.io/groups/cluster-admins
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward

--- a/cluster-scope/bundles/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/bundles/group-sync-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/group-sync-operator
+- ../../base/operators.coreos.com/operatorgroups/group-sync-operator
+- ../../base/operators.coreos.com/subscriptions/group-sync-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-cluster-reader.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-cluster-reader.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-ops-cluster-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-ops

--- a/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-portforward.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-portforward.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-ops-portforward
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-portforward-all
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-ops

--- a/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-sudoers.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterrolebindings/nerc-ops-sudoers.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-ops-sudoers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sudoer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-ops

--- a/cluster-scope/overlays/nerc-ocp-infra/groupsyncs/github-ocp-on-nerc.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/groupsyncs/github-ocp-on-nerc.yaml
@@ -1,0 +1,14 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GroupSync
+metadata:
+  name: github-ocp-on-nerc
+  namespace: group-sync-operator
+spec:
+  providers:
+  - name: github
+    github:
+      organization: ocp-on-nerc
+      prune: true
+      credentialsSecret:
+        name: github-ocp-on-nerc
+        namespace: group-sync-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
 - ../../bundles/odf
 - clusterversion.yaml
 
+- groupsyncs/github-ocp-on-nerc.yaml
+- clusterrolebindings/nerc-ops-cluster-reader.yaml
+- clusterrolebindings/nerc-ops-sudoers.yaml
+
 patches:
-  - path: oauths/cluster_patch.yaml
-  - path: groups/cluster-admins_patch.yaml
+- path: oauths/cluster_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - groupsyncs/github-ocp-on-nerc.yaml
 - clusterrolebindings/nerc-ops-cluster-reader.yaml
 - clusterrolebindings/nerc-ops-sudoers.yaml
+- clusterrolebindings/nerc-ops-portforward.yaml
 
 patches:
 - path: oauths/cluster_patch.yaml


### PR DESCRIPTION
This PR installs the [group sync operator](https://github.com/redhat-cop/group-sync-operator) and configures it to sync teams from the [ocp-on-nerc](https://github.com/OCP-on-NERC) organization to groups in the nerc-ocp-infra cluster.

It adds RBAC to give members of the `nerc-ops` team cluster-read access (with sudoers capability).
