### PR TITLE
Restore nerc-ocp-prod clusterversion

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.10
+  clusterID: 431b0152-5ee5-471d-9f48-ee2d733232dc
+  desiredUpdate:
+    image: >-
+      quay.io/openshift-release-dev/ocp-release@sha256:59d7ac85da072fea542d7c43498e764c72933e306117a105eac7bd5dda4e6bbe
+    version: 4.10.39

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - machineconfigs/public-ingress
 - nodenetworkconfigurationpolicies
 - metallb
+- clusterversion.yaml
 
 patches:
 - path: ingresscontrollers/default_patch.yaml


### PR DESCRIPTION
Now that we have re-installed the cluster and we're running the desired
version, we can now manage the version with the clusterversion resource.

Reverts c983b87
