### PR TITLE
Replace printf with dirname

### DIFF
--- a/ci/validate-manifests.sh
+++ b/ci/validate-manifests.sh
@@ -3,7 +3,7 @@
 : "${KUSTOMIZE:=kustomize}"
 
 find_overlays() {
-    find . -regex '.*/overlays/[^/]*/kustomization.yaml' -printf '%h\n'
+    find . -regex '.*/overlays/[^/]*/kustomization.yaml' -exec dirname {} \;
 }
 
 okay() {


### PR DESCRIPTION
The printf option for find is only present in the GNU variant of find
and doesn't work on mac.

This patch replaces it with dirname.

While this spawns an extra command, I find it's the most readable
alternative for what we're trying to do.

Related: https://github.com/CCI-MOC/moc-apps/pull/203