### PR TITLE
Fix ordering of allowed volume types in hostpath-provisioner scc

### DIFF
--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/securitycontextconstraints.yaml
@@ -25,6 +25,6 @@ readOnlyRootFilesystem: false
 users:
 - system:serviceaccount:kubevirt-hostpath-provisioner:kubevirt-hostpath-provisioner
 volumes:
-- hostPath
 - downwardAPI
+- hostPath
 - projected


### PR DESCRIPTION
It looks like something in openshift sorts the `volumes` list, so that we
end up with the deployed manifest looking different from the source
manifest.

This commit will make ArgoCD happy.
