### PR TITLE
Prevent argocd conflicts with exernal-secret generated secret

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-client-secret.yaml
@@ -9,6 +9,9 @@ spec:
     kind: ClusterSecretStore
   target:
     name: github-client-secret
+    template:
+      metadata:
+        labels: {}
   data:
   - secretKey: clientSecret
     remoteRef:


### PR DESCRIPTION
By default, when ExternalSecret creates a Secret it populates the labels of
the Secret with the content of .metadata.labels from the ExternalSecret. In
the case of ExternalSecrets managed with ArgoCD, this includes the special
`app.kubernetes.io/instance` label that ArgoCD uses to identify managed
resources.

This causes ArgoCD to think it manages the Secret, but since the Secret
itself does not appear in the repository it gets marked as a resource that
must be deleted, leading to the OutOfSync error.

We can resolve this issue by providing `.spec.template.metadata.labels`
with an empty value.

See [1] for some historical discussion about this issue.

[1]: https://github.com/external-secrets/external-secrets/issues/68
