### PR TITLE
Apply hostpath provision machineconfig to controller nodes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -34,6 +34,7 @@ patches:
 - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
 - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
 - path: ingresscontrollers/default_patch.yaml
+- path: machineconfigs/hostpath-provisioner-selinux_patch.yaml
 
 patchesStrategicMerge:
   - externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/hostpath-provisioner-selinux_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/machineconfigs/hostpath-provisioner-selinux_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: hostpath-provisioner-selinux
+  labels:
+    machineconfiguration.openshift.io/role: master


### PR DESCRIPTION
On the infra cluster, we only have controllers. The hostpath provisioner
machineconfig applies by default to worker nodes, but this was a no-op on
infra.
