### PR TITLE
Correct issues with metallb configuration

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/addresspools/public.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/addresspools/public.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: metallb-system
 spec:
   protocol: layer2
+  autoAssign: false
   addresses:
     - 199.94.61.6/32
     - 199.94.61.240/28

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/addresspools/public.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/addresspools/public.yaml
@@ -1,9 +1,10 @@
 apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
+kind: AddressPool
 metadata:
   name: public
   namespace: metallb-system
 spec:
+  protocol: layer2
   addresses:
     - 199.94.61.6/32
     - 199.94.61.240/28

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metallb-system
 resources:
-- ipaddresspools/public.yaml
-- l2advertisements/default.yaml
+- addresspools/public.yaml
 - metallbs/metallb.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/metallb/l2advertisements/default.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/metallb/l2advertisements/default.yaml
@@ -1,5 +1,0 @@
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: default
-  namespace: metallb-system


### PR DESCRIPTION
This PR fixes aspects of the metallb configuration that were using syntax only available in 4.11, and it also disabled address auto-assignment.