### PR TITLE
Onboard ai4cloudops to test cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/ai4cloudops/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ai4cloudops/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ../../../../components/project-admin-rolebindings/ai4cloudops
+namespace: ai4cloudops

--- a/cluster-scope/base/core/namespaces/ai4cloudops/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/ai4cloudops/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai4cloudops
+spec: {}

--- a/cluster-scope/bundles/ai4cloudops/kustomization.yaml
+++ b/cluster-scope/bundles/ai4cloudops/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: ai4cloudops
+resources:
+- ../../base/core/namespaces/ai4cloudops

--- a/cluster-scope/components/project-admin-rolebindings/ai4cloudops/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/ai4cloudops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/ai4cloudops/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/ai4cloudops/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: ai4cloudops
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: nerc-ai4cloudops


### PR DESCRIPTION
This commit adds the ai4cloudops project namespace to the test cluster, as well as adds a project-namespace-admin component that we can easily add to namespaces as needed moving forward. 
Syed is added as the project admin for now