### PR TITLE
Fix nerc-ocp-prod sync issues

### DIFF
--- a/cluster-scope/base/config.openshift.io/oauths/cluster/oauth.yaml
+++ b/cluster-scope/base/config.openshift.io/oauths/cluster/oauth.yaml
@@ -7,3 +7,4 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: cluster
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/external-secrets/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/external-secrets/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/external-secrets/operatorgroup.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: external-secrets-operator

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - ../../base/operator.external-secrets.io/operatorconfigs/cluster
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview
+- ../../base/operators.coreos.com/operatorgroups/external-secrets

--- a/cluster-scope/overlays/nerc-ocp-prod/apiserver/cluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/apiserver/cluster.yaml
@@ -10,5 +10,5 @@ spec:
     namedCertificates:
       - names:
         - api.nerc-ocp-prod.rc.fas.harvard.edu
-        serviceCertificate:
+        servingCertificate:
           name: default-api-certificate

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -13,3 +13,27 @@ resources:
 
 patches:
 - path: ingresscontrollers/default_patch.yaml
+
+- target:
+    group: "external-secrets.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "operator.external-secrets.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "nmstate.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"


### PR DESCRIPTION
This pull request corrects a number of problems that were preventing the nerc-ocp-prod-cluster-scope application from syncing:

- Enable SkipDryRunOnMissingResource for some resources
- Add missing operatorgroup for external secrets
- Fix typo in APIServer certificate configuration
- Base oauth must have a spec