### PR TITLE
Partially revert "Remove patches to default ingress controller"

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/ingresscontrollers/default_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/ingresscontrollers/default_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: default-ingress-certificate

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
   namespace: openshift-monitoring
 
 patches:
+- path: ingresscontrollers/default_patch.yaml
 - path: oauths/cluster_patch.yaml
 - path: patches/skipdryrunonmissingresource.yaml
   target:


### PR DESCRIPTION
This partially reverts commit bdbef5dccf0521471f41cc3e244f3759236beff1. We
need to patch the ingress controller to reference our custom certificate.
