### PR TITLE
Update openshift-gitops subscription to "gitops-1.6" channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: openshift-gitops-operator
 spec:
-  channel: stable
+  channel: gitops-1.6
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
With the release of openshift-gitops 1.6, updates will no longer show up in
the "stable" channel. From the 1.6 release notes [1]:

> With this update, the latest releases of the Red Hat OpenShift GitOps are
> available in latest and version-based channels. To get these upgrades,
> update the channel parameter in the Subscription object YAML file: change
> its value from stable to latest or a version-based channel such as
> gitops-1.6.

[1]: https://docs.openshift.com/container-platform/4.10/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-6-0_gitops-release-notes

Part-of: ocp-on-nerc/operations#42
