### PR TITLE
Change mapping method for NERC SSO to Lookup

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/oauths/cluster_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-    - mappingMethod: claim
+    - mappingMethod: lookup
       name: mss-keycloak
       openID:
         claims:


### PR DESCRIPTION
This ensures that users aren't automatically created if they haven't been provisioned from ColdFront.