### PR TITLE
Remove desiredUpdate from clusterversion

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -4,8 +4,4 @@ metadata:
   name: version
 spec:
   channel: stable-4.10
-  clusterID: c17c3ede-423f-4db6-8313-3d0ef3d543c7
-  desiredUpdate:
-    image: >-
-      quay.io/openshift-release-dev/ocp-release@sha256:ddcb70ce04a01ce487c0f4ad769e9e36a10c8c832a34307c1b1eb8e03a5b7ddb
-    version: 4.10.15
+  clusterID: 01f68d3f-2938-4e07-aad4-d7c5d9763e8f


### PR DESCRIPTION
We've just re-deployed the cluster so we want whatever version it has right
now. We'll update this in the future to trigger and upgrade.

This also captures the updated cluster ID.
