### PR TITLE
Set routingViaHost in OVN configuration

### DIFF
--- a/cluster-scope/base/operator.openshift.io/networks/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.openshift.io/networks/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - network.yaml

--- a/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
+++ b/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
@@ -1,0 +1,9 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        routingViaHost: true

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: kubernetes-nmstate-operator
 spec:
-    channel: stable
+    channel: "4.10"
     installPlanApproval: Automatic
     name: kubernetes-nmstate-operator
     source: redhat-operators

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../../bundles/openshift-gitops
 - ../../bundles/acm
 - ../../bundles/odf
+- ../../base/operator.openshift.io/networks/cluster
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
 - machineconfigs/mellanox-udev-rules


### PR DESCRIPTION
Set the `gatewayConfig.routingViaHost` option in the OVNKubernetes
configuration. This is necessary for connections initiated from pods
to use the host routing tables. From the docs [1]:

> Set this field to true to send egress traffic from pods to the host
> networking stack. For highly-specialized installations and
> applications that rely on manually configured routes in the kernel
> routing table, you might want to route egress traffic to the host
> networking stack. By default, egress traffic is processed in OVN to
> exit the cluster and is not affected by specialized routes in the
> kernel routing table. The default value is false.
>
> This field has an interaction with the Open vSwitch hardware
> offloading feature. If you set this field to true, you do not
> receive the performance benefits of the offloading because egress
> traffic is processed by the host networking stack.

[1]: https://docs.openshift.com/container-platform/4.10/networking/cluster-network-operator.html