### PR TITLE
Allow nerc-ops to control application sync

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -18,3 +18,12 @@ spec:
       - "ManagedClusterInfo"
       clusters:
       - "*"
+  rbac:
+    policy: |
+      p, role:operator, applications, sync, */*, allow
+      p, role:operator, applications, update, */*, allow
+
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+      g, nerc-ops, role:operator
+    scopes: '[groups]'


### PR DESCRIPTION
Update the argocd rbac policy so that members of the nerc-ops group can
control application sync settings via the web ui (or the argocd cli).

Closes ocp-on-nerc/operations#43
