### PR TITLE
Upgrading ACM and Loki Operators

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: acm
 spec:
-    channel: release-2.5
+    channel: release-2.6
     installPlanApproval: Automatic
     name: advanced-cluster-management
     source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: candidate
+  channel: stable-5.5
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators

--- a/loki/base/lokistacks/lokistack.yaml
+++ b/loki/base/lokistacks/lokistack.yaml
@@ -16,22 +16,7 @@ spec:
       type: s3
     tls:
       caName: lokistack-ca-bundle-custom
-  template:
-    compactor:
-      replicas: 1
-    distributor:
-      replicas: 1
-    gateway:
-      replicas: 1
-    indexGateway:
-      replicas: 1
-    ingester:
-      replicas: 1
-    querier:
-      replicas: 1
-    queryFrontend:
-      replicas: 1
   tenants:
     mode: openshift-logging
-  size: 1x.extra-small
+  size: 1x.medium
   storageClassName: ocs-external-storagecluster-ceph-rbd


### PR DESCRIPTION
We ran into an issue with Observability where the prod cluster was no longer reporting metrics. Observability is back online thanks to a suggestion from @jakobo from the CoreOS forum-acm-cluster-lifecycle Slack channel. After deleting the multicluster-engine Subscription and CSV, deleting the openshift-monitoring pods, and deleting the ACM Subscription, CSV, and MultiClusterObservability CRD again, the infra and prod cluster metrics are back in Observability.
- See the [Red Hat Support Case](https://access.redhat.com/support/cases/#/case/03391625/discussion)
- close https://github.com/OCP-on-NERC/operations/issues/47

We are also migrating from the candidate channel of the LokiOperator to the stable-5.5 channel. Also Loki was configured on the smallest `1x.extra-small` setting with minimal pod replicas [which is not recommended here](https://docs.openshift.com/container-platform/4.11/logging/cluster-logging-loki.html#deployment-sizing_cluster-logging-loki). 
