### PR TITLE
patcher-openshift-ingress: s/node/nodes in cluster role resources list

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/app/rbac/clusterrole.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-ingress/app/rbac/clusterrole.yaml
@@ -7,7 +7,7 @@ rules:
   - ""
   resources:
   - services
-  - node
+  - nodes
   verbs:
   - get
   - list


### PR DESCRIPTION
This fixes an issue where the external ingress router pods were pending given that the patch operator was faililng to apply the external ingress node label due to permissions issue.

Temporarily disabling auto-sync in ArgoCD and applying this fix manually on the prod cluster fixed the issue and allowed the external ingress router pods to schedule.