### PR TITLE
Add externalsecret manifests for cluster secrets

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-client-secret
+  namesapce: openshift-config
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: github-client-secret
+  data:
+  - secretKey: clientSecret
+    remoteRef:
+      key: nerc/nerc-ocp-infra/openshift-config/github-client-secret
+      property: clientSecret

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-ocp-on-nerc.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-ocp-on-nerc.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-ocp-on-nerc
+  namesapce: openshift-config
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: github-ocp-on-nerc
+  data:
+  - secretKey: token
+    remoteRef:
+      key: nerc/nerc-ocp-infra/group-sync-operator/github-ocp-on-nerc
+      property: token

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github-client-secret.yaml
+- github-ocp-on-nerc.yaml
+- rook-ceph-external-cluster-details.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namesapce: openshift-storage
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: rook-ceph-external-cluster-details
+  data:
+  - secretKey: external_cluster_details
+    remoteRef:
+      key: nerc/nerc-ocp-infra/openshift-storage/rook-ceph-external-cluster-details
+      property: external_cluster_details

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - clusterrolebindings/nerc-ops-cluster-reader.yaml
 - clusterrolebindings/nerc-ops-sudoers.yaml
 - clusterrolebindings/nerc-ops-portforward.yaml
+- externalsecrets
 
 patches:
 - path: oauths/cluster_patch.yaml


### PR DESCRIPTION
This replaces manually installed secrets with ExternalSecret manifests
to pull the secrets from our Vault instance.