### PR TITLE
Install crunchy-postgres-operator to prod

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: crunchy-postgres-operator
+  namespace: openshift-operators
+spec:
+  channel: v5
+  installPlanApproval: Automatic
+  name: crunchy-postgres-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
+++ b/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: crunchy-postgres-operator
+resources:
+- ../../base/operators.coreos.com/subscriptions/crunchy-postgres-operator

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../../bundles/acct-mgt
 - ../../bundles/patch-operator
 - ../../bundles/xdmod-reader
+- ../../bundles/crunchy-postgres-operator
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops


### PR DESCRIPTION
The [Smart Village Collaboratory project](https://research.redhat.com/blog/research_project/creating-a-global-open-research-platform-to-better-understand-social-sustainability-using-data-from-a-real-life-smart-village/) would like to install the Crunchy Postgres for Kubernetes Operator to NERC. The [Smart Village project configures users, databases, and Postgres clusters](https://github.com/computate-org/smartabyar-smartvillage/tree/main/openshift/kustomize/bundles/postgres) for persistence of data.

closes https://github.com/OCP-on-NERC/operations/issues/106