### PR TITLE
Use production letsencrypt servers

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/certificates/default-api-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/certificates/default-api-certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-config
 spec:
   issuerRef:
-    name: letsencrypt-staging-dns01
+    name: letsencrypt-production-dns01
     kind: Issuer
   secretName: default-api-certificate
   duration: 2160h0m0s

--- a/cluster-scope/overlays/nerc-ocp-prod/certificates/default-ingress-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/certificates/default-ingress-certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-ingress
 spec:
   issuerRef:
-    name: letsencrypt-staging-dns01
+    name: letsencrypt-production-dns01
     kind: Issuer
   secretName: default-ingress-certificate
   duration: 2160h0m0s


### PR DESCRIPTION
Things seem to be working so switch to the production letsencrypt servers.
