### PR TITLE
Add correct targetNamespaces to metallb operatorgroup

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
@@ -2,3 +2,6 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: metallb-system
+spec:
+  targetNamespaces:
+  - metallb-system


### PR DESCRIPTION
The metallb operator install was failing because the operatorgroup resource
was missing the `targetNamespaces` option, and:

> AllNamespaces InstallModeType not supported, cannot configure to watch
> all namespaces

Closes ocp-on-nerc/operations#35
