### PR TITLE
Add hostpath provisioner

### DIFF
--- a/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-hostpath-provisioner

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - machineconfig.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: hostpath-provisioner-selinux
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - name: hostpath-provisioner-selinux.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Set SELinux chcon for hostpath-provisioner
+            Before=kubelet.service
+
+            [Service]
+            ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
+
+            [Install]
+            WantedBy=multi-user.target

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-hostpath-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-hostpath-provisioner-admin
+    namespace: kubevirt-hostpath-provisioner
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-hostpath-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/clusterrole.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-hostpath-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    resourceNames:
+    - hostpath-provisioner
+    verbs:
+    - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/securitycontextconstraints.yaml
@@ -1,0 +1,30 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: hostpath-provisioner
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: true
+readOnlyRootFilesystem: false
+users:
+- system:serviceaccount:kubevirt-hostpath-provisioner:kubevirt-hostpath-provisioner
+volumes:
+- hostPath
+- downwardAPI
+- projected

--- a/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kubevirt-hostpath-provisioner
+provisioner: kubevirt.io/hostpath-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: hostpath-provisioner
+
+resources:
+- ../../base/core/namespaces/kubevirt-hostpath-provisioner
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner
+- ../../base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner
+- ../../base/security.openshift.io/securitycontextconstraints/hostpath-provisioner
+- ../../base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner
+- ../../base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../bundles/openshift-gitops
 - ../../bundles/acm
 - ../../bundles/acm/observability
+- ../../bundles/hostpath-provisioner
 - ../../bundles/vault
 - ../../bundles/patch-operator
 - ../../bundles/odf-external

--- a/hostpath-provisioner/base/daemonset.yaml
+++ b/hostpath-provisioner/base/daemonset.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubevirt-hostpath-provisioner
+  labels:
+    k8s-app: kubevirt-hostpath-provisioner
+  namespace: kubevirt-hostpath-provisioner
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kubevirt-hostpath-provisioner
+  template:
+    metadata:
+      labels:
+        k8s-app: kubevirt-hostpath-provisioner
+    spec:
+      serviceAccountName: kubevirt-hostpath-provisioner-admin
+      containers:
+        - name: kubevirt-hostpath-provisioner
+          image: quay.io/kubevirt/hostpath-provisioner
+          imagePullPolicy: Always
+          env:
+            - name: USE_NAMING_PREFIX
+              value: "false"  # change to true, to have the name of the pvc be part of the directory
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PV_DIR
+              value: /var/hpvolumes
+          volumeMounts:
+            - name: pv-volume  # root dir where your bind mounts will be on the node
+              mountPath: /var/hpvolumes
+      volumes:
+        - name: pv-volume
+          hostPath:
+            path: /var/hpvolumes

--- a/hostpath-provisioner/base/kustomization.yaml
+++ b/hostpath-provisioner/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: hostpath-provisioner
+resources:
+- daemonset.yaml
+- serviceaccount.yaml

--- a/hostpath-provisioner/base/serviceaccount.yaml
+++ b/hostpath-provisioner/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-hostpath-provisioner-admin
+  namespace: kubevirt-hostpath-provisioner

--- a/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+resources:
+- ../../base


### PR DESCRIPTION
Add the [hostpath provisioner](https://github.com/kubevirt/hostpath-provisioner) to nerc-ocp-infra. This allows us to dynamically provision host-local storage using PersistentVolumeClaims.

Part of: ocp-on-nerc/operations#49
See also: ocp-on-nerc/nerc-ocp-apps#23