### PR TITLE
Fix typo in vault backup task.yaml

### DIFF
--- a/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
+++ b/vault/overlays/nerc-ocp-infra/backup-job/task.yaml
@@ -54,7 +54,7 @@ spec:
         #!/bin/sh
         set -e
 
-        S3Retention="10"
+        S3Retention="10d"
         PVCRetention="2d"
         snapshot_pvc_path=$(workspaces.snapshots.path)
 


### PR DESCRIPTION
This fix adds the missing time unit to the S3Retention variable in task.yaml