### PR TITLE
Add odf manifests and patch operator to test cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namespace: openshift-storage
+spec:
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  target:
+    name: rook-ceph-external-cluster-details
+  data:
+  - secretKey: external_cluster_details
+    remoteRef:
+      key: nerc/nerc-ocp-test/openshift-storage/rook-ceph-external-cluster-details
+      property: external_cluster_details

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+
+commonLabels:
+  nerc.mghpcc.org/feature: odf
+
+components:
+  - ../../../../components/nerc-secret-store
+
+resources:
+  - ../../../../bundles/odf-external
+  - externalsecrets/rook-ceph-external-cluster-details.yaml
+  - redhatcop.redhat.io/odf-node-patcher.yaml
+
+patches:
+  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/redhatcop.redhat.io/odf-node-patcher.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/redhatcop.redhat.io/odf-node-patcher.yaml
@@ -1,0 +1,21 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  name: odf-node-label-workers
+  namespace: openshift-storage
+spec:
+  serviceAccountRef:
+    name: patcher
+  patches:
+    odf-node-label-workers:
+      targetObjectRef:
+        apiVersion: v1
+        kind: Node
+        labelSelector:
+          matchLabels:
+            node-role.kubernetes.io/worker: ""
+      patchType: application/strategic-merge-patch+json
+      patchTemplate: |
+        metadata:
+          labels:
+            "cluster.ocs.openshift.io/openshift-storage": ""

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
@@ -1,0 +1,17 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-external-storagecluster-ceph-rbd
+parameters:
+  clusterID: openshift-storage
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: nerc_ocp_test_1_rbd

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -5,3 +5,4 @@ commonLabels:
 
 resources:
 - ../common
+- feature/odf

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -5,4 +5,5 @@ commonLabels:
 
 resources:
 - ../common
+- ../../bundles/patch-operator
 - feature/odf


### PR DESCRIPTION
Depends on #202

Addresses [https://github.com/OCP-on-NERC/operations/issues/92](https://github.com/OCP-on-NERC/operations/issues/92)

This PR does 2 things:

1. Adds odf manifests to enable ceph storage on the test cluster
2. Add patch operator resource bundle for patching worker nodes

 