### PR TITLE
Correct secret namespace for groupsync config

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-group-sync-token.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-group-sync-token.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: github-ocp-on-nerc
-  namespace: openshift-config
+  namespace: group-sync-operator
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
@@ -2,7 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: github-ocp-on-nerc
-  namespace: openshift-config
+  namespace: group-sync-operator
 spec:
   secretStoreRef:
     name: nerc-secret-store


### PR DESCRIPTION
The secret with the github token for the group-sync operator was installed
in the wrong namespace.
