### PR TITLE
Prevent oauth secret from inheriting labels from externalsecret

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-client-secret.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/github-client-secret.yaml
@@ -9,6 +9,11 @@ spec:
     kind: SecretStore
   target:
     name: github-client-secret
+    # Prevent generated Secret from inheriting the labels from this
+    # ExternalSecret. OpenShift will create a copy of the Secret, and the
+    # labels will causse it to show up as out-of-sync in ArgoCD. See
+    # https://github.com/OCP-on-NERC/operations/issues/42 for additional
+    # details.
     template:
       metadata:
         labels: {}

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/oauths-clientsecret-nerc.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/oauths-clientsecret-nerc.yaml
@@ -9,6 +9,14 @@ spec:
     name: nerc-secret-store
   target:
     name: oauths-clientsecret-nerc
+    # Prevent generated Secret from inheriting the labels from this
+    # ExternalSecret. OpenShift will create a copy of the Secret, and the
+    # labels will causse it to show up as out-of-sync in ArgoCD. See
+    # https://github.com/OCP-on-NERC/operations/issues/42 for additional
+    # details.
+    template:
+      metadata:
+        labels: {}
   data:
     - secretKey: clientSecret
       remoteRef:


### PR DESCRIPTION
This will prevent the secret "v4-0-config-user-idp-0-client-secret" from
showing up as out-of-sync in ArgoCD.

Part of ocp-on-nerc/operations#42
