### PR TITLE
Update namespace of openshift-pipelines-operator target namespace to …

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-operators-redhat
+namespace: openshift-operators
 resources:
 - subscription.yaml


### PR DESCRIPTION
The openshift-pipelines-operator operator subscription is not liking the openshift-operators-redhat namespace operatorgroup, so I'm going to move it back to the default namespace for this operator. 