### PR TITLE
Use shared validate-manifests workflow

### DIFF
--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -1,25 +1,8 @@
-name: Kustomize build overlays
+name: Validate Kubernetes manifests
 
 on:
   pull_request:
-    paths:
-      - '**.yaml'
 
 jobs:
   validate-manifests:
-    runs-on: ubuntu-latest
-    env:
-      KUSTOMIZE_VERSION: v4.5.5
-      TERM: xterm-256color
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Pull kustomize image
-        run: |
-          docker pull k8s.gcr.io/kustomize/kustomize:${KUSTOMIZE_VERSION}
-
-      - name: Validate manifests
-        run: |
-          export KUSTOMIZE="docker run --rm -v $PWD:$PWD -w $PWD k8s.gcr.io/kustomize/kustomize:${KUSTOMIZE_VERSION}"
-          ./ci/validate-manifests.sh
+    uses: ocp-on-nerc/workflows/.github/workflows/validate-manifests.yaml@main


### PR DESCRIPTION
Replace the local validate-manifests workflow and script with the one
recently added to our shared workflows repository [1].

Closes ocp-on-nerc/operations#99

[1]: https://github.com/OCP-on-NERC/workflows
