### PR TITLE
Fix namespace in ExternalSecret for external ceph cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: rook-ceph-external-cluster-details
-  namesapce: openshift-storage
+  namespace: openshift-storage
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets


### PR DESCRIPTION
The ExternalSecret was not created due to a typo in the word "namespace".
The actual secret exists which may have been created manually.

Part of trying to fix argocd sync issues.