### PR TITLE
Label all bundle generated resources

### DIFF
--- a/cluster-scope/bundles/acct-mgt/kustomization.yaml
+++ b/cluster-scope/bundles/acct-mgt/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: acct-mgt
 
 resources:
   - ../../base/core/namespaces/acct-mgt

--- a/cluster-scope/bundles/acm/kustomization.yaml
+++ b/cluster-scope/bundles/acm/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: acm
 resources:
 - ../../base/operators.coreos.com/subscriptions/acm
 - ../../base/core/namespaces/open-cluster-management

--- a/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: cluster-admin-rbac
 resources:
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader

--- a/cluster-scope/bundles/console/kustomization.yaml
+++ b/cluster-scope/bundles/console/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: console
 resources:
 - ../../base/operator.openshift.io/consoles/cluster
 - ../../base/core/configmaps/nerc-logo

--- a/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: external-secrets-clustersecretstore
 resources:
 - ../../base/core/serviceaccounts/vault-secret-reader
 - ../../base/external-secrets.io/clustersecretstores/nerc-cluster-secrets

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: external-secrets
 resources:
 - ../../base/core/namespaces/external-secrets-operator
 - ../../base/core/serviceaccounts/eso-vault-auth

--- a/cluster-scope/bundles/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/bundles/group-sync-operator/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: group-sync-operator
 resources:
 - ../../base/core/namespaces/group-sync-operator
 - ../../base/operators.coreos.com/operatorgroups/group-sync-operator

--- a/cluster-scope/bundles/image-registry/kustomization.yaml
+++ b/cluster-scope/bundles/image-registry/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: image-registry
 resources:
 - ../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../base/core/persistentvolumeclaims/image-registry-storage

--- a/cluster-scope/bundles/logging/kustomization.yaml
+++ b/cluster-scope/bundles/logging/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: logging
 resources:
 - ../../base/core/namespaces/openshift-logging
 - ../../base/operators.coreos.com/operatorgroups/openshift-logging

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: metallb
 resources:
 - ../../base/core/namespaces/metallb-system
 - ../../base/operators.coreos.com/subscriptions/metallb-operator

--- a/cluster-scope/bundles/nmstate/kustomization.yaml
+++ b/cluster-scope/bundles/nmstate/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nmstate
 resources:
 - ../../base/core/namespaces/openshift-nmstate
 - ../../base/operators.coreos.com/operatorgroups/openshift-nmstate

--- a/cluster-scope/bundles/odf-external/kustomization.yaml
+++ b/cluster-scope/bundles/odf-external/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: odf-external
 resources:
 - ../odf
 - ../../base/odf.openshift.io/storagesystems/ocs-external-storagecluster-storagesystem

--- a/cluster-scope/bundles/odf/kustomization.yaml
+++ b/cluster-scope/bundles/odf/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: odf
 resources:
 - ../../base/core/namespaces/openshift-storage
 - ../../base/operators.coreos.com/operatorgroups/openshift-storage

--- a/cluster-scope/bundles/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-gitops/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: openshift-gitops
 resources:
 - ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/

--- a/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: openshift-operators-redhat
 resources:
 - ../../base/core/namespaces/openshift-operators-redhat/
 - ../../base/operators.coreos.com/operatorgroups/openshift-operators-redhat

--- a/cluster-scope/bundles/patch-operator/kustomization.yaml
+++ b/cluster-scope/bundles/patch-operator/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: patch-operator
 resources:
 - ../../base/core/namespaces/patch-operator
 - ../../base/operators.coreos.com/operatorgroups/patch-operator

--- a/cluster-scope/bundles/vault/kustomization.yaml
+++ b/cluster-scope/bundles/vault/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: vault
 resources:
 - ../../base/core/namespaces/vault
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding

--- a/cluster-scope/bundles/xdmod-reader/kustomization.yaml
+++ b/cluster-scope/bundles/xdmod-reader/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: xdmod-reader
 resources:
 - ../../base/core/namespaces/xdmod-reader/
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/xdmod-reader-permissions/


### PR DESCRIPTION
This allows us to identify the resources generated by a bundle, and can
also be used if you want to install a single bundle while still applying
any customizations from a cluster overlay:

    cd cluster-scope/overlays/nerc-ocp-prod
    kustomize build |
      yq 'select(.metadata.labels."nerc.mghpcc.org/bundle" == "metallb")' |
      kubectl apply -f-
