### PR TITLE
Correct minor kustomize syntax issue

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - applicationsets
 
 patches:
-- patches/argocds/openshift-gitops.yaml
+- path: patches/argocds/openshift-gitops.yaml


### PR DESCRIPTION
Our kustomization.yaml in openshift-gitops/overlays/nerc-ocp-infra/ was
using legacy syntax for specifying patches. This PR updates the syntax.
