### PR TITLE
Add common resources to nerc-ocp-test cluster overlay

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../common


### PR DESCRIPTION
Addresses [https://github.com/OCP-on-NERC/operations/issues/92](https://github.com/OCP-on-NERC/operations/issues/92) as part of configuring the test cluster. 