### PR TITLE
Configure ODF on nerc-ocp-prod cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - oauths-clientsecret-nerc.yaml
 - github-client-secret.yaml
 - github-group-sync-token.yaml
+- rook-ceph-external-cluster-details.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namespace: openshift-storage
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: rook-ceph-external-cluster-details
+  data:
+  - secretKey: external_cluster_details
+    remoteRef:
+      key: nerc/nerc-ocp-prod/openshift-storage/rook-ceph-external-cluster-details
+      property: external_cluster_details

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../common
 - ../../bundles/acct-mgt
 - ../../bundles/metallb
+- ../../bundles/odf-external
 - ingresscontrollers/external-apps-ingress-controller.yaml
 - externalsecrets
 - apiserver/cluster.yaml
@@ -17,6 +18,7 @@ resources:
 patches:
 - path: ingresscontrollers/default_patch.yaml
 - path: oauths/cluster_patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
 
 - target:
     group: "external-secrets.io"

--- a/cluster-scope/overlays/nerc-ocp-prod/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
@@ -1,0 +1,17 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-external-storagecluster-ceph-rbd
+parameters:
+  clusterID: openshift-storage
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: nerc_ocp_prod_1_rbd

--- a/fake-metrics-server/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+resources:
+- ../nerc-ocp-infra


### PR DESCRIPTION
It's ready for review.

- [x] create the appropriate secret in vault
- [x] create fake-metrics app (https://github.com/OCP-on-NERC/nerc-ocp-apps/pull/15)

blocked on argocd being setup to manage nerc-ocp-prod and a cluster-scope app for nerc-ocp-prod.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202467165231356