### PR TITLE
Fix typo in namespace in ExternalSecret

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: github-client-secret
-  namesapce: openshift-config
+  namespace: openshift-config
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-ocp-on-nerc.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-ocp-on-nerc.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: github-ocp-on-nerc
-  namesapce: openshift-config
+  namespace: openshift-config
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: rook-ceph-external-cluster-details
-  namesapce: openshift-storage
+  namespace: openshift-storage
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets


### PR DESCRIPTION
Due to this typo the externalsecrets were not created.

The actual secrets `ceph-external-secret` and `github-client-secrets` exist.
Maybe those were created manually, but the secret `github-ocp-on-nerc` was
never created.