### PR TITLE
Correct incorrect service name in vault route

### DIFF
--- a/vault/base/routes/route.yaml
+++ b/vault/base/routes/route.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   to:
     kind: Service
-    name: vault
+    name: nerc-vault
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Vault route was looking for service called vault. Updating to the correct name nerc-vault