### PR TITLE
Configure ArgoCD to always consider services healthy

### DIFF
--- a/openshift-gitops/base/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/base/argocds/openshift-gitops.yaml
@@ -4,6 +4,13 @@ metadata:
   name: openshift-gitops
   namespace: openshift-gitops
 spec:
+  resourceCustomizations: |
+    Service:
+      health.lua: |
+        hs = {}
+        hs.status = "Healthy"
+        return hs
+
   applicationSet:
     resources:
       limits:


### PR DESCRIPTION
ArgoCD considers some services to be "progressing" because they are of type
loadbalancer but will never be assigned a loadbalancer address. This commit
configures ArgoCD to always consider services to be healthy.

Part of ocp-on-nerc/operations#42
