### PR TITLE
ensure root:root on /var/hpvolumes

### DIFF
--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
@@ -18,7 +18,7 @@ spec:
             Before=kubelet.service
 
             [Service]
-            ExecStartPre=-/usr/bin/install -d /var/hpvolumes -m 0755
+            ExecStartPre=-/usr/bin/install -d /var/hpvolumes -m 0755 -o root -g root
             ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
 
             [Install]


### PR DESCRIPTION
This happens anyway given that the install command gets run by the root user via the systemd service but just to be sure...