### PR TITLE
Configure argocd to use default ingress certificate

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -4,6 +4,13 @@ metadata:
   name: openshift-gitops
   namespace: openshift-gitops
 spec:
+  server:
+    insecure: true
+    route:
+      enabled: true
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
   resourceExclusions: |
     - apiGroups:
       - tekton.dev


### PR DESCRIPTION
Follow the instructions [1] to configure ArgoCD to use the default ingress
certificate and "edge" encryption, rather than passthrough encryption with
its own certificate.

[1]: https://access.redhat.com/solutions/6041341

Closes: ocp-on-nerc/operations#44