### PR TITLE
Update s3 endpoint ES and vault backup task.yaml to reflect ES change

### DIFF
--- a/vault/overlays/nerc-ocp-infra/backup-job/externalsecret.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/externalsecret.yaml
@@ -13,20 +13,6 @@ spec:
     deletionPolicy: "Retain"
     template:
       engineVersion: v2
-  data:
-  - secretKey: ACCESS_KEY_ID
-    remoteRef:
-      key: nerc/nerc-ocp-infra/vault/backup/s3
-      property: S3AccessKey
-  - secretKey: SECRET_ACCESS_KEY
-    remoteRef:
-      key: nerc/nerc-ocp-infra/vault/backup/s3
-      property: S3SecretKey
-  - secretKey: ENDPOINT
-    remoteRef:
-      key: nerc/nerc-ocp-infra/vault/backup/s3
-      property: S3EndPoint
-  - secretKey: BUCKET
-    remoteRef:
-      key: nerc/nerc-ocp-infra/vault/backup/s3
-      property: S3bucket
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-infra/vault/backup/s3

--- a/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
@@ -52,23 +52,22 @@ spec:
 
         S3Retention="10"
         PVCRetention="2d"
-
         snapshot_pvc_path=$(workspaces.snapshots.path)
 
         echo Setting up mc connection to S3 Bucket
-        mc alias set store ${S3EndPoint} ${S3AccessKey} ${S3SecretKey} --api S3v4
+        mc alias set store ${ENDPOINT} ${ACCESS_KEY_ID} ${SECRET_ACCESS_KEY} --api S3v4
 
-        echo Syncing contents of ${snapshot_pvc_path}/ to Bucket ${S3Bucket} that are newer than ${S3Retention}
-        mc mirror ${snapshot_pvc_path}/ store/${S3Bucket}/ --newer-than ${S3Retention}
+        echo Syncing contents of ${snapshot_pvc_path}/ to Bucket ${BUCKET} that are newer than ${S3Retention}
+        mc mirror ${snapshot_pvc_path}/ store/${BUCKET}/ --newer-than ${S3Retention}
 
-        echo Removing files from Bucket ${S3Bucket} that are older than ${S3Retention}
+        echo Removing files from Bucket ${BUCKET} that are older than ${S3Retention}
 
-        mc rm -r --force --older-than ${S3Retention} store/${S3Bucket}
+        mc rm -r --force --older-than ${S3Retention} store/${BUCKET}
 
-        echo Printing contents of Bucket ${S3Bucket}
+        echo Printing contents of Bucket ${BUCKET}
 
         echo --------------------------------------------
-        mc ls store/${S3Bucket}
+        mc ls store/${BUCKET}
         echo --------------------------------------------
 
         echo Removing files from PVC that are older than ${PVCRetention} in path ${snapshot_pvc_path}


### PR DESCRIPTION
I believe externalsecrets operator was getting confused because my property and secretKey fields were different in externalsecret.yaml. This PR amends this and updates the referenced key values from the resulting secret in task.yaml.