### PR TITLE
Allow read access to Observability to AI 4 Cloud Ops team

### DIFF
--- a/cluster-scope/overlays/common/clusterrolebindings/nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
+++ b/cluster-scope/overlays/common/clusterrolebindings/nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-logs-metrics-open-cluster-management-cluster-manager-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:cluster-manager-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-logs-metrics

--- a/cluster-scope/overlays/common/clusterrolebindings/nerc-ops-cluster-reader.yaml
+++ b/cluster-scope/overlays/common/clusterrolebindings/nerc-ops-cluster-reader.yaml
@@ -10,3 +10,6 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: nerc-ops
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-logs-metrics

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -18,5 +18,6 @@ resources:
 - clusterrolebindings/nerc-ops-cluster-reader.yaml
 - clusterrolebindings/nerc-ops-sudoers.yaml
 - clusterrolebindings/nerc-ops-portforward.yaml
+- clusterrolebindings/nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
 - groupsyncs
 - machineconfigs

--- a/cluster-scope/overlays/nerc-ocp-infra/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/oauths/cluster_patch.yaml
@@ -13,3 +13,4 @@ spec:
           name: github-client-secret
         teams:
           - ocp-on-nerc/nerc-ops
+          - ocp-on-nerc/nerc-logs-metrics


### PR DESCRIPTION
Based on ACM Observability documentation for required access[1], it's possible to grant the AI 4 Cloud Ops team open-cluster-management:cluster-manager-admin access to Observability through a new OCP on NERC GitHub team.

[1] https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/observability/observing-environments-intro#enable-observability

close https://github.com/OCP-on-NERC/operations/issues/123