### PR TITLE
Patch nerc-secret-store in test cluster overlay

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: secretstores/secretstore-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/secretstores/secretstore-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/secretstores/secretstore-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: nerc-secret-store
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          mountPath: kubernetes/nerc-ocp-test


### PR DESCRIPTION
Patches the nerc-secret-store in the test cluster to use test cluster k8s auth method in vault