### PR TITLE
Fix ocs-external-storagecluster-ceph-rbd storageclass

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
 patches:
 - path: oauths/cluster_patch.yaml
 - path: consoles.operator.openshift.io/cluster_patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
@@ -1,0 +1,17 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-external-storagecluster-ceph-rbd
+parameters:
+  clusterID: openshift-storage
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: nerc_ocp_infra_1_rbd


### PR DESCRIPTION
ArgoCD doesn't support patching a resource; we need to provide the
complete definition in the repository (or resort to some sort of
post-sync hook [1], which is less than ideal).

This commit updates the definition of the
ocs-external-storagecluster-ceph-rbd storageclass so that it matches
the in-cluster definition.

[1]: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/