### PR TITLE
Adding ipmi and ceph custom metrics by regex wildcard

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -15,18 +15,6 @@ data:
       - node_network_transmit_bytes_total
       - node_network_transmit_errs_total
       - node_network_transmit_packets_total
-      - ipmi_bmc_info
-      - ipmi_chassis_power_state
-      - ipmi_current_amperes
-      - ipmi_current_state
-      - ipmi_dcmi_power_consumption_watts
-      - ipmi_fan_speed_rpm
-      - ipmi_fan_speed_state
-      - ipmi_power_state
-      - ipmi_power_watts
-      - ipmi_scrape_duration_seconds
-      - ipmi_sensor_state
-      - ipmi_sensor_value
-      - ipmi_temperature_celsius
-      - ipmi_temperature_state
-      - ipmi_up
+    matches:
+      - __name__=~"(ipmi_.*)"
+      - __name__=~"(ceph_.*)"


### PR DESCRIPTION
- I couldn't find documentation for this kind of regex matches, but I did find an [example that removes alerts matching a name and a job field](https://github.com/stolostron/multicluster-observability-operator/blob/3493964af4c4a583bdfff50740eb26322a5a1c95/examples/metrics/allowlist/custom-metrics-allowlist.yaml#L12-L13).
- I wondered if these kind of matches allow for the regular expression =~ matching, based on the [regex code I found here](https://github.com/stolostron/multicluster-observability-operator/blob/3493964af4c4a583bdfff50740eb26322a5a1c95/proxy/pkg/rewrite/rewrite.go#L23), and when I tried out the `matches` expression `- __name__=~"(ipmi_.*)"`, it worked!