### PR TITLE
Enable SkipDryRunOnMissingResource for logging.openshift.io

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -38,3 +38,11 @@ patches:
     - op: add
       path: /metadata/annotations/argocd.argoproj.io~1sync-options
       value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "logging.openshift.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"


### PR DESCRIPTION
ArgoCD is stuck wishing to deploy a logging.openshift.io/v1/ClusterLogging and logging.openshift.io/v1/ClusterLogForwarder resource before the Operator is installed that provides these CRDs. This commit instructs ArgoCD to skip the dry run on these resources.