### PR TITLE
Increase database storage size for ACM agent service

### DIFF
--- a/acm/base/agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
+++ b/acm/base/agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
@@ -8,7 +8,7 @@ spec:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 100M
+        storage: 1G
   filesystemStorage:
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
The database PV size was set to 100M, which ends up being too small. This
commit updates the requested size in the AgentServiceConfig. It's not clear
if this will also update the existing PVC or if we'll need to do that
separately.
