### PR TITLE
Add self-signed certificate issuer

### DIFF
--- a/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/clusterissuer.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/clusterissuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}

--- a/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterissuer.yaml

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: cert-manager
+resources:
+- ../../base/operators.coreos.com/subscriptions/cert-manager
+- ../../base/cert-manager.io/clusterissuers/selfsigned

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../base/config.openshift.io/oauths/cluster
 - ../../base/rbac.authorization.k8s.io/clusterroles/node-labeler/
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
+- ../../bundles/cert-manager
 - ../../bundles/openshift-operators-redhat
 - ../../bundles/cluster-admin-rbac
 - ../../bundles/external-secrets


### PR DESCRIPTION
Add a cert-manager ClusterIssuer that generates self-signed certificates. This can be used as described in [1] to create internal certificate authorities for securing traffic between services running in the same namespace.

[1]: https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers
