### PR TITLE
Update vault to use local storage

### DIFF
--- a/vault/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/overlays/nerc-ocp-infra/kustomization.yaml
@@ -4,3 +4,12 @@ resources:
   - ../../base
   - backup-job
 namespace: vault
+
+patches:
+  - target:
+      kind: StatefulSet
+      name: nerc-vault
+    patch: |
+      - op: add
+        path: /spec/volumeClaimTemplates/0/spec/storageClassName
+        value: kubevirt-hostpath-provisioner


### PR DESCRIPTION
Update the vault StatefulSet to explicitly use the
kubevirt-hostpath-provisioner StorageClass, which will allocate
storage from the local disk.

Closes ocp-on-nerc/operations#49