### PR TITLE
Fix legacy syntax in kustomization.yaml

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - applicationsets
 
 patches:
-- patches/argocds/openshift-gitops.yaml
+- path: patches/argocds/openshift-gitops.yaml


### PR DESCRIPTION
openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml was using
legacy patch syntax. This works but fails validation (and may be deprecated
in the future).

This commit updates the syntax to match current usage.
