### PR TITLE
Fix target node role for bond0 interface configuration

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/configure-bond0/machineconfig.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/configure-bond0/machineconfig.yaml
@@ -3,7 +3,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
   name: configure-bond0
 spec:
   config:

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/configure-bond0/src/machineconfig.bu
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/configure-bond0/src/machineconfig.bu
@@ -3,7 +3,7 @@ version: 4.10.0
 metadata:
   name: configure-bond0
   labels:
-    machineconfiguration.openshift.io/role: master
+    machineconfiguration.openshift.io/role: worker
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/bond0.nmconnection


### PR DESCRIPTION
The machineconfig for implementing the bond0 interface configuration was
erroneously targeting the control nodes rather than the worker nodes.
