### PR TITLE
openshift-acct-mgt: bump default limits

### DIFF
--- a/acct-mgt/base/configmaps.yaml
+++ b/acct-mgt/base/configmaps.yaml
@@ -53,12 +53,12 @@ data:
         {
             "type": "Container",
             "default": {
-                "cpu": "200m",
-                "memory": "512Mi"
+                "cpu": "2",
+                "memory": "1024Mi"
             },
             "defaultRequest": {
-                "cpu": "100m",
-                "memory": "256Mi"
+                "cpu": "1",
+                "memory": "512Mi"
             }
         }
     ]


### PR DESCRIPTION
Similar to:
CCI-MOC/openshift-acct-mgt#90

Part of:
OCP-on-NERC/operations#90