### PR TITLE
Fix indentation so systemd is under spec.config

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/refresh-storage-interface.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/refresh-storage-interface.yaml
@@ -8,27 +8,27 @@ spec:
   config:
     ignition:
       version: 3.2.0
-  systemd:
-    units:
-      - name: refresh-storage-interface.timer
-        enabled: true
-        contents: |
-          [Timer]
-          OnBootSec=3d
-          OnUnitActiveSec=3d
-          RandomizedDelaySec=4h
+    systemd:
+      units:
+        - name: refresh-storage-interface.timer
+          enabled: true
+          contents: |
+            [Timer]
+            OnBootSec=3d
+            OnUnitActiveSec=3d
+            RandomizedDelaySec=4h
 
-          [Install]
-          WantedBy=timers.target
-      - name: refresh-storage-interface.service
-        contents: |
-          [Unit]
-          Description=Refresh storage interface
-          Requires=NetworkManager.service
-          After=NetworkManager.service
+            [Install]
+            WantedBy=timers.target
+        - name: refresh-storage-interface.service
+          contents: |
+            [Unit]
+            Description=Refresh storage interface
+            Requires=NetworkManager.service
+            After=NetworkManager.service
 
-          [Service]
-          Type=oneshot
-          ExecStartPre=/bin/sh -c "echo BEFORE:; /usr/sbin/ip addr show bond0.2177"
-          ExecStart=/bin/sh -c "nmcli c down bond0.2177; nmcli c up bond0.2177"
-          ExecStartPost=/bin/sh -c "echo AFTER:; /usr/sbin/ip addr show bond0.2177"
+            [Service]
+            Type=oneshot
+            ExecStartPre=/bin/sh -c "echo BEFORE:; /usr/sbin/ip addr show bond0.2177"
+            ExecStart=/bin/sh -c "nmcli c down bond0.2177; nmcli c up bond0.2177"
+            ExecStartPost=/bin/sh -c "echo AFTER:; /usr/sbin/ip addr show bond0.2177"


### PR DESCRIPTION
Without this, it is an invalid manifest and will not be applied.

This machineconfig is to periodically refresh the storage interface on the infra nodes. 