### PR TITLE
Fixing metrics alert descriptions, and adding IPMI, and node alerts

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -89,6 +89,64 @@ data:
           labels:
             severity: warning
 
+      - name: ipmi
+        rules:
+
+        - alert: CustomIpmiServerPowerSupplyFailure
+          annotations:
+            summary: "{{ $labels.cluster }} Server power supply failure"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ipmi_power_state%7B%7D%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster }} on instance {{$labels.instance }} has a non-zero power supply state {{ $value }}.
+          expr: ipmi_power_state{} > 0
+          for: 1m
+          labels:
+            severity: warning
+
+        - alert: CustomIpmiChassisPowerSupplyFailure
+          annotations:
+            summary: "{{ $labels.cluster }} Chassis power supply failure"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ipmi_chassis_power_state%7B%7D%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster}} on instance {{$labels.instance }} chassis power is off.
+          expr: ipmi_chassis_power_state{} == 0
+          for: 1m
+          labels:
+            severity: warning
+
+        - alert: CustomIpmiServerMemoryError
+          annotations:
+            summary: "{{ $labels.cluster }} Server memory error"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ipmi_sensor_state%7Btype%3D%5C%22Memory%5C%22%7D%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster}} on instance {{$labels.instance }} has a non-zero memory state {{ $value }}.
+          expr: ipmi_sensor_state{type="Memory"} > 0
+          for: 1m
+          labels:
+            severity: warning
+
+        - alert: CustomIpmiLocalDiskError
+          annotations:
+            summary: "{{ $labels.cluster }} Local disk error"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ipmi_sensor_state%7Btype%3D%5C%22Drive%20Slot%5C%22%7D%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster}} on instance {{$labels.instance }} has a non-zero drive slot state {{ $value }}.
+          expr: ipmi_sensor_state{type="Drive Slot"} > 0
+          for: 1m
+          labels:
+            severity: warning
+
+        - alert: CustomIpmiInternalCoolingFanError
+          annotations:
+            summary: "{{ $labels.cluster}} Internal cooling fan error on {{$labels.instance }}"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ipmi_fan_speed_state%7B%7D%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster}} on instance {{$labels.instance }} has a non-zero fan speed state {{ $value }}.
+          expr: ipmi_fan_speed_state{} > 0
+          for: 1m
+          labels:
+            severity: warning
+
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.
 # The up metric is useful for debugging and alerting for targets that are down or having issues.

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -62,14 +62,10 @@ data:
         - alert: CustomCephStorageFillingUp
           annotations:
             summary: Ceph Storage is filling up.
-            description: "The Ceph Storage is {{ $value | humanizePercentage }} full."
-          expr: sum((kubelet_volume_stats_used_bytes{cluster="local-cluster"} * on (namespace,persistentvolumeclaim) group_right() kube_pod_spec_volumes_persistentvolumeclaims_info{cluster="local-cluster"}) * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info{cluster="local-cluster"} * on (storageclass)  group_left(provisioner) kube_storageclass_info{cluster="local-cluster", provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"}))/sum((kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster="local-cluster"} * on (namespace,persistentvolumeclaim) group_right() kube_pod_spec_volumes_persistentvolumeclaims_info{cluster="local-cluster"}) * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info{cluster="local-cluster"} * on (storageclass)  group_left(provisioner) kube_storageclass_info{cluster="local-cluster", provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)|(ceph.rook.io/block)"})) > 0.80
+            description: "The {{ $labels.pool }} pool Ceph Storage is {{ $value | humanizePercentage }} full."
+          expr: (ceph_pool_raw_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) / on (cluster, namespace, pool) (ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) > 0.80
           for: 1m
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
-            PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
             severity: warning
 
         - alert: CustomNetworkInterfaceErrors

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -147,6 +147,20 @@ data:
           labels:
             severity: warning
 
+      - name: node
+        rules:
+
+        - alert: CustomNodeNotReady
+          annotations:
+            summary: "{{ $labels.cluster}} node {{$labels.node }} not in ready status"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22kube_node_status_condition%7Bcondition%3D%5C%22Ready%5C%22,%20status!%3D%5C%22true%5C%22%7D%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $labels.cluster}} node {{$labels.node }} is not in ready status.
+          expr: kube_node_status_condition{condition="Ready", status!="true"} > 0
+          for: 1m
+          labels:
+            severity: warning
+
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.
 # The up metric is useful for debugging and alerting for targets that are down or having issues.

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -11,73 +11,82 @@ data:
 
         - alert: CustomStoragePersistentVolumeFillingUp
           annotations:
-            summary: PersistentVolume is filling up.
-            description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
-          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"db-noobaa-db-pg-.*|metrics-backing-store-noobaa-pvc-.*|noobaa-default-backing-store-noobaa-pvc-.*"}/kubelet_volume_stats_capacity_bytes < 0.10
+            summary: "{{ $labels.cluster }} PersistentVolume is filling up"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22kubelet_volume_stats_available_bytes%7Bpersistentvolumeclaim!~%5C%22wal-logging-loki-ingester-.*%5C%22%7D%2Fkubelet_volume_stats_capacity_bytes%20%3C%200.10%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.
+          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim!~"wal-logging-loki-ingester-.*"}/kubelet_volume_stats_capacity_bytes < 0.10
           for: 1m
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
-            PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
             severity: critical
 
         - alert: CustomStoragePersistentVolumeFillingUpPredicted
           annotations:
-            summary: PersistentVolume is filling up and is predicted to run out of space in 6h.
-            description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
-          expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"db-noobaa-db-pg-.*|metrics-backing-store-noobaa-pvc-.*|noobaa-default-backing-store-noobaa-pvc-.*"}/kubelet_volume_stats_capacity_bytes) < 0.10 and (predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600)) < 0
+            summary: "{{ $labels.cluster }} PersistentVolume is filling up and is predicted to run out of space in 6h"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(kubelet_volume_stats_available_bytes%7Bpersistentvolumeclaim!~%5C%22wal-logging-loki-ingester-.*%5C%22%7D%2Fkubelet_volume_stats_capacity_bytes)%20%3C%200.10%20and%20(predict_linear(kubelet_volume_stats_available_bytes%5B6h%5D,%204%20*%2024%20*%203600))%20%3C%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.
+          expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim!~"wal-logging-loki-ingester-.*"}/kubelet_volume_stats_capacity_bytes) < 0.10 and (predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600)) < 0
           for: 1h
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
-            PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
             severity: warning
+
+      - name: memory
+        rules:
 
         - alert: CustomContainerMemoryUsage
           annotations:
-            summary: Container Memory usage (instance {{ $labels.instance }})
-            description: "Container Memory usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-          expr: (sum(container_memory_working_set_bytes{name!=""}) BY (cluster, pod, container) / sum(kube_pod_container_resource_limits{resource="memory"} > 0) BY (cluster, pod, container) * 100) > 80
+            summary: "{{ $labels.cluster }} container Memory usage above 80%"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(sum(container_memory_working_set_bytes%7Bname!%3D%5C%22%5C%22%7D)%20BY%20(cluster,%20namespace,%20pod,%20container)%20%2F%20sum(kube_pod_container_resource_limits%7Bresource%3D%5C%22memory%5C%22%7D%20%3E%200)%20BY%20(cluster,%20namespace,%20pod,%20container))%20%3E%200.80%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Container Memory usage is at {{ $value | humanizePercentage }} in namespace {{ $labels.namespace }}, pod {{ $labels.pod }}, container {{ $labels.container }}"
+          expr: (sum(container_memory_working_set_bytes{name!=""}) BY (cluster, namespace, pod, container) / sum(kube_pod_container_resource_limits{resource="memory"} > 0) BY (cluster, namespace, pod, container)) > 0.80
           for: 2m
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
             severity: warning
+            groupname: memory
+
+      - name: cpu
+        rules:
 
         - alert: CustomContainerCpuUsage
           annotations:
-            summary: Container CPU usage (instance {{ $labels.container_name }})
-            description: "Container CPU usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-          expr: sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate[1h])) by (cluster, namespace, pod) / avg(kube_pod_container_resource_limits{resource="cpu"}) by (cluster, namespace, pod) * 100 > 80
+            summary: "{{ $labels.cluster }} container CPU usage above 80%"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate%5B1h%5D))%20by%20(cluster,%20namespace,%20pod)%20%2F%20avg(kube_pod_container_resource_limits%7Bresource%3D%5C%22cpu%5C%22%7D)%20by%20(cluster,%20namespace,%20pod)%20%3E%200.80%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Container CPU usage is at {{ $value | humanizePercentage }} in namespace {{ $labels.namespace }}, pod {{ $labels.pod }}.
+          expr: sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate[1h])) by (cluster, namespace, pod) / avg(kube_pod_container_resource_limits{resource="cpu"}) by (cluster, namespace, pod) > 0.80
           for: 5m
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
             severity: warning
+            cpu: memory
+
+      - name: ceph-storage
+        rules:
 
         - alert: CustomCephStorageFillingUp
           annotations:
-            summary: Ceph Storage is filling up.
-            description: "The {{ $labels.pool }} pool Ceph Storage is {{ $value | humanizePercentage }} full."
+            summary: "{{ $labels.cluster }} Ceph Storage is filling up"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(ceph_pool_raw_used_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D)%20%2F%20on%20(cluster,%20namespace,%20pool)%20(ceph_pool_quota_max_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D)%20%3E%200.80%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              The {{ $labels.pool }} pool Ceph Storage is {{ $value | humanizePercentage }} full.
           expr: (ceph_pool_raw_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) / on (cluster, namespace, pool) (ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) > 0.80
           for: 1m
           labels:
             severity: warning
 
+      - name: network
+        rules:
+
         - alert: CustomNetworkInterfaceErrors
           annotations:
-            summary: Node network transmit errors
-            description: "{{ $value }} node network transmit errors occured"
+            summary: "{{ $labels.cluster }} Node network transmit errors"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22increase(node_network_transmit_errs_total%5B1h%5D)%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              {{ $value }} node network transmit errors occured.
           expr: increase(node_network_transmit_errs_total[1h]) > 0
           for: 1m
           labels:
-            instance: "{{ $labels.instance }}"
-            cluster: "{{ $labels.cluster }}"
-            clusterID: "{{ $labels.clusterID }}"
             severity: warning
 
 # Prometheus generates a metric called up that indicates whether a scrape was successful.

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -69,9 +69,20 @@ data:
             summary: "{{ $labels.cluster }} Ceph Storage is filling up"
             description: |
               <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(ceph_pool_raw_used_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D)%20%2F%20on%20(cluster,%20namespace,%20pool)%20(ceph_pool_quota_max_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D)%20%3E%200.80%22%7D%5D|Click here to see these metrics in Observability Monitoring>
-              The {{ $labels.pool }} pool Ceph Storage is {{ $value | humanizePercentage }} full.
+              The {{ $labels.cluster }} {{ $labels.pool }} pool Ceph Storage is {{ $value | humanizePercentage }} full.
           expr: (ceph_pool_raw_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) / on (cluster, namespace, pool) (ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}) > 0.80
           for: 1m
+          labels:
+            severity: warning
+
+        - alert: CustomCephStorageFillingUpPredicted
+          annotations:
+            summary: "{{ $labels.cluster }} Ceph Storage is filling up and is predicted to run out of space in 90 days"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ceph_pool_quota_max_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%20-%20on%20(cluster,%20namespace,%20pool,%20pod)%20predict_linear(ceph_pool_used_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%5B90d%5D,%2090%20*%2024%20*%2060%20*%2060)%20%3C%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              The {{ $labels.cluster }} {{ $labels.pool }} pool Ceph Storage is predicted to run out of space in 90 days
+          expr: ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"} - on (cluster, namespace, pool, pod) predict_linear(ceph_pool_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}[90d], 90 * 24 * 60 * 60) <= 0
+          for: 1h
           labels:
             severity: warning
 

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -47,7 +47,7 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "(CustomCephStorageFillingUp)"
+                  - alertname =~ "(CustomCephStorage.*)"
               - receiver: slack-notifications
                 group_by: [cluster, alertname]
                 group_wait: 5m

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -63,6 +63,13 @@ spec:
                 matchers:
                   - alertname =~ "(CustomIpmi.*)"
               - receiver: slack-notifications
+                group_by: [cluster, alertname, node]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomNodeNotReady)"
+              - receiver: slack-notifications
                 group_by: [cluster, alertname]
                 group_wait: 5m
                 group_interval: 1d

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -21,12 +21,54 @@ spec:
             group_by: [cluster, alertname]
             routes:
               - receiver: slack-notifications
-                group_by: [alertname, datacenter, app]
-                group_wait: 1d
+                group_by: [cluster, alertname, namespace, persistentvolumeclaim]
+                group_wait: 5m
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "CustomStoragePersistentVolumeFillingUp|CustomStoragePersistentVolumeFillingUpPredicted|CustomContainerMemoryUsage|CustomContainerCpuUsage|LokiStackWriteRequestErrors|LokiRequestErrors|LokiRequestLatency|NooBaaBucketErrorState|NooBaaResourceErrorState|ClusterOperatorDown|ClusterOperatorDegraded|ClusterOperatorFlapping|ClusterVersionOperatorDown|ClusterMonitoringOperatorReconciliationErrors"
+                  - alertname =~ "(CustomStoragePersistentVolume.*)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, namespace, instance]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomContainerMemoryUsage)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, namespace, pod, container]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomContainerCpuUsage)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, pool]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomCephStorageFillingUp)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomNetworkInterfaceErrors)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, instance]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomIpmi.*)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "LokiStackWriteRequestErrors|LokiRequestErrors|LokiRequestLatency|NooBaaBucketErrorState|NooBaaResourceErrorState|ClusterOperatorDown|ClusterOperatorDegraded|ClusterOperatorFlapping|ClusterVersionOperatorDown|ClusterMonitoringOperatorReconciliationErrors"
           receivers:
           - name: default
           - name: slack-notifications


### PR DESCRIPTION
- [Improve the Ceph storage metric by using the actual Ceph exported metrics](https://github.com/OCP-on-NERC/nerc-ocp-config/commit/16a1734532eb69a5d902e8ccf71d2b17c779daca)
- [Fixing the missing alert labels, grouping, and better alert descriptions](https://github.com/OCP-on-NERC/nerc-ocp-config/commit/cf713a0edf7748e74926a2482a4690d423035112)
- [Adding IPMI alerts](https://github.com/OCP-on-NERC/nerc-ocp-config/commit/f2d3ec277089cb3b873b3b0d515714ed0252ac3a)
- [Adding node not in ready status alert](https://github.com/OCP-on-NERC/nerc-ocp-config/commit/7c1548c4b54ee5234da38d56c2b328c215f06f65)
- [Adding a ceph storage filling up in 90 days predicted metric](https://github.com/OCP-on-NERC/nerc-ocp-config/pull/229/commits/4667b6d0e00391ab3b18401b63ff934db3d16747)

@aabaris I have added IPMI alerts for the 5 remaining items in this [issue](https://github.com/OCP-on-NERC/operations/issues/55), I would love to hear your feedback on these. 
@larsks I would love to know if you think the node not in ready status alert is sufficient for node errors. 
