### PR TITLE
Fix namespace for the patch of openshift-ingress

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/app/patches/external-ingress-node-labeler.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/app/patches/external-ingress-node-labeler.yaml
@@ -3,7 +3,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
   name: external-ingress-node-label-wrk-10
-  namespace: openshift-storage
+  namespace: openshift-ingress
 spec:
   serviceAccountRef:
     name: patcher
@@ -23,7 +23,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
   name: external-ingress-node-label-wrk-11
-  namespace: openshift-storage
+  namespace: openshift-ingress
 spec:
   serviceAccountRef:
     name: patcher
@@ -43,7 +43,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
   name: external-ingress-node-label-wrk-13
-  namespace: openshift-storage
+  namespace: openshift-ingress
 spec:
   serviceAccountRef:
     name: patcher
@@ -63,7 +63,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
   name: external-ingress-node-label-wrk-14
-  namespace: openshift-storage
+  namespace: openshift-ingress
 spec:
   serviceAccountRef:
     name: patcher
@@ -83,7 +83,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
   name: external-ingress-node-label-wrk-16
-  namespace: openshift-storage
+  namespace: openshift-ingress
 spec:
   serviceAccountRef:
     name: patcher


### PR DESCRIPTION
~it matters because the patch will use the serviceaccount in that namespace which has the permissions to patch `Node` resources.~
The odf serviceaccount patcher should also have worked, but it's better this  stay in the correct namespace. 