### PR TITLE
Fix nerc-ocp-prod KlusterletAddonConfig

### DIFF
--- a/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/nerc-ocp-prod.yaml
+++ b/acm/overlays/nerc-ocp-infra/klusterletaddonconfigs/nerc-ocp-prod.yaml
@@ -13,7 +13,6 @@ spec:
     cluster.open-cluster-management.io/clusterset: default
   applicationManager:
     enabled: true
-    argocdCluster: true
   policyController:
     enabled: true
   searchCollector:


### PR DESCRIPTION
Apparently the `argocdCluser` attribute we see in some of the operate-first
manifests isn't supported by our ACM.
