### PR TITLE
Add nerc-ocp-prod cluster to ACM

### DIFF
--- a/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- managedclusters
-- klusterletaddonconfigs
+- nerc-ocp-prod.yaml

--- a/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/nerc-ocp-prod.yaml
+++ b/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/nerc-ocp-prod.yaml
@@ -1,0 +1,24 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: nerc-ocp-prod
+  namespace: nerc-ocp-prod
+spec:
+  clusterName: nerc-ocp-prod
+  clusterNamespace: nerc-ocp-prod
+  clusterLabels:
+    name: nerc-ocp-prod
+    cloud: auto-detect
+    vendor: auto-detect
+    cluster.open-cluster-management.io/clusterset: default
+  applicationManager:
+    enabled: true
+    argocdCluster: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true

--- a/acm/overlays/nerc-ocp-infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/managedclusters/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- managedclusters
-- klusterletaddonconfigs
+- nerc-ocp-prod.yaml

--- a/acm/overlays/nerc-ocp-infra/managedclusters/nerc-ocp-prod.yaml
+++ b/acm/overlays/nerc-ocp-infra/managedclusters/nerc-ocp-prod.yaml
@@ -1,0 +1,12 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: nerc-ocp-prod
+  labels:
+    name: nerc-ocp-prod
+    cloud: auto-detect
+    vendor: auto-detect
+    cluster.open-cluster-management.io/clusterset: default
+  annotations: {}
+spec:
+  hubAcceptsClient: true


### PR DESCRIPTION
This adds nerc-ocp-prod to ACM. Once this commit has merged we will need to
follow the instructions in the console to complete the import.
