### PR TITLE
Configure MetalLB

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - secretstores
 - machineconfigs/configure-bond0
 - nodenetworkconfigurationpolicies
+- metallb
 
 patches:
 - path: ingresscontrollers/default_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/ipaddresspools/public.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/ipaddresspools/public.yaml
@@ -1,0 +1,9 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: public
+  namespace: metallb-system
+spec:
+  addresses:
+    - 199.94.61.6/32
+    - 199.94.61.240/28

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+- ipaddresspools/public.yaml
+- l2advertisements/default.yaml
+- metallbs/metallb.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/l2advertisements/default.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/l2advertisements/default.yaml
@@ -1,0 +1,5 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/metallbs/metallb.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/metallbs/metallb.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+spec:
+  nodeSelector:
+    nerc.mghpcc.org/external-ingress: "true"

--- a/cluster-scope/overlays/nerc-ocp-prod/nodenetworkconfigurationpolicies/vlan-2180-external.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/nodenetworkconfigurationpolicies/vlan-2180-external.yaml
@@ -13,8 +13,16 @@ spec:
       ipv4:
         enabled: true
         dhcp: true
-        auto-routes: true
+        auto-routes: false
       vlan:
         base-iface: bond0
         id: 2180
       mtu: 1500
+    routes:
+      - table-id: 200
+        destination: 0.0.0.0/0
+        next-hop-address: 199.94.61.1
+        next-hop-interface: bond0.2180
+    route-rules:
+      - ip-from: 199.94.61.0/24
+        route-table: 200


### PR DESCRIPTION
Add a MetalLB API object and set up the necessary CRs to provide a small
pool of public addresses, including the address we plan to use for the
public ingress service, and configure the necessary routes to support the
public network.

The route configuration adds a source route such that replies to traffic
inbound on the public network will leave via the public network, rather than by
the internal default gateway.

This is performing the equivalent of:

    ip rule add from 199.94.61.0/24 table 200
    ip route add default via 199.94.61.1 dev bond0.2180 table 200


