### PR TITLE
Configure ArgoCD to use the "annotation" resource tracking method

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -11,6 +11,7 @@ spec:
       tls:
         insecureEdgeTerminationPolicy: Redirect
         termination: edge
+  resourceTrackingMethod: annotation
   resourceExclusions: |
     - apiGroups:
       - tekton.dev


### PR DESCRIPTION
Set the argocd `resourceTrackingMethod` to `annotation`. This tells ArgoCD to track resources using a generated tracking id, rather than relying on the `app.kubernetes.io/instance` label. From the docs [1]:

> The advantages of using the tracking id annotation is that there are no
> clashes any more with other Kubernetes tools and Argo CD is never
> confused about the owner of a resource.

[1]: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_tracking/

