### PR TITLE
add custom routes for console and downloads

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/cluster-ingress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/cluster-ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  domain: apps.shift.nerc.mghpcc.org
+  componentRoutes:
+    - name: console
+      namespace: openshift-console
+      hostname: console.apps.shift.nerc.mghpcc.org
+    - name: downloads
+      namespace: openshift-console
+      hostname: downloads.apps.shift.nerc.mghpcc.org

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-ingress.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../bundles/patch-operator
 - ../../bundles/xdmod-reader
 - feature/odf
+- feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops
 - externalsecrets
 - apiserver/cluster.yaml


### PR DESCRIPTION
This is to restore the custom routes we had previously for the console and downloads routes in the `openshift-console` namespace.