### PR TITLE
Disable autosync in generated applications

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/applicationsets/nerc-cluster-aoa.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/applicationsets/nerc-cluster-aoa.yaml
@@ -17,8 +17,3 @@ spec:
         path: "clusters/{{ name }}"
         repoURL: https://github.com/ocp-on-nerc/nerc-ocp-apps.git
         targetRevision: HEAD
-      syncPolicy:
-        automated:
-          selfHeal: true
-        syncOptions:
-          - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
I would like to disable autosync on the nerc-ocp-prod-cluster-scope app, but this isn't possible due to our ArgoCD configuration.

This commit disables autosync in the nerc-cluster-aoa ApplicationSet. This will allow us to control autosync on individual applications via the ArgoCD API/UI.

We can discuss later on whether or not this is something we want to re-enable.