### PR TITLE
common: bump systemReserved to 4 CPU and 4Gi RAM

### DIFF
--- a/cluster-scope/overlays/common/kubeletconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/common/kubeletconfigs/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - system-reserved.yaml

--- a/cluster-scope/overlays/common/kubeletconfigs/system-reserved.yaml
+++ b/cluster-scope/overlays/common/kubeletconfigs/system-reserved.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved
+  namespace: openshift-config-operator
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    systemReserved:
+      cpu: '4'
+      memory: '4Gi'

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
 - clusterrolebindings/nerc-ops-portforward.yaml
 - groupsyncs
 - machineconfigs
+- kubeletconfigs

--- a/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved
+  namespace: openshift-config-operator
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+      pools.operator.machineconfiguration.openshift.io/worker: ""

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -36,3 +36,4 @@ configMapGenerator:
 patches:
 - path: ingresscontrollers/default_patch.yaml
 - path: oauths/cluster_patch.yaml
+- path: kubeletconfigs/system-reserved-patch.yaml


### PR DESCRIPTION
We're currently debugging an issue with timeouts/unavailability of at least the authentication cluster operator and potentially others (e.g. apiserver/kube-apiserver) on the nerc-ocp-infra cluster. In the case we opened with RedHat, they pointed out the warning about reserved system memory. This bumps the system memory from the default of 500m CPU and 1Gi RAM, via a kubeletconfig in the common overlay, to see if this helps given the number of pods running on this cluster.

See:
- https://github.com/OCP-on-NERC/operations/issues/127
- https://access.redhat.com/support/cases/#/case/03513513