### PR TITLE
Increase resource limits for patch operator

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/patch-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/patch-operator/subscription.yaml
@@ -10,3 +10,11 @@ spec:
   name: patch-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "1000m"
+      limits:
+        memory: "1024Mi"
+        cpu: "1500m"


### PR DESCRIPTION
While experimenting with the patch operator, the controller was repeatedly
getting OOMKilled due to hitting its declared resource limits. Based on [1]
and [2], it looks like we can change the resource limits of the controller
by modifying the Subscription.

This commit attempts to increase the limits to 1G memory and 1.5 cpu
shares.

[1]: https://github.com/redhat-cop/patch-operator/issues/48
[2]: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#resources
