### PR TITLE
Adding custom alerts and Slack integration

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thanos-ruler-custom-rules
+  namespace: open-cluster-management-observability
+data:
+  custom_rules.yaml: |
+    groups:
+      - name: openshift-storage
+        rules:
+
+        - alert: CustomStoragePersistentVolumeFillingUp
+          annotations:
+            summary: PersistentVolume is filling up.
+            description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"db-noobaa-db-pg-.*|metrics-backing-store-noobaa-pvc-.*|noobaa-default-backing-store-noobaa-pvc-.*"}/kubelet_volume_stats_capacity_bytes < 0.10
+          for: 1m
+          labels:
+            instance: "{{ $labels.instance }}"
+            cluster: "{{ $labels.cluster }}"
+            clusterID: "{{ $labels.clusterID }}"
+            PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
+            severity: critical
+
+        - alert: CustomStoragePersistentVolumeFillingUpPredicted
+          annotations:
+            summary: PersistentVolume is filling up and is predicted to run out of space in 6h.
+            description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+          expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"db-noobaa-db-pg-.*|metrics-backing-store-noobaa-pvc-.*|noobaa-default-backing-store-noobaa-pvc-.*"}/kubelet_volume_stats_capacity_bytes) < 0.10 and (predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600)) < 0
+          for: 1h
+          labels:
+            instance: "{{ $labels.instance }}"
+            cluster: "{{ $labels.cluster }}"
+            clusterID: "{{ $labels.clusterID }}"
+            PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
+            severity: warning
+
+        - alert: CustomContainerMemoryUsage
+          annotations:
+            summary: Container Memory usage (instance {{ $labels.instance }})
+            description: "Container Memory usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          expr: (sum(container_memory_working_set_bytes{name!=""}) BY (cluster, pod, container) / sum(kube_pod_container_resource_limits{resource="memory"} > 0) BY (cluster, pod, container) * 100) > 80
+          for: 2m
+          labels:
+            instance: "{{ $labels.instance }}"
+            cluster: "{{ $labels.cluster }}"
+            clusterID: "{{ $labels.clusterID }}"
+            severity: warning
+
+        - alert: CustomContainerCpuUsage
+          annotations:
+            summary: Container CPU usage (instance {{ $labels.container_name }})
+            description: "Container CPU usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          expr: sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate[1h])) by (cluster, namespace, pod) / avg(kube_pod_container_resource_limits{resource="cpu"}) by (cluster, namespace, pod) * 100 > 80
+          for: 5m
+          labels:
+            instance: "{{ $labels.instance }}"
+            cluster: "{{ $labels.cluster }}"
+            clusterID: "{{ $labels.clusterID }}"
+            severity: warning
+
+# Prometheus generates a metric called up that indicates whether a scrape was successful.
+# A value of “1” is scrape indicates success, “0” failure.
+# The up metric is useful for debugging and alerting for targets that are down or having issues.
+# Each target should produce an up metric on every scrape.
+# I'm not sure which of the many metrics we want to check are up, but there are many here:
+# https://multicloud-console.apps.nerc-ocp-infra.rc.fas.harvard.edu/grafana/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22up%7Bpod!%3D%5C%22%5C%22%7D%20%3D%3D%200%22%7D%5D
+#        - alert: CustomInstanceDown
+#          annotations:
+#            summary: "Instance [{{ $labels.instance }}] down"
+#            description: "[{{ $labels.instance }}] of job [{{ $labels.job }}] has been down for more than 15 minute."
+#          expr: up == 0
+#          for: 15m
+#          labels:
+#            severity: critical

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/kustomization.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - configmap.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -1,0 +1,58 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: open-cluster-management-observability-alertmanager-config
+  namespace: open-cluster-management-observability
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: alertmanager-config
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        alertmanager.yaml: |
+          global:
+          route:
+            receiver: default
+            group_by: [cluster, alertname]
+            routes:
+              - receiver: slack-notifications
+                group_by: [alertname, datacenter, app]
+                group_wait: 1d
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage"
+          receivers:
+          - name: default
+          - name: slack-notifications
+            slack_configs:
+            - channel: '#alerts-nerc-ocp'
+              api_url: "{{ .slack_api_url }}"
+              mrkdwn_in:
+                - text
+                - title
+              text: |{{ .slack_config_text }}
+              title: "{{ .slack_config_title }}"
+              title_link: "{{ .slack_config_title_link }}"
+  data:
+  - secretKey: slack_api_url
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/slack/alerts-nerc-ocp
+      property: slack_api_url
+  - secretKey: slack_config_text
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/slack/alerts-nerc-ocp
+      property: slack_config_text
+  - secretKey: slack_config_title
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/slack/alerts-nerc-ocp
+      property: slack_config_title
+  - secretKey: slack_config_title_link
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/slack/alerts-nerc-ocp
+      property: slack_config_title_link

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - externalsecret.yaml

--- a/cluster-scope/bundles/acm/observability/kustomization.yaml
+++ b/cluster-scope/bundles/acm/observability/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
   - ../../../base/objectbucket.io/objectbucketclaims/observability
   - ../../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage
   - ../../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret
+  - ../../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config
+  - ../../../base/core/configmaps/thanos-ruler-custom-rules/
   - ../../../base/observability.open-cluster-management.io/multiclusterobservabilities/observability


### PR DESCRIPTION
Added a new custom alert named StoragePersistentVolumeFillingUp, for reporting when the PersistentVolumeClaim in a given namespace like openshift-storage is only a small percent free. Slack integration for alerts of a given matcher like "alertname = StoragePersistentVolumeFillingUp" is also setup so that these Alerts show up in the "alerts-nerc-ocp" Slack channel.

See the documentation here: 
- [Configuration | Prometheus](https://prometheus.io/docs/alerting/latest/configuration/)
- [Formatting text for app surfaces | Slack](https://api.slack.com/reference/surfaces/formatting)
- [Create and edit alert rules | Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/legacy-alerting/grafana-cloud-alerting/create-edit-rules/)
- [ACM Forwarding Alerts](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html-single/observability/index#customizing-observability)