### PR TITLE
Update SecretStore configuration to use secretRef

### DIFF
--- a/cluster-scope/components/nerc-secret-store/README.md
+++ b/cluster-scope/components/nerc-secret-store/README.md
@@ -1,0 +1,17 @@
+# A note about service account tokens
+
+In Kubernetes 1.24 and later, creating a ServiceAccount will no longer automatically create a Secret with an authentication token. This means that using a `serviceAccountRef` when configuring a SecretStore (or ClusterSecretStore) will no longer work, because the external secrets controller will not be able to find an appropriate token from the ServiceAccount.
+
+Instead, we [manually create a service account token][1] and then use a `secretRef` in the SecretStore resource, e.g:
+
+```
+auth:
+  kubernetes:
+    mountPath: kubernetes/nerc-ocp-prod
+    role: secret-reader
+    secretRef:
+      name: "vault-secret-reader"
+      key: "token"
+```
+
+[1]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token

--- a/cluster-scope/components/nerc-secret-store/kustomization.yaml
+++ b/cluster-scope/components/nerc-secret-store/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+
+commonLabels:
+  nerc.mghpcc.org/secretstore: "true"
+
 resources:
 - secretstore.yaml
 - serviceaccount.yaml
+- token.yaml

--- a/cluster-scope/components/nerc-secret-store/secretstore.yaml
+++ b/cluster-scope/components/nerc-secret-store/secretstore.yaml
@@ -10,7 +10,7 @@ spec:
       version: "v2"
       auth:
         kubernetes:
-          mountPath: kubernetes/nerc-ocp-prod/openshift-api
+          mountPath: kubernetes/nerc-ocp-prod
           role: secret-reader
           serviceAccountRef:
             name: "vault-secret-reader"

--- a/cluster-scope/components/nerc-secret-store/secretstore.yaml
+++ b/cluster-scope/components/nerc-secret-store/secretstore.yaml
@@ -12,5 +12,6 @@ spec:
         kubernetes:
           mountPath: kubernetes/nerc-ocp-prod
           role: secret-reader
-          serviceAccountRef:
+          secretRef:
             name: "vault-secret-reader"
+            key: "token"

--- a/cluster-scope/components/nerc-secret-store/token.yaml
+++ b/cluster-scope/components/nerc-secret-store/token.yaml
@@ -1,0 +1,10 @@
+# Kubernetes will automatically update this secret with a token
+# corresponding to the named ServiceAccount.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-secret-reader
+  annotations:
+    kubernetes.io/service-account.name: vault-secret-reader
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
In Kubernetes 1.24 and later, creating a ServiceAccount will no longer
automatically create a Secret with an authentication token. This means that
using a `serviceAccountRef` when configuring a SecretStore (or
ClusterSecretStore) will no longer work, because the external secrets
controller will not be able to find an appropriate token from the
ServiceAccount.

Instead, we manually create a service account token [1] and then use a
`secretRef` in the SecretStore resource, e.g:

    auth:
      kubernetes:
        mountPath: kubernetes/nerc-ocp-prod
        role: secret-reader
        secretRef:
          name: "vault-secret-reader"
          key: "token"

[1]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token
