### PR TITLE
Add external-secret to vault backup kustomization.yaml

### DIFF
--- a/vault/overlays/nerc-ocp-infra/backup-job/kustomization.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/kustomization.yaml
@@ -9,6 +9,7 @@ configMapGenerator:
     name: backup-vault-run
 resources:
   - cronjob.yaml
+  - externalsecret.yaml
   - pvc.yaml
   - rolebinding.yaml
   - sa.yaml


### PR DESCRIPTION
I was wondering why the backup job wasn't running properly and why the external secret wasn't showing up in argoCD... Helps when you add all the resources to the kustomize :)

Just adding externalsecret.yaml to kustomization