### PR TITLE
Configure ClusterSecretStore for infra cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: external-secrets-operator
 resources:
-- subscription.yaml
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets-operator
+spec: {}

--- a/cluster-scope/base/core/serviceaccounts/eso-vault-auth/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/eso-vault-auth/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+    - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/eso-vault-auth/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/eso-vault-auth/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-vault-auth

--- a/cluster-scope/base/core/serviceaccounts/vault-secret-reader/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/vault-secret-reader/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+- serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/vault-secret-reader/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/vault-secret-reader/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secret-reader

--- a/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/clustersecretstore.yaml
+++ b/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/clustersecretstore.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: nerc-cluster-secrets
+spec:
+  provider:
+    vault:
+      server: "http://nerc-vault.vault.svc:8200"
+      path: "nerc"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: kubernetes/
+          role: secret-reader
+          serviceAccountRef:
+            name: "vault-secret-reader"
+            namespace: "external-secrets-operator"

--- a/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clustersecretstore.yaml

--- a/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+    - operatorconfig.yaml

--- a/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/operatorconfig.yaml
+++ b/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/operatorconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.external-secrets.io/v1alpha1
+kind: OperatorConfig
+metadata:
+  name: cluster
+spec:
+  prometheus:
+    enabled: true
+    service:
+      port: 8080
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 96Mi

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eso-tokenreview
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: eso-vault-auth
+    namespace: external-secrets-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/serviceaccounts/vault-secret-reader
+- ../../base/external-secrets.io/clustersecretstores/nerc-cluster-secrets

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/core/namespaces/external-secrets-operator
+- ../../base/core/serviceaccounts/eso-vault-auth
+- ../../base/operator.external-secrets.io/operatorconfigs/cluster
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../../base/core/serviceaccounts/eso-vault-auth
 - ../../base/operator.external-secrets.io/operatorconfigs/cluster
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/external-secrets-operator
+- ../../base/operators.coreos.com/subscriptions/external-secrets-operator

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -4,10 +4,10 @@ resources:
 - machineconfigs/99-master-ssh.yaml
 - machineconfigs/99-worker-ssh.yaml
 - ../../base/operators.coreos.com/subscriptions/cert-manager
-- ../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
 - ../../bundles/cluster-admin-rbac
+- ../../bundles/external-secrets
 - ../../bundles/nmstate
 - ../../bundles/console
 - ../../bundles/image-registry

--- a/cluster-scope/overlays/nerc-ocp-infra/clustersecretstores/nerc-cluster-secrets_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clustersecretstores/nerc-cluster-secrets_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: nerc-cluster-secrets
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes/nerc-ocp-infra/

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../../bundles/vault
 - ../../base/operator.openshift.io/networks/cluster
 - ../../bundles/odf-external
+- ../../bundles/external-secrets-clustersecretstore
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
 - machineconfigs/mellanox-udev-rules
@@ -24,3 +25,4 @@ patches:
 - path: oauths/cluster_patch.yaml
 - path: consoles.operator.openshift.io/cluster_patch.yaml
 - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+- path: clustersecretstores/nerc-cluster-secrets_patch.yaml


### PR DESCRIPTION
A ClusterSecretStore [1] creates a cluster-scoped secret store that will watch for ExternalSecret resources in all namespaces.

This commit creates a ClusterSecretStore that by defaults points at the vault instance on the local cluster and authenticates using a ServiceAccount. Every cluster overlay will need to patch spec.provider.vault.auth.kubernetes.mountPath, and clusters other than nerc-ocp-infra will need to (a) patch spec.provider.vault.server and (b) provide an alternative auth mechanism.

[1]: https://external-secrets.io/latest/api-clustersecretstore/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202594685849610