### PR TITLE
Configure OpenShift image registry

### DIFF
--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/kustomization.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - persistentvolumeclaim.yaml

--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: image-registry-storage
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/config.yaml
+++ b/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/config.yaml
@@ -1,0 +1,10 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+  replicas: 1
+  storage:
+    pvc:
+      claim: image-registry-storage

--- a/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/kustomization.yaml
+++ b/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - config.yaml

--- a/cluster-scope/bundles/image-registry/kustomization.yaml
+++ b/cluster-scope/bundles/image-registry/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/imageregistry.operator.openshift.io/configs/cluster
+- ../../base/core/persistentvolumeclaims/image-registry-storage

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
-- ../../bundles/cluster-admin-rbac/
+- ../../bundles/cluster-admin-rbac
 - ../../bundles/nmstate
 - ../../bundles/console
+- ../../bundles/image-registry


### PR DESCRIPTION
Now that we have storage we can enable the image registry. Because
we're limited to Ceph RBD storage, we only have RWO [1] volumes, which
means we can only have a single replica for the registry service.

It is possible to use an S3 backend for the registry (which would
allow us to have multiple replicas), but it looks as if getting things
set up to use a bucket from ODF [2] will be tricky.

[1]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
[2]: https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation

