### PR TITLE
Expose console and API externally

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/README.md
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/README.md
@@ -1,0 +1,25 @@
+This is necessary to work around an apparent issue with routes to the API server.
+
+We have tried to expose the API externally by adding a route to the `openshift-kube-apiserver` namespace:
+
+```
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: api-external
+  namespace: openshift-kube-apiserver
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: api.apps.shift.nerc.mghpcc.org
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: apiserver
+  port:
+    targetPort: https
+```
+
+Unfortunately, with this route in place, attempts to access `https://api.apps.shift.nerc.mghpcc.org`  fail with the "Application is not available" message.

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/deployment.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-proxy
+spec:
+  replicas: 3
+  template:
+    spec:
+      serviceAccountName: haproxy
+      containers:
+      - name: haproxy
+        image: docker.io/haproxy:lts
+        ports:
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+          - name: haproxy-config
+            mountPath: /usr/local/etc/haproxy
+          - name: haproxy-state
+            mountPath: /var/lib/haproxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+      volumes:
+        - name: haproxy-config
+          configMap:
+            name: haproxy-config
+        - name: haproxy-state
+          emptyDir: {}

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/haproxy.cfg
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/haproxy.cfg
@@ -1,0 +1,30 @@
+global
+    log         stdout format raw local0
+
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+
+    stats socket /var/lib/haproxy/stats
+
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout http-keep-alive 10s
+    timeout check           10s
+
+frontend main
+    bind *:8080
+    default_backend kubernetes
+
+backend kubernetes
+    server api kubernetes.default.svc.cluster.local:443 check ssl verify none

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nerc-api-proxy
+commonLabels:
+  app: api-proxy
+resources:
+- namespace.yaml
+- deployment.yaml
+- rolebinding.yaml
+- role.yaml
+- route.yaml
+- serviceaccount.yaml
+- service.yaml
+
+configMapGenerator:
+  - name: haproxy-config
+    files:
+      - haproxy.cfg

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/namespace.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nerc-api-proxy
+spec: {}

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/role.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: haproxy-run-as-root
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/rolebinding.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: haproxy-run-as-root
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: haproxy-run-as-root
+subjects:
+- kind: ServiceAccount
+  name: haproxy

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/route.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/route.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: api-external
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: api.apps.shift.nerc.mghpcc.org
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: api-proxy

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/service.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-proxy
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/serviceaccount.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/api-proxy/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: haproxy

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/console-external-certificate.cert
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/console-external-certificate.cert
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: console-external-certificate
+spec:
+  secretName: console-external-certificate
+  duration: 2160h
+  renewBefore: 360h
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - console.apps.shift.nerc.mghpcc.org
+  uris:
+    - https://console.apps.shift.nerc.mghpcc.org
+  issuerRef:
+    name: nerc-external-apps-issuer
+    kind: Issuer

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/downloads-external-certificate.cert
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/downloads-external-certificate.cert
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: downloads-external-certificate
+spec:
+  secretName: downloads-external-certificate
+  duration: 2160h
+  renewBefore: 360h
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - downloads.apps.shift.nerc.mghpcc.org
+  uris:
+    - https://downloads.apps.shift.nerc.mghpcc.org
+  issuerRef:
+    name: nerc-external-apps-issuer
+    kind: Issuer

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+
+resources:
+- console-external-certificate.cert
+- downloads-external-certificate.cert
+- oauth-external-certificate.cert
+- nerc-external-apps-issuer.yaml
+- nerc-route53-creds.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/nerc-external-apps-issuer.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/nerc-external-apps-issuer.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: nerc-external-apps-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: nerc-external-apps-issuer
+    solvers:
+      - selector:
+          dnsZones:
+            - "apps.shift.nerc.mghpcc.org"
+        dns01:
+          route53:
+            region: us-east-1
+
+            # The hostedZoneID is optional, but if not provided the associated
+            # IAM account requires the route53:ListHostedZonesByName capability.
+            # (https://cert-manager.io/docs/configuration/acme/dns01/route53/)
+            hostedZoneID: Z05272992YC46BUE2REFK
+            accessKeyIDSecretRef:
+              name: nerc-route53-creds
+              key: ACCESS_KEY_ID
+            secretAccessKeySecretRef:
+              name: nerc-route53-creds
+              key: SECRET_ACCESS_KEY

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/nerc-route53-creds.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/nerc-route53-creds.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nerc-route53-creds
+spec:
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  target:
+    name: nerc-route53-creds
+    template:
+      type: Opaque
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-prod/openshift-ingress/route53-creds

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/oauth-external-certificate.cert
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/certificates/oauth-external-certificate.cert
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: oauth-external-certificate
+spec:
+  secretName: oauth-external-certificate
+  duration: 2160h
+  renewBefore: 360h
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - oauth.apps.shift.nerc.mghpcc.org
+  uris:
+    - https://oauth.apps.shift.nerc.mghpcc.org
+  issuerRef:
+    name: nerc-external-apps-issuer
+    kind: Issuer

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/cluster-ingress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/cluster-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  domain: apps.nerc-ocp-prod.rc.fas.harvard.edu
+  componentRoutes:
+    - name: console
+      namespace: openshift-console
+      hostname: console.apps.shift.nerc.mghpcc.org
+      servingCertKeyPairSecret:
+        name: console-external-certificate
+    - name: downloads
+      namespace: openshift-console
+      hostname: downloads.apps.shift.nerc.mghpcc.org
+      servingCertKeyPairSecret:
+        name: downloads-external-certificate
+    - name: oauth-openshift
+      namespace: openshift-authentication
+      hostname: oauth.apps.shift.nerc.mghpcc.org
+      servingCertKeyPairSecret:
+        name: oauth-external-certificate

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/feature: external-console
+
+resources:
+- cluster-ingress.yaml
+- certificates
+- routes
+- api-proxy

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/api.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/api.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: api-external
+  namespace: openshift-kube-apiserver
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: api.apps.shift.nerc.mghpcc.org
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: apiserver
+  port:
+    targetPort: https

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/console.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/console.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: console-external
+  namespace: openshift-console
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: console.apps.shift.nerc.mghpcc.org
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: console
+  port:
+    targetPort: https

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/downloads.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/downloads.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: downloads-external
+  namespace: openshift-console
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: downloads.apps.shift.nerc.mghpcc.org
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: downloads
+  port:
+    targetPort: http

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- oauth.yaml
+- console.yaml
+- downloads.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/oauth.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/external-console-access/routes/oauth.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: oauth-openshift-external
+  namespace: openshift-authentication
+  labels:
+    nerc.mghpcc.org/external-ingress: "true"
+spec:
+  host: oauth-openshift.apps.shift.nerc.mghpcc.org
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: oauth-openshift
+  port:
+    targetPort: 6443

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ../../bundles/xdmod-reader
 - feature/odf
 - feature/external-ingress
+- feature/external-console-access
 - ../../base/core/namespaces/openshift-gitops
 - externalsecrets
 - apiserver/cluster.yaml


### PR DESCRIPTION
This commit includes several changes to make the OpenShift console and API
available externally (without VPN access). Broadly, there are

- Modify the cluster-ingress configuration to use externally visible
  hostnames for the console, downloads, and oauth services
- Add explicit external routes (i.e, routes with a label that matches
  our external ingress service) for these services
- Add a proxy to the OpenShift API, exposed with an external route

With these changes in place, it is possible to access the console from
outside the VPN. Some URLs (e.g., when using the "copy login command" menu
option) will still use the internal, vpn-only hostnames.

Closes ocp-on-nerc/operations#67
Closes ocp-on-nerc/operations#66


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204165599358399