### PR TITLE
Use Recreate rollout strategy for image registry

### DIFF
--- a/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/config.yaml
+++ b/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/config.yaml
@@ -1,10 +1,20 @@
 apiVersion: imageregistry.operator.openshift.io/v1
 kind: Config
 metadata:
+  labels:
+    app.kubernetes.io/instance: cluster-scope-prod
   name: cluster
 spec:
+  logLevel: Normal
   managementState: Managed
+  operatorLogLevel: Normal
   replicas: 1
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  rolloutStrategy: Recreate
   storage:
     pvc:
       claim: image-registry-storage


### PR DESCRIPTION
When using ReadWriteOnce storage, the registry only supports a single
replica and requires the Recreate rollout strategy.

Part-of: ocp-on-nerc/operations#65
