### PR TITLE
prod: upgrade openshift-acct-mgt to v0.2.0

### DIFF
--- a/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
+++ b/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
         - name: acct-mgt
-          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.1.0"
+          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.2.0"


### PR DESCRIPTION
This upgrades to the latest v0.2.0 release to test out: https://github.com/CCI-MOC/openshift-acct-mgt/pull/86

https://github.com/CCI-MOC/openshift-acct-mgt/releases/tag/v0.2.0