### PR TITLE
Stop argocd from fighting managedcluster resource

### DIFF
--- a/acm/overlays/nerc-ocp-infra/managedclusters/nerc-ocp-prod.yaml
+++ b/acm/overlays/nerc-ocp-infra/managedclusters/nerc-ocp-prod.yaml
@@ -4,8 +4,8 @@ metadata:
   name: nerc-ocp-prod
   labels:
     name: nerc-ocp-prod
-    cloud: auto-detect
-    vendor: auto-detect
+    cloud: BareMetal
+    vendor: OpenShift
     cluster.open-cluster-management.io/clusterset: default
   annotations: {}
 spec:


### PR DESCRIPTION
When setting cloud: and vendor: to "auto-detect", the values are replaced in the resource by ACM, which causes a conflict with ACM. This change makes the values in git correspond to the detected values.

x-branch: fix/stop-acm-sync-conflict