### PR TITLE
Update vault task to avoid permissions error in taskrun

### DIFF
--- a/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
@@ -3,6 +3,10 @@ kind: Task
 metadata:
   name: backup-vault
 spec:
+  stepTemplate:
+    env:
+      - name: "HOME"
+        value: "/tekton/home"
   workspaces:
     - name: snapshots
       mountPath: /snapshots


### PR DESCRIPTION
After some digging into the error in the vault backup job taskrun I found this patch suggestion that should eliminate the perms error popping up in the taskrun logs. 

Here is the post documenting the fix: [https://access.redhat.com/solutions/6956010](https://access.redhat.com/solutions/6956010)

Here is the taskrun log showing the error: [https://console-openshift-console.apps.nerc-ocp-infra.rc.fas.harvard.edu/k8s/ns/vault/tekton.dev~v1beta1~TaskRun/backup-vault-runxwxnh/logs](https://console-openshift-console.apps.nerc-ocp-infra.rc.fas.harvard.edu/k8s/ns/vault/tekton.dev~v1beta1~TaskRun/backup-vault-runxwxnh/logs)