### PR TITLE
Patching the secretStoreRef in prod for lokistack-gateway-bearer-token

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - openshift-config
 - openshift-ingress-operator
+- openshift-logging

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/openshift-logging/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/openshift-logging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-logging
+components:
+  - ../../../../components/nerc-secret-store

--- a/logging/overlays/nerc-ocp-prod/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+++ b/logging/overlays/nerc-ocp-prod/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
@@ -4,6 +4,9 @@ metadata:
   name: openshift-logging-lokistack-gateway-bearer-token
   namespace: openshift-logging
 spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: nerc-secret-store
   dataFrom:
     - extract:
         # Command to extract the JSON pull secret: oc extract secret/pull-secret -n openshift-config --to=-


### PR DESCRIPTION
The lokistack-gateway-bearer-token ExternalSecret is pointed to a ClusterSecretStore that only exists in the infra cluster. This points the ExternalSecret to the SecretStore available in prod.