### PR TITLE
Fix some external secrets in openshift-config

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: openshift-config
 spec:
   secretStoreRef:
-    name: nerc-cluster-secrets
-    kind: ClusterSecretStore
+    name: nerc-secret-store
+    kind: SecretStore
   target:
     name: github-ocp-on-nerc
   data:

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/oauths-clientsecret-nerc.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/oauths-clientsecret-nerc.yaml
@@ -10,7 +10,7 @@ spec:
   target:
     name: oauths-clientsecret-nerc
   data:
-    - secretKey: secret
+    - secretKey: clientSecret
       remoteRef:
         key: nerc/nerc-ocp-prod/openshift-config/oauths-clientsecret-nerc
-        property: secret
+        property: clientSecret


### PR DESCRIPTION
* We are using SecretStore `nerc-secret-store` for `github-ocp-on-nerc` ExternalSecret
* the secretKey should be `clientSecret` in `oauths-clientsecret-nerc`.

With these changes, the production openshift console shows us the option to login with keyloak and github. Though I could not successfully login with github.