### PR TITLE
Configure Dex as an OIDC provider

### DIFF
--- a/cluster-scope/base/core/namespaces/dex/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/dex/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/dex/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/dex/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex
+spec: {}

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ../../base/operator.openshift.io/networks/cluster
 - ../../bundles/odf-external
 - ../../bundles/external-secrets-clustersecretstore
+- ../../base/core/namespaces/dex
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
 - machineconfigs/mellanox-udev-rules

--- a/dex/base/deployments/dex.yaml
+++ b/dex/base/deployments/dex.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+spec:
+  template:
+    spec:
+      containers:
+        - command:
+            - "/usr/local/bin/dex"
+            - "serve"
+            - "/etc/dex/cfg/config.yaml"
+          image: quay.io/dexidp/dex:v2.28.1
+          imagePullPolicy: Always
+          name: dex
+          ports:
+            - containerPort: 5556
+              name: web
+            - containerPort: 5557
+              name: grpc
+            - containerPort: 5558
+              name: telemetry
+          volumeMounts:
+            - mountPath: /etc/dex/cfg
+              name: config
+            - name: ssl
+              mountPath: /etc/ssl/certs/ca.crt
+              subPath: ca.crt
+            - name: ssl
+              mountPath: /etc/ssl/certs/namespace
+              subPath: namespace
+            - name: ssl
+              mountPath: /etc/ssl/certs/service-ca.crt
+              subPath: service-ca.crt
+            - name: ssl
+              mountPath: /etc/ssl/certs/token
+              subPath: token
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          envFrom:
+            - secretRef:
+                name: dex-clients
+          env:
+            - name: OPENSHIFT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dex-sa-token
+                  key: token
+      volumes:
+        - name: config
+          configMap:
+            name: dex
+        - name: ssl
+          secret:
+            secretName: dex-sa-token
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: namespace
+                path: namespace
+              - key: service-ca.crt
+                path: service-ca.crt
+              - key: token
+                path: token

--- a/dex/base/deployments/kustomization.yaml
+++ b/dex/base/deployments/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  deployment: dex
+resources:
+  - dex.yaml

--- a/dex/base/externalsecrets/dex-clients.yaml
+++ b/dex/base/externalsecrets/dex-clients.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-clients
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  target:
+    name: dex-clients
+    creationPolicy: 'Owner'
+    deletionPolicy: "Retain"
+    template:
+      engineVersion: v2
+  dataFrom:
+    - extract:
+        key: $ENV/$CLUSTER/dex/dex-clients     # Patch $ENV/$CLUSTER in overlay

--- a/dex/base/externalsecrets/kustomization.yaml
+++ b/dex/base/externalsecrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex-clients.yaml

--- a/dex/base/kustomization.yaml
+++ b/dex/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+resources:
+- deployments
+- externalsecrets
+- routes
+- secrets
+- serviceaccounts
+- services
+commonLabels:
+  app.kubernetes.io/name: dex
+  app.kubernetes.io/component: dex-server
+  app.kubernetes.io/part-of: auth

--- a/dex/base/routes/dex.yaml
+++ b/dex/base/routes/dex.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: dex
+spec:
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  port:
+    targetPort: 5556
+  to:
+    kind: Service
+    name: dex

--- a/dex/base/routes/kustomization.yaml
+++ b/dex/base/routes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex.yaml

--- a/dex/base/secrets/dex-sa-token.yaml
+++ b/dex/base/secrets/dex-sa-token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-sa-token
+  annotations:
+    kubernetes.io/service-account.name: dex
+type: kubernetes.io/service-account-token

--- a/dex/base/secrets/kustomization.yaml
+++ b/dex/base/secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex-sa-token.yaml

--- a/dex/base/serviceaccounts/dex.yaml
+++ b/dex/base/serviceaccounts/dex.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+    serviceaccounts.openshift.io/oauth-redirecturi.dex: "callback"
+    serviceaccounts.openshift.io/oauth-redirectreference.dex: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"dex"}}'

--- a/dex/base/serviceaccounts/kustomization.yaml
+++ b/dex/base/serviceaccounts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex.yaml

--- a/dex/base/services/dex.yaml
+++ b/dex/base/services/dex.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+spec:
+  ports:
+    - name: http
+      port: 5556
+      protocol: TCP
+      targetPort: 5556
+    - name: grpc
+      port: 5557
+      protocol: TCP
+      targetPort: 5557
+    - name: metrics
+      port: 5558
+      protocol: TCP
+      targetPort: 5558

--- a/dex/base/services/kustomization.yaml
+++ b/dex/base/services/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex.yaml

--- a/dex/overlays/nerc-ocp-infra/configmaps/files/config.yaml
+++ b/dex/overlays/nerc-ocp-infra/configmaps/files/config.yaml
@@ -1,0 +1,36 @@
+issuer: https://dex-dex.apps.nerc-ocp-infra.rc.fas.harvard.edu
+
+storage:
+  type: memory
+
+web:
+  http: "0.0.0.0:5556"
+
+grpc:
+  addr: "0.0.0.0:5557"
+
+telemetry:
+  http: "0.0.0.0:5558"
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: vault
+    name: Vault
+    redirectURIs:
+      - https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/oidc/callback
+      - https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/ui/vault/auth/oidc/oidc/callback
+    secretEnv: VAULT_SECRET
+
+connectors:
+  - type: openshift
+    id: openshift
+    name: OpenShift
+    config:
+      issuer: https://kubernetes.default.svc
+      clientID: system:serviceaccount:dex:dex
+      clientSecret: $OPENSHIFT_CLIENT_SECRET
+      redirectURI: https://dex-dex.apps.nerc-ocp-infra.rc.fas.harvard.edu/callback
+      groups:
+        - system:authenticated

--- a/dex/overlays/nerc-ocp-infra/configmaps/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-infra/configmaps/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  kustomize.config.k8s.io/behavior: merge
+
+configMapGenerator:
+  - files:
+      - files/config.yaml
+    name: dex

--- a/dex/overlays/nerc-ocp-infra/externalsecrets/dex-clients_patch.yaml
+++ b/dex/overlays/nerc-ocp-infra/externalsecrets/dex-clients_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-clients
+spec:
+  dataFrom:
+    - extract:
+        key: nerc-ocp-infra/dex/dex-clients

--- a/dex/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+resources:
+  - ../../base
+  - configmaps
+patchesStrategicMerge:
+  - externalsecrets/dex-clients_patch.yaml


### PR DESCRIPTION
This imports the Dex configuration from https://github.com/operate-first/apps so that we can use Dex as an OIDC provider for Vault.