### PR TITLE
Install Apache Solr Operator Helm Chart Repository and CRDs to prod

### DIFF
--- a/cluster-scope/base/helm.openshift.io/helmchartrepositories/solr-helm-repo/helmchartrepository.yaml
+++ b/cluster-scope/base/helm.openshift.io/helmchartrepositories/solr-helm-repo/helmchartrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: helm.openshift.io/v1beta1
+kind: HelmChartRepository
+metadata:
+  name: solr-helm-repo
+spec:
+  name: solr-helm-repo
+  connectionConfig:
+    url: https://solr.apache.org/charts

--- a/cluster-scope/base/helm.openshift.io/helmchartrepositories/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/base/helm.openshift.io/helmchartrepositories/solr-helm-repo/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmchartrepository.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 - ../../bundles/acct-mgt
 - ../../bundles/patch-operator
 - ../../bundles/xdmod-reader
+- ../../base/helm.openshift.io/helmchartrepositories/solr-helm-repo
+- https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops


### PR DESCRIPTION
The [Smart Village Collaboratory project](https://research.redhat.com/blog/research_project/creating-a-global-open-research-platform-to-better-understand-social-sustainability-using-data-from-a-real-life-smart-village/) would like to install the Apache Solr Operator and CRDs to NERC. There are two important parts here. The Apache Zookeeper cluster for running Solr as a clustered cloud, as well as our smart village application which is a Vert.x application that is also clustered between pods with the Apache Zookeeper cluster. The second part is Apache Solr which is the search engine for the Smart Village application. The search engine powers the API for extremely fast querying, pagination, filtering, faceting, pivoting, sorting and more. This allows for building custom analytics and dashboards that are extremely powerful. You can find the [CRDs for Apache Solr](https://solr.apache.org/operator/downloads/crds/v0.6.0/all-with-dependencies.yaml) here, and the [Helm Chart Repository for Apache Solr](https://github.com/computate-org/smartabyar-smartvillage/blob/main/openshift/kustomize/bundles/solr/base/helmchartrepositories/solr-helm-repo/helmchartrepository.yaml) here. 

closes https://github.com/OCP-on-NERC/operations/issues/110