### PR TITLE
Adding the cluster-logging operator.

### DIFF
--- a/logging/base/clusterlogforwarders/instance.yaml
+++ b/logging/base/clusterlogforwarders/instance.yaml
@@ -1,0 +1,38 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: loki-app
+      type: loki
+      url: https://lokistack-gateway-http.openshift-operators-redhat.svc.cluster.local:8080/api/logs/v1/application
+      secret:
+        name: lokistack-gateway-bearer-token
+    - name: loki-infra
+      type: loki
+      url: https://lokistack-gateway-http.openshift-operators-redhat.svc.cluster.local:8080/api/logs/v1/infrastructure
+      secret:
+        name: lokistack-gateway-bearer-token
+    - name: loki-audit
+      type: loki
+      url: https://lokistack-gateway-http.openshift-operators-redhat.svc.cluster.local:8080/api/logs/v1/audit
+      secret:
+        name: lokistack-gateway-bearer-token
+  pipelines:
+    - name: send-app-logs
+      inputRefs:
+      - application
+      outputRefs:
+      - loki-app
+    - name: send-infra-logs
+      inputRefs:
+      - infrastructure
+      outputRefs:
+      - loki-infra
+    - name: send-audit-logs
+      inputRefs:
+      - audit
+      outputRefs:
+      - loki-audit

--- a/logging/base/clusterlogforwarders/kustomization.yaml
+++ b/logging/base/clusterlogforwarders/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - instance.yaml

--- a/logging/base/clusterloggings/instance.yaml
+++ b/logging/base/clusterloggings/instance.yaml
@@ -1,0 +1,11 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}

--- a/logging/base/clusterloggings/kustomization.yaml
+++ b/logging/base/clusterloggings/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - instance.yaml

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces
+  - operatorgroups
+  - subscriptions
+  - clusterloggings
+  - clusterlogforwarders
+commonLabels:
+  app.kubernetes.io/name: loki
+  app.kubernetes.io/component: lokistack
+  app.kubernetes.io/part-of: cluster-logging

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - clusterloggings
   - clusterlogforwarders
 commonLabels:
-  app.kubernetes.io/name: loki
-  app.kubernetes.io/component: lokistack
+  app.kubernetes.io/name: logging
+  app.kubernetes.io/component: logging
   app.kubernetes.io/part-of: cluster-logging

--- a/logging/base/namespaces/kustomization.yaml
+++ b/logging/base/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openshift-logging.yaml

--- a/logging/base/namespaces/openshift-logging.yaml
+++ b/logging/base/namespaces/openshift-logging.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+spec: {}

--- a/logging/base/namespaces/openshift-logging.yaml
+++ b/logging/base/namespaces/openshift-logging.yaml
@@ -6,4 +6,3 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: 'true'
-spec: {}

--- a/logging/base/operatorgroups/kustomization.yaml
+++ b/logging/base/operatorgroups/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - openshift-logging.yaml

--- a/logging/base/operatorgroups/openshift-logging.yaml
+++ b/logging/base/operatorgroups/openshift-logging.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging

--- a/logging/base/subscriptions/cluster-logging.yaml
+++ b/logging/base/subscriptions/cluster-logging.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/logging/base/subscriptions/elasticsearch-operator.yaml
+++ b/logging/base/subscriptions/elasticsearch-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/logging/base/subscriptions/kustomization.yaml
+++ b/logging/base/subscriptions/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster-logging.yaml
+  - elasticsearch-operator.yaml

--- a/logging/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base


### PR DESCRIPTION
This is to add a cluster-logging operator with log forwarding to loki

Documentation for this task can be found in many links here:

  https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/logging/cluster-logging-external#cluster-logging-collector-log-forward-loki_cluster-logging-external
  https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/logging/index#cluster-logging-exported-fields-kubernetes_cluster-logging-exported-fields
  https://docs.openshift.com/container-platform/4.10/logging/cluster-logging-exported-fields.html#cluster-logging-exported-fields-kubernetes_cluster-logging-exported-fields
  https://docs.openshift.com/container-platform/4.10/logging/cluster-logging-deploying.html
