### PR TITLE
Set redhatcop.redhat.io/GroupSync objects to SkipDryRunOnMissingResource

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -38,3 +38,11 @@ patches:
     - op: add
       path: /metadata/annotations/argocd.argoproj.io~1sync-options
       value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "redhatcop.redhat.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"


### PR DESCRIPTION
ArgoCD cannot find the GroupSync objects before the group-sync-operator is in place in prod. This commit will set SkipDryRunOnMissingResource=true for the redhatcop.redhat.io group.