### PR TITLE
Add curator-operator and install prerequisites

### DIFF
--- a/cluster-scope/base/core/namespaces/curator-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/curator-operator/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/curator-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/curator-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: curator-operator

--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: koku-metrics-operator
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+    - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+    name: koku-metrics-operator
+spec:
+    targetNamespaces:
+        - koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: koku-metrics-operator
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: koku-metrics-operator
+spec:
+    channel: beta
+    installPlanApproval: Automatic
+    name: koku-metrics-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/curator-operator/kustomization.yaml
+++ b/cluster-scope/bundles/curator-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/core/namespaces/curator-operator/
+  - ../../base/core/namespaces/koku-metrics-operator/
+  - ../../base/operators.coreos.com/operatorgroups/koku-metrics-operator/
+  - ../../base/operators.coreos.com/subscriptions/koku-metrics-operator/

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - ../common
 - ../../bundles/acct-mgt
+- ../../bundles/curator-operator
 - ../../bundles/patch-operator
 - ../../bundles/xdmod-reader
 - ../../bundles/solr-helm-repo

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/curator-operator/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/curator-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: curator-operator
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - openshift-ingress
 - openshift-logging
 - group-sync-operator
+- curator-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - apiserver/cluster.yaml
 - ../common
+- ../../bundles/curator-operator
 - ../../bundles/patch-operator
 - externalsecrets/
 - ../../bundles/rhods-operator

--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/curator-operator/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/curator-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: curator-operator
+components:
+  - ../../../../components/nerc-secret-store

--- a/curator-operator/base/deploymentconfigs/postgres/deploymentconfig.yaml
+++ b/curator-operator/base/deploymentconfigs/postgres/deploymentconfig.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: postgresql
+spec:
+  replicas: 1
+  selector:
+    name: postgresql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: postgresql
+    spec:
+      containers:
+        - env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secrets
+                  key: DatabaseUser
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secrets
+                  key: DatabasePassword
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secrets
+                  key: DatabaseName
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          image: "postgres:13"
+          imagePullPolicy: IfNotPresent
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: pgsql-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+        - name: pgsql-data
+          persistentVolumeClaim:
+            claimName: pgsql-data

--- a/curator-operator/base/deploymentconfigs/postgres/kustomization.yaml
+++ b/curator-operator/base/deploymentconfigs/postgres/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: curator-operator
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - deploymentconfig.yaml

--- a/curator-operator/base/kustomization.yaml
+++ b/curator-operator/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- deploymentconfigs/postgres
+- pvcs/postgres
+- services/postgres

--- a/curator-operator/base/pvcs/postgres/kustomization.yaml
+++ b/curator-operator/base/pvcs/postgres/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: curator-operator
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - pvc.yaml

--- a/curator-operator/base/pvcs/postgres/pvc.yaml
+++ b/curator-operator/base/pvcs/postgres/pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pgsql-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: ocs-external-storagecluster-ceph-rbd
+  volumeMode: Filesystem

--- a/curator-operator/base/services/postgres/kustomization.yaml
+++ b/curator-operator/base/services/postgres/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: curator-operator
 resources:
-- curator-operator
-- openshift-config
-- group-sync-operator
+  - service.yaml

--- a/curator-operator/base/services/postgres/service.yaml
+++ b/curator-operator/base/services/postgres/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+spec:
+  ports:
+    - name: postgresql
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    name: postgresql

--- a/curator-operator/overlays/nerc-ocp-prod/externalsecrets/database-secrets.yaml
+++ b/curator-operator/overlays/nerc-ocp-prod/externalsecrets/database-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgres-database-secrets
+  namespace: curator-operator
+spec:
+  target:
+    name: postgres-database-secrets
+    template:
+      metadata:
+        labels: {}
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-prod/curator/postgres

--- a/curator-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/curator-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+  - ../../base
+  - externalsecrets/database-secrets.yaml

--- a/curator-operator/overlays/nerc-ocp-test/externalsecrets/database-secrets.yaml
+++ b/curator-operator/overlays/nerc-ocp-test/externalsecrets/database-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgres-database-secrets
+  namespace: curator-operator
+spec:
+  target:
+    name: postgres-database-secrets
+    template:
+      metadata:
+        labels: {}
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-test/curator/postgres

--- a/curator-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/curator-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base
+- externalsecrets/database-secrets.yaml


### PR DESCRIPTION
This PR adds resources to deploy the curator operator, in this case specifically on the nerc-ocp-prod cluster. 

the first commit is adding the curator operator prerequisites. For this I've followed the instructions at [https://curator-operator.readthedocs.io/en/latest/requirements.html](https://curator-operator.readthedocs.io/en/latest/requirements.html)