### PR TITLE
Adding storage retention to logging and observability

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -41,3 +41,10 @@ spec:
       replicas: 3
     queryFrontendMemcached:
       replicas: 3
+    retentionConfig:
+      blockDuration: 2h
+      deleteDelay: 48h
+      retentionInLocal: 24h
+      retentionResolutionRaw: 30d
+      retentionResolution5m: 90d
+      retentionResolution1h: 0d

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: candidate
+  channel: stable
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators

--- a/loki/base/lokistacks/lokistack.yaml
+++ b/loki/base/lokistacks/lokistack.yaml
@@ -1,4 +1,4 @@
-apiVersion: loki.grafana.com/v1beta1
+apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
   name: lokistack

--- a/loki/base/lokistacks/lokistack.yaml
+++ b/loki/base/lokistacks/lokistack.yaml
@@ -9,6 +9,21 @@ spec:
       ingestion:
         ingestionBurstSize: 10
         ingestionRate: 10
+      retention:
+        days: 90
+        streams:
+          - selector: >
+              {log_type="audit"}
+            priority: 200
+            days: 90
+          - selector: >
+              {log_type="application"}
+            priority: 100
+            days: 30
+          - selector: >
+              {log_type="infrastructure"}
+            priority: 100
+            days: 30
   managementState: Managed
   storage:
     secret:


### PR DESCRIPTION
- Adding 90 day retention for audit logs as suggested by the [NERC Operational Use Cases](https://docs.google.com/document/d/1dHHpWvJD4b1mdXTDQhgWhiGeOLY7N7FmwvgI5VB3tP0/edit) useful for security audits.
- Adding 30 day retention for application and infrastructure logs.
- Configuring 90 days to retain samples of resolution 1 (5 minutes) in a bucket for Observability as well as already existing defaults.

## Upgrading LokiStack Operator to the latest stable verison

We also wish to upgrade the LokiStack Operator. 
The latest stable version of the LokiStack Operator provides the v1 API.
The v1 API provides additional fields for managing storage of loki logs.
For example, the RetentionLimitSpec defines how long logs are kept in storage.
See https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-LimitsTemplateSpec

## Issues:
This relates to a couple of issues, to avoid running out of disk space: 
- https://github.com/OCP-on-NERC/operations/issues/38
- https://github.com/OCP-on-NERC/operations/issues/39

## Documentation:
- [See retention configuration for Loki](https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-LimitsTemplateSpec#loki-grafana-com-v1-LimitsTemplateSpec)
- [See retention configuration for Observability](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html-single/apis/index#rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_observabilityretention)
