### PR TITLE
Add secretstore for openshift-ingress-operator namespace

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/kustomization.yaml
@@ -6,4 +6,5 @@ commonLabels:
 resources:
 - ingresscontrollers/external-apps.yaml
 - externalsecrets/external-apps-ingress-certificate.yaml
+- secretstores
 - post-sync-hook

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/secretstores/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress-operator
+
+components:
+  - ../../../../../components/nerc-secret-store


### PR DESCRIPTION
This enables us to fetch the external apps certificate from the vault.
