### PR TITLE
Remove erroneous machineConfigPoolSelector configuration

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: openshift-config-operator
 spec:
   machineConfigPoolSelector:
-    matchLabels:
-      pools.operator.machineconfiguration.openshift.io/master: ""
-      pools.operator.machineconfiguration.openshift.io/worker: ""
+    $patch: delete


### PR DESCRIPTION
In pr #242, we added a Kubeletconfig resource with the following
configuration:

    machineConfigPoolSelector:
      matchLabels:
        pools.operator.machineconfiguration.openshift.io/master: ""
        pools.operator.machineconfiguration.openshift.io/worker: ""

That was intended to apply the configuration to both work and master nodes,
but from the documentation for the `machineConfigPoolSelector` key we see
that `matchLabels` are ANDed together:

    machineConfigPoolSelector    <Object>
      A label selector is a label query over a set of resources. The result
      of matchLabels and matchExpressions are ANDed. An empty label
      selector matches all objects. A null label selector matches no
      objects.

This commit *removes* the `machineConfigPoolSelector` configuration, which
means the Kubeletconfig will apply to all pools.
