### PR TITLE
Restore missing namespace declaration for ODF

### DIFF
--- a/cluster-scope/components/nerc-secret-store/kustomization.yaml
+++ b/cluster-scope/components/nerc-secret-store/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-commonLabels:
-  nerc.mghpcc.org/secretstore: "true"
-
 resources:
 - secretstore.yaml
 - serviceaccount.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-storage
+
 commonLabels:
   nerc.mghpcc.org/feature: odf
 


### PR DESCRIPTION
We lost a namespace: declaration in 87d34c3.

And while I'm fixing things, I've removed a `commonLabels` directive that I think I added by mistake (in 579e99e).