### PR TITLE
Remove use of deprecated patchesStrategicMerge

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -36,7 +36,5 @@ patches:
 - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
 - path: ingresscontrollers/default_patch.yaml
 - path: machineconfigs/hostpath-provisioner-selinux_patch.yaml
-
-patchesStrategicMerge:
-  - externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml
-  - externalsecrets/open-cluster-management-observability-thanos-object-storage_patch.yaml
+- path: externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml
+- path: externalsecrets/open-cluster-management-observability-thanos-object-storage_patch.yaml


### PR DESCRIPTION
The Kustomize `patchesStrategicMerge` and `patchesJson6902` keywords
have both been replaced by the `patches` keyword.

