### PR TITLE
Add link to NERC helpdesk

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/consolelinks/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/consolelinks/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nerc-helpdesk.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/consolelinks/nerc-helpdesk.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/consolelinks/nerc-helpdesk.yaml
@@ -1,0 +1,8 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: nerc-helpdesk
+spec:
+  href: 'https://mghpcc.supportsystem.com/'
+  location: HelpMenu
+  text: "NERC Helpdesk"

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - nodenetworkconfigurationpolicies
 - clusterversion.yaml
 - certificates
+- consolelinks
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Following [1], add a link for https://mghpcc.supportsystem.com/ to the help
(?) menu in the OpenShift console.

[1]: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/web_console/customizing-web-console#creating-custom-links_customizing-web-console
