### PR TITLE
Update secret to match GroupSync definition

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-group-sync-token.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/github-group-sync-token.yaml
@@ -1,16 +1,16 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: github-ocp-on-nerc
+  name: github-group-sync-token
   namespace: group-sync-operator
 spec:
   secretStoreRef:
     name: nerc-cluster-secrets
     kind: ClusterSecretStore
   target:
-    name: github-ocp-on-nerc
+    name: github-group-sync-token
   data:
   - secretKey: token
     remoteRef:
-      key: nerc/nerc-ocp-infra/group-sync-operator/github-ocp-on-nerc
+      key: nerc/nerc-ocp-infra/group-sync-operator/github-group-sync-token
       property: token

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-group-sync-token.yaml
@@ -8,9 +8,9 @@ spec:
     name: nerc-secret-store
     kind: SecretStore
   target:
-    name: github-ocp-on-nerc
+    name: github-group-sync-token
   data:
   - secretKey: token
     remoteRef:
-      key: nerc/nerc-ocp-prod/group-sync-operator/github-ocp-on-nerc
+      key: nerc/nerc-ocp-prod/group-sync-operator/github-group-sync-token
       property: token


### PR DESCRIPTION
This was the causing the groups to not sync in either cluster. The operator on both clusters complained about not finding the secret, though I am not sure why the groups existed in the infra cluster.

I will also update the token in vault to match it.

It would be easier to update the credentialSecret in GroupSync definition, but I like the name `github-group-sync-token` slightly more than `github-ocp-on-nerc`. 