### PR TITLE
Switch nmstate from "stable" to "4.10" channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: kubernetes-nmstate-operator
 spec:
-    channel: stable
+    channel: 4.10
     installPlanApproval: Automatic
     name: kubernetes-nmstate-operator
     source: redhat-operators


### PR DESCRIPTION
The "stable" channel is resulting in errors:

> no channel heads (entries not replaced by another entry) found in
> channel "stable" of package "kubernetes-nmstate-operator"",