### PR TITLE
Add external-apps-ingress-certificate.yaml ES to prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - default-ingress-certificate.yaml
 - default-api-certificate.yaml
+- external-apps-ingress-certificate.yaml
 - oauths-clientsecret-nerc.yaml
 - github-client-secret.yaml
 - github-group-sync-token.yaml


### PR DESCRIPTION
The external ingressController in prod is looking for the cert which was not created in the cluster, since it was not added to the kustomization file.
This should allow the ingress to create successfully. 

In response to: [https://github.com/OCP-on-NERC/operations/issues/29](https://github.com/OCP-on-NERC/operations/issues/29)