### PR TITLE
update cluster version for latest nerc-ocp-prod rebuild

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -4,4 +4,4 @@ metadata:
   name: version
 spec:
   channel: stable-4.10
-  clusterID: 311ea4d8-ee60-4440-8850-911a51f72ec1
+  clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982


### PR DESCRIPTION
This latest rebuild is to incorporate #207 which requires a different cluster name in order to configure public access for API and Ingress servers