### PR TITLE
Set routingViaHost to true for nerc-ocp-prod

### DIFF
--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
 - ../../bundles/logging
 - ../../bundles/group-sync-operator
 - ../../base/operator.openshift.io/ingresscontrollers/default
+- ../../base/operator.openshift.io/networks/cluster
 - groupsyncs
 - machineconfigs

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 - ../../bundles/acm/observability
 - ../../bundles/vault
 - ../../bundles/patch-operator
-- ../../base/operator.openshift.io/networks/cluster
 - ../../bundles/odf-external
 - ../../bundles/external-secrets-clustersecretstore
 - ../../base/core/namespaces/dex


### PR DESCRIPTION
This puts the resource in the common overlay.

See commit 37c4dc731604a08ed777ebdc8db7897c6b62d5af

closes https://github.com/OCP-on-NERC/operations/issues/26