### PR TITLE
Add metallb operator

### DIFF
--- a/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-system

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: metallb-operator
+spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: metallb-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/metallb-system
+- ../../base/operators.coreos.com/subscriptions/metallb-operator
+- ../../base/operators.coreos.com/operatorgroups/metallb-system

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - ../common
 - ../../bundles/acct-mgt
+- ../../bundles/metallb
 - ingresscontrollers/external-apps-ingress-controller.yaml
 - externalsecrets
 - apiserver/cluster.yaml


### PR DESCRIPTION
Install the metallb [1] operator on nerc-ocp-prod. Our immediate use case
for this operator is providing a public ip address to the public-facing
ingress service.

Part of: OCP-on-NERC/operations#16

[1]: https://metallb.universe.tf/
