### PR TITLE
Fix wrong format in External Secret in acct-mgt

### DIFF
--- a/acct-mgt/overlays/nerc-ocp-prod/externalsecret.yaml
+++ b/acct-mgt/overlays/nerc-ocp-prod/externalsecret.yaml
@@ -7,4 +7,4 @@ spec:
     name: nerc-secret-store
     kind: SecretStore
   dataFrom:
-    key: nerc/nerc-ocp-prod/acct-mgt/admin_password
+    - key: nerc/nerc-ocp-prod/acct-mgt/admin_password


### PR DESCRIPTION
dataFrom should be an array.

```
spec.dataFrom: Invalid value: "object": spec.dataFrom in body must be
of type array: "object"
```
https://external-secrets.io/v0.4.4/api-externalsecret/