### PR TITLE
Add OpenShift Pipelines operator to infra cluster

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators-redhat
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - ../../base/core/namespaces/grafana
 - ../../base/core/namespaces/openshift-logging
 - ../../base/core/namespaces/openshift-operators-redhat
+- ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
 - machineconfigs/refresh-storage-interface.yaml


### PR DESCRIPTION
This PR is to add the OpenShift Pipelines Operator subscription to fix the argoCD sync error we're seeing in argoCD relating to the vault backup job. 

The job uses custom resources such as `task` and `taskRun`, which are added to the cluster through this operator. 

Once merged we should be able to sync the vault resources in argoCD.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202713521265401