### PR TITLE
Use the prod secret from vault for lokistack-gateway-bearer-token

### DIFF
--- a/logging/overlays/nerc-ocp-prod/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+++ b/logging/overlays/nerc-ocp-prod/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
@@ -7,4 +7,4 @@ spec:
   dataFrom:
     - extract:
         # Command to extract the JSON pull secret: oc extract secret/pull-secret -n openshift-config --to=-
-        key: nerc/nerc-ocp-infra/lokistack-gateway-bearer-token
+        key: nerc/nerc-ocp-prod/lokistack-gateway-bearer-token


### PR DESCRIPTION
It looks like there are policies preventing using nerc-ocp-infra secrets from vault. This commit points the lokistack-gateway-bearer-token to use the lokistack-gateway-bearer-token secret for nerc-ocp-prod in vault instead.