### PR TITLE
Adding RHODS image streams for project notebooks in test cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - machineconfigs/udev-rules
 - machineconfigs/configure-bond0
 - nodenetworkconfigurationpolicies/vlan-2175-nese.yaml
+- rhods/

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ucsls-stable-burosa-prods23/
+  - stable-base-ope-nerc/

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/stable-base-ope-nerc/imagestream.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/stable-base-ope-nerc/imagestream.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: stable-base-ope-nerc
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://quay.io/repository/ucsls/ucsls?tab=tags"
+    opendatahub.io/notebook-image-name: "stable-base-ope-nerc"
+    opendatahub.io/notebook-image-desc: "stable-base-ope-nerc"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: 'quay.io/rh_ee_keli/ope-template:stable-base-ope-NERC'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/stable-base-ope-nerc/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/stable-base-ope-nerc/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/ucsls-stable-burosa-prods23/imagestream.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/ucsls-stable-burosa-prods23/imagestream.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ucsls-stable-burosa-prods23
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://quay.io/repository/ucsls/ucsls?tab=tags"
+    opendatahub.io/notebook-image-name: "ucsls stable-burosa-prodS23"
+    opendatahub.io/notebook-image-desc: "ucsls stable-burosa-prodS23"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: 'quay.io/ucsls/ucsls:stable-burosa-prodS23'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/ucsls-stable-burosa-prods23/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/imagestreams/ucsls-stable-burosa-prods23/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rhods/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rhods/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestreams/


### PR DESCRIPTION
Here are some RHODS jupyter notebook images that the RHODS Red Hat Research team uses. 

- ucsls-stable-burosa-prods23 image
- stable-base-ope-nerc image