### PR TITLE
Create a serviceaccount that can read metrics required by xdmod

### DIFF
--- a/cluster-scope/base/core/namespaces/xdmod-reader/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/xdmod-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/xdmod-reader/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/xdmod-reader/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: xdmod-reader
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xdmod-reader-permissions
+subjects:
+- kind: ServiceAccount
+  name: xdmod-reader
+  namespace: xdmod-reader
+roleRef:
+  kind: ClusterRole
+  name: xdmod-permissions
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xdmod-permissions
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/xdmod-reader/kustomization.yaml
+++ b/cluster-scope/bundles/xdmod-reader/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/xdmod-reader/
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/
+- ../../base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../bundles/acct-mgt
 - ../../bundles/metallb
 - ../../bundles/odf-external
+- ../../bundles/xdmod-reader
 - ingresscontrollers/external-apps-ingress-controller.yaml
 - externalsecrets
 - apiserver/cluster.yaml

--- a/xdmod-reader/base/core/serviceaccounts/xdmod-reader/kustomization.yaml
+++ b/xdmod-reader/base/core/serviceaccounts/xdmod-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml

--- a/xdmod-reader/base/core/serviceaccounts/xdmod-reader/serviceaccount.yaml
+++ b/xdmod-reader/base/core/serviceaccounts/xdmod-reader/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xdmod-reader

--- a/xdmod-reader/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/xdmod-reader/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: xdmod-reader
+resources:
+  - ../../base/core/serviceaccounts/xdmod-reader


### PR DESCRIPTION
There's also a clusterrole and a corresponding clusterrolebinding that the serviceaccount is bound to to give it necessary permissions.

To create the service account, a new top level xdmod-reader app is added.

closes https://github.com/OCP-on-NERC/operations/issues/13

The top level app which will create the serviceaccount is here: https://github.com/OCP-on-NERC/nerc-ocp-apps/pull/21

Once the service account is created I will generate a token and place it in vault as suggested by @rob-baron so then it can be used in the infra cluster.
