### PR TITLE
Forcibly refresh the storage network interface every three days

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - ../../base/core/namespaces/dex
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
+- machineconfigs/refresh-storage-interface.yaml
 - machineconfigs/mellanox-udev-rules
 - machineconfigs/configure-bond0
 - nodenetworkconfigurationpolicies/vlan-2177-nese.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/refresh-storage-interface.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/refresh-storage-interface.yaml
@@ -1,0 +1,34 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: refresh-storage-interface
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  systemd:
+    units:
+      - name: refresh-storage-interface.timer
+        enabled: true
+        contents: |
+          [Timer]
+          OnBootSec=3d
+          OnUnitActiveSec=3d
+          RandomizedDelaySec=4h
+
+          [Install]
+          WantedBy=timers.target
+      - name: refresh-storage-interface.service
+        contents: |
+          [Unit]
+          Description=Refresh storage interface
+          Requires=NetworkManager.service
+          After=NetworkManager.service
+
+          [Service]
+          Type=oneshot
+          ExecStartPre=/bin/sh -c "echo BEFORE:; /usr/sbin/ip addr show bond0.2177"
+          ExecStart=/bin/sh -c "nmcli c down bond0.2177; nmcli c up bond0.2177"
+          ExecStartPost=/bin/sh -c "echo AFTER:; /usr/sbin/ip addr show bond0.2177"


### PR DESCRIPTION
Add a systemd timer [1] and service [2] that will forcibly refresh the
bond0.2177 interface every three days (by bringing it down and then back up
using nmcli).

This is a workaround for rhbz#2105088 [3].

[1]: https://www.freedesktop.org/software/systemd/man/systemd.timer.html
[2]: https://www.freedesktop.org/software/systemd/man/systemd.service.html
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2105088
