### PR TITLE
Remove upgradeStrategy field from redhat-operators OperatorGroup

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-operators/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-operators/operatorgroup.yaml
@@ -3,5 +3,4 @@ kind: OperatorGroup
 metadata:
   name: redhat-operators
   namespace: openshift-operators-redhat
-spec:
-  upgradeStrategy: Default
+spec: {}


### PR DESCRIPTION
This is apparently an OCP 4.11-ism.
