### PR TITLE
Correct namespace for ingress certificate

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/default-ingress-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/default-ingress-certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: default-ingress-certificate
-  namespace: openshift-ingress-operator
+  namespace: openshift-ingress
 spec:
   secretStoreRef:
     name: nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - openshift-config
-- openshift-ingress-operator
+- openshift-ingress
 - openshift-logging

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/openshift-ingress/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/openshift-ingress/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-ingress-operator
+namespace: openshift-ingress
 components:
   - ../../../../components/nerc-secret-store


### PR DESCRIPTION
The external secret for the custom ingress certificate [1] was incorrectly
placed in the openshift-ingress-operator namespace. It should be in the
openshift-ingress namespace.

[1]: https://docs.openshift.com/container-platform/4.10/security/certificates/replacing-default-ingress-certificate.html
