### PR TITLE
Adding alerts for noobaa and loki errors

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -26,7 +26,7 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage|LokiStackWriteRequestErrors|LokiRequestErrors|LokiRequestLatency|NooBaaBucketErrorState|NooBaaResourceErrorState"
+                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage|LokiStackWriteRequestErrors|LokiRequestErrors|LokiRequestLatency|NooBaaBucketErrorState|NooBaaResourceErrorState|ClusterOperatorDown|ClusterOperatorDegraded|ClusterOperatorFlapping|ClusterVersionOperatorDown|ClusterMonitoringOperatorReconciliationErrors"
           receivers:
           - name: default
           - name: slack-notifications

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -26,7 +26,7 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage"
+                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage|LokiStackWriteRequestErrors|LokiRequestErrors|LokiRequestLatency|NooBaaBucketErrorState|NooBaaResourceErrorState"
           receivers:
           - name: default
           - name: slack-notifications


### PR DESCRIPTION
Please suggest any other alerts you want to see from the list of default cluster alerts. 