### PR TITLE
Enable ACM's Central Infrastructure Management service

### DIFF
--- a/acm/base/agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
+++ b/acm/base/agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
@@ -1,0 +1,30 @@
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+spec:
+  databaseStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100M
+  filesystemStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 100M
+  imageStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20G
+  osImages:
+    # You can get the value for "version" from "oc adm release info <openshiftVersion>"
+    - openshiftVersion: "4.10"
+      version: "410.84.202205191234-0"
+      url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/4.10.16/rhcos-live.x86_64.iso"
+      rootFSUrl: "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/4.10.16/rhcos-live-rootfs.x86_64.img"
+      cpuArchitecture: "x86_64"

--- a/acm/base/kustomization.yaml
+++ b/acm/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
+- metal3.io/provisionings/provisioning-configuration/provisioning.yaml

--- a/acm/base/metal3.io/provisionings/provisioning-configuration/provisioning.yaml
+++ b/acm/base/metal3.io/provisionings/provisioning-configuration/provisioning.yaml
@@ -1,0 +1,7 @@
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  provisioningNetwork: Disabled
+  watchAllNamespaces: true

--- a/acm/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base


### PR DESCRIPTION
The CIM service [1] allows ACM to manage bare metal hosts.

[1]: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html-single/clusters/index#enable-cim

x-branch: feature/assisted-installer

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202542604173706