### PR TITLE
update prod clusterversion after rebuild

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -4,4 +4,4 @@ metadata:
   name: version
 spec:
   channel: stable-4.10
-  clusterID: 431b0152-5ee5-471d-9f48-ee2d733232dc
+  clusterID: b36da721-2e23-46b6-a7c5-317985cd0e2f

--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -5,7 +5,3 @@ metadata:
 spec:
   channel: stable-4.10
   clusterID: 431b0152-5ee5-471d-9f48-ee2d733232dc
-  desiredUpdate:
-    image: >-
-      quay.io/openshift-release-dev/ocp-release@sha256:59d7ac85da072fea542d7c43498e764c72933e306117a105eac7bd5dda4e6bbe
-    version: 4.10.39


### PR DESCRIPTION
The prod cluster has been rebuilt so we're bumping the cluster ID to match. This will also remove the `desiredUpdate` so that we install with the version that's currently installed.