### PR TITLE
Move argocd workarounds to dedicated directory

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/argocd-workarounds/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/argocd-workarounds/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+patches:
+
+- target:
+    group: "redhatcop.redhat.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "metallb.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "external-secrets.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "operator.external-secrets.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "nmstate.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"
+
+- target:
+    group: "redhatcop.redhat.io"
+    name: ".*"
+  patch: |
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value: "SkipDryRunOnMissingResource=true"

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - nodenetworkconfigurationpolicies
 - metallb
 - clusterversion.yaml
+- argocd-workarounds
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -33,43 +34,3 @@ configMapGenerator:
 patches:
 - path: ingresscontrollers/default_patch.yaml
 - path: oauths/cluster_patch.yaml
-
-- target:
-    group: "metallb.io"
-    name: ".*"
-  patch: |
-    - op: add
-      path: /metadata/annotations/argocd.argoproj.io~1sync-options
-      value: "SkipDryRunOnMissingResource=true"
-
-- target:
-    group: "external-secrets.io"
-    name: ".*"
-  patch: |
-    - op: add
-      path: /metadata/annotations/argocd.argoproj.io~1sync-options
-      value: "SkipDryRunOnMissingResource=true"
-
-- target:
-    group: "operator.external-secrets.io"
-    name: ".*"
-  patch: |
-    - op: add
-      path: /metadata/annotations/argocd.argoproj.io~1sync-options
-      value: "SkipDryRunOnMissingResource=true"
-
-- target:
-    group: "nmstate.io"
-    name: ".*"
-  patch: |
-    - op: add
-      path: /metadata/annotations/argocd.argoproj.io~1sync-options
-      value: "SkipDryRunOnMissingResource=true"
-
-- target:
-    group: "redhatcop.redhat.io"
-    name: ".*"
-  patch: |
-    - op: add
-      path: /metadata/annotations/argocd.argoproj.io~1sync-options
-      value: "SkipDryRunOnMissingResource=true"


### PR DESCRIPTION
The patches that add the `SkipDryRunOnMissingResource` annotation to crds are entirely boilerplate and clutter up the main kustomization.yaml. This commit moves them to a dedicated kustomization.

This introduces no changes to the output of `kustomize build`.