### PR TITLE
Add patch for secret in logging-grafana

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator/clusterrolebinding.yaml
@@ -6,4 +6,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: patch-operator
-subjects: []
+subjects:
+  - kind: ServiceAccount
+    name: patch-operator
+    namespace: grafana

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/patch-operator/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/patch-operator/clusterrole.yaml
@@ -14,3 +14,13 @@ rules:
       - get
       - watch
       - list
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanas
+    verbs:
+      - update
+      - patch
+      - get
+      - watch
+      - list

--- a/grafana/base/kustomization.yaml
+++ b/grafana/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - grafanas
   - grafanadatasources
   - routes
+  - serviceaccounts
 commonLabels:
   app.kubernetes.io/name: grafana
   app.kubernetes.io/component: grafana

--- a/grafana/base/serviceaccounts/kustomization.yaml
+++ b/grafana/base/serviceaccounts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml

--- a/grafana/base/serviceaccounts/serviceaccount.yaml
+++ b/grafana/base/serviceaccounts/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-operator
+  namespace: grafana

--- a/grafana/overlays/nerc-ocp-infra/patches/logging-grafana-patch.yaml
+++ b/grafana/overlays/nerc-ocp-infra/patches/logging-grafana-patch.yaml
@@ -1,0 +1,26 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  name: logging-grafana-patch
+  namespace: grafana
+spec:
+  serviceAccountRef:
+    name: patch-operator
+  patches:
+    logging-grafana-patch:
+      targetObjectRef:
+        apiVersion: integreatly.org/v1alpha1
+        kind: Grafana
+        name: logging-grafana
+      patchTemplate: |
+        spec:
+          config:
+            auth.generic_oauth:
+              client_id: grafana
+              client_secret: {{ (index . 1).data.GRAFANA_SECRET | b64dec }}
+      patchType: application/strategic-merge-patch+json
+      sourceObjectRefs:
+      - apiVersion: v1
+        kind: Secret
+        name: oauth-client-secret
+        namespace: grafana


### PR DESCRIPTION
This PR adds the necessary rbac at the cluster scope to allow for runtime patch enforcement via the patch-operator. The clusterrole being added here is bound to a serviceaccount in the grafana namespace which will enable patching the secret value into the grafana resource