### PR TITLE
Add job to automate vault backup procedure

### DIFF
--- a/vault/overlays/nerc-ocp-infra/backup-job/cronjob.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/cronjob.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: trigger-backup-job
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  schedule: "0 1,13 * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: trigger-backup-job
+        spec:
+          serviceAccountName: backup-job
+          volumes:
+            - name: backup-vault-run
+              configMap:
+                name: backup-vault-run
+          containers:
+            - name: submit-backup-job
+              image: quay.io/operate-first/opf-toolbox:v0.8.0
+              env:
+                - name: POD_NS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - "oc create -f /backupjob/taskrun.yaml -n ${POD_NS}"
+              volumeMounts:
+                - mountPath: /backupjob
+                  name: backup-vault-run
+          restartPolicy: Never

--- a/vault/overlays/nerc-ocp-infra/backup-job/externalsecret.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/externalsecret.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: vault-backup-s3-endpoint
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  target:
+    name: vault-backup-s3-endpoint
+    creationPolicy: 'Owner'
+    deletionPolicy: "Retain"
+    template:
+      engineVersion: v2
+  data:
+  - secretKey: ACCESS_KEY_ID
+    remoteRef:
+      key: nerc/nerc-ocp-infra/vault/backup/s3
+      property: S3AccessKey
+  - secretKey: SECRET_ACCESS_KEY
+    remoteRef:
+      key: nerc/nerc-ocp-infra/vault/backup/s3
+      property: S3SecretKey
+  - secretKey: ENDPOINT
+    remoteRef:
+      key: nerc/nerc-ocp-infra/vault/backup/s3
+      property: S3EndPoint
+  - secretKey: BUCKET
+    remoteRef:
+      key: nerc/nerc-ocp-infra/vault/backup/s3
+      property: S3bucket

--- a/vault/overlays/nerc-ocp-infra/backup-job/kustomization.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+namespace: vault
+configMapGenerator:
+  - files:
+      - taskrun.yaml
+    name: backup-vault-run
+resources:
+  - cronjob.yaml
+  - pvc.yaml
+  - rolebinding.yaml
+  - sa.yaml
+  - task.yaml

--- a/vault/overlays/nerc-ocp-infra/backup-job/pvc.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-snapshots
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi

--- a/vault/overlays/nerc-ocp-infra/backup-job/rolebinding.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/rolebinding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: backup-job
+subjects:
+  - kind: ServiceAccount
+    name: backup-job
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/vault/overlays/nerc-ocp-infra/backup-job/sa.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup-job

--- a/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: backup-vault
+spec:
+  workspaces:
+    - name: snapshots
+      mountPath: /snapshots
+    - name: backup-job
+      mountPath: /backup-job
+  steps:
+    - name: create-snapshot
+      image: quay.io/operate-first/opf-toolbox:v0.8.0
+      workingDir: /workspace
+      script: |
+        #!/bin/sh
+        set -e
+
+        echo 'Logging into nerc-vault-0 to retrieve leader'
+        oc exec -i nerc-vault-0 -- vault operator raft list-peers --format=json > /tmp/peers.json
+        leader=$(yq e '.data.config.servers.[] | select(.leader == "true") | .address' -P /tmp/peers.json | cut -d '.' -f1)
+
+        echo retrieved leader: ${leader}
+        echo Creating Snapshot in leader pod ${leader}...
+
+        export snapshot_file_path=$(date +"snapshot-%F_T%H-%M-%S.snap")
+        oc exec -i $leader -- vault operator raft snapshot save /tmp/backup_job_snapshot.snap
+
+        echo Snapshot created in Vault Leader pod. Moving snapshot from pod to backup PVC.
+
+        snapshot_pvc_path=$(workspaces.snapshots.path)
+        oc cp $(context.taskRun.namespace)/$leader:/tmp/backup_job_snapshot.snap ${snapshot_pvc_path}/${snapshot_file_path}
+        oc exec -i $leader -- rm /tmp/backup_job_snapshot.snap
+
+        echo Backup Snapshot saved at ${snapshot_pvc_path}/$snapshot_file_path
+        echo Listing current snapshots in backedup PVC
+
+        echo --------------------------------------------
+        ls -lha ${snapshot_pvc_path}
+        echo --------------------------------------------
+
+        echo "Done!"
+    - name: backup-snapshot-to-s3
+      image: quay.io/operate-first/mc:RELEASE.2022-06-17T02-52-50Z
+      workingDir: /workspace
+      envFrom:
+        - secretRef:
+            name: vault-backup-s3-endpoint
+      script: |
+        #!/bin/sh
+        set -e
+
+        S3Retention="10"
+        PVCRetention="2d"
+
+        snapshot_pvc_path=$(workspaces.snapshots.path)
+
+        echo Setting up mc connection to S3 Bucket
+        mc alias set store ${S3EndPoint} ${S3AccessKey} ${S3SecretKey} --api S3v4
+
+        echo Syncing contents of ${snapshot_pvc_path}/ to Bucket ${S3Bucket} that are newer than ${S3Retention}
+        mc mirror ${snapshot_pvc_path}/ store/${S3Bucket}/ --newer-than ${S3Retention}
+
+        echo Removing files from Bucket ${S3Bucket} that are older than ${S3Retention}
+
+        mc rm -r --force --older-than ${S3Retention} store/${S3Bucket}
+
+        echo Printing contents of Bucket ${S3Bucket}
+
+        echo --------------------------------------------
+        mc ls store/${S3Bucket}
+        echo --------------------------------------------
+
+        echo Removing files from PVC that are older than ${PVCRetention} in path ${snapshot_pvc_path}
+        mc rm -r --force --older-than ${PVCRetention} ${snapshot_pvc_path}/
+
+        echo Printing contents of PVC
+
+        echo --------------------------------------------
+        ls ${snapshot_pvc_path} -lha
+        echo --------------------------------------------
+
+        echo "Done!"
+    - name: cleanup-old-taskruns
+      image: quay.io/operate-first/opf-toolbox:v0.8.0
+      workingDir: /workspace
+      script: |
+        #!/bin/sh
+        set -e
+        NUM_TO_KEEP="10"
+        while read -r TASK; do
+          while read -r TASK_TO_REMOVE; do
+            test -n "${TASK_TO_REMOVE}" || continue;
+            oc delete ${TASK_TO_REMOVE} \
+                && echo "$(date -Is) TaskRun ${TASK_TO_REMOVE} deleted." \
+                || echo "$(date -Is) Unable to delete TaskRun ${TASK_TO_REMOVE}.";
+          done < <(oc get taskrun -l tekton.dev/task=${TASK} --sort-by=.metadata.creationTimestamp -o name | head -n -${NUM_TO_KEEP});
+        done < <(oc get taskrun -o go-template='{{range .items}}{{index .metadata.labels "tekton.dev/task"}}{{"\n"}}{{end}}' | uniq);

--- a/vault/overlays/nerc-ocp-infra/backup-job/taskrun.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/taskrun.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: backup-vault-run
+spec:
+  serviceAccountName: backup-job
+  taskRef:
+    name: backup-vault
+  workspaces:
+    - name: snapshots
+      persistentVolumeClaim:
+        claimName: vault-snapshots
+    - name: backup-job
+      secret:
+        secretName: backup-job

--- a/vault/overlays/nerc-ocp-infra/backup-job/toolkitpod.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/toolkitpod.yaml
@@ -1,0 +1,45 @@
+# Used for inspecting PVC used for the job, or retrieving/restoring snapshots
+
+# To retrieve a snapshot, deploy this pod in vault backup namespace
+# Then set VAULT_ADDR, have the root token ready
+# `oc rsh` into the toolbox container and run `vault login`
+# Use the root token to login.
+# Find the latest snapshot in the /snapshots directory. This is the pvc where snapshots are stored.
+# Then run `vault operator raft snapshot restore -force snapshot-${LATEST_TIMESTAMP}.snap`
+# You can also download the snapshot to your local file system by running:
+# oc cp debug-pod:/snapshots/snapshot-${LATEST_TIMESTAMP}.snap snapshot-${LATEST_TIMESTAMP}.snap
+# And restore vault via vault CLI from your local file system.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backup-toolkit
+spec:
+  serviceAccountName: backup-job
+  containers:
+    - name: toolbox
+      image: quay.io/operate-first/opf-toolbox:v0.8.0
+      command:
+        - sleep
+        - "inf"
+      volumeMounts:
+        - mountPath: /snapshots
+          name: snapshots
+        - mountPath: /backup-job
+          name: backup-job
+    - name: mc
+      image: quay.io/operate-first/mc:RELEASE.2022-06-17T02-52-50Z
+      command:
+        - sleep
+        - "inf"
+      volumeMounts:
+        - mountPath: /snapshots
+          name: snapshots
+        - mountPath: /backup-job
+          name: backup-job
+  volumes:
+    - name: snapshots
+      persistentVolumeClaim:
+        claimName: vault-snapshots
+    - name: backup-job
+      secret:
+        secretName: backup-job

--- a/vault/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/overlays/nerc-ocp-infra/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - backup-job
 namespace: vault


### PR DESCRIPTION
This CronJob works by using the vault snapshot utility and storing the backup in an s3 bucket as well as a PVC in the vault namespace. 

In order for this to work as is we'll need to set up an s3bucket endpoint and add it to the secret.yaml file (I'm not familiar with the process of adding S3 buckets). 

We can also edit the frequency of the backup by editing the secret.yaml file 