### PR TITLE
Create Noobaa backing store for metrics storage

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - clusterrolebindings/nerc-ops-portforward.yaml
 - externalsecrets
 - apiserver/cluster.yaml
+- metrics-bucket-storage
 
 patches:
 - path: oauths/cluster_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: metrics-backing-store
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 3
+    resources:
+      requests:
+        storage: 400Gi
+    storageClass: ocs-external-storagecluster-ceph-rbd
+  type: pv-pool

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/bucketclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/bucketclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: metrics-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - metrics-backing-store

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: noobaa
+resources:
+- backingstore.yaml
+- bucketclass.yaml
+- storageclass.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/storageclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/storageclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    description: Provides Object Bucket Claims (OBCs) specifically for metrics/logging
+  name: metrics-bucket-storage
+parameters:
+  bucketclass: metrics-bucket-class
+provisioner: openshift-storage.noobaa.io/obc
+reclaimPolicy: Delete
+volumeBindingMode: Immediate


### PR DESCRIPTION
Metrics and logging requires more storage than is available in the default
Noobaa backing store. Rather than trying to update the default store (which
is tricky), this commit creates a  new backing store explicitly for
metrics/logging storage.

ObjectBucketClaims must use the `metrics-bucket-storage` StorageClass to
utilize this new backing store:

    apiVersion: objectbucket.io/v1alpha1
    kind: ObjectBucketClaim
    metadata:
      name: test-bucket
    spec:
      generateBucketName: test-bucket
      storageClassName: metrics-bucket-storage
