### PR TITLE
Increasing metrics-backing-store to 800Gi

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -8,6 +8,6 @@ spec:
     numVolumes: 3
     resources:
       requests:
-        storage: 400Gi
+        storage: 800Gi
     storageClass: ocs-external-storagecluster-ceph-rbd
   type: pv-pool


### PR DESCRIPTION
In May 2023, NERC Infra reached NO_CAPACITY on the metrics backing store set at 400Gi. We will set the metrics-backing-store storage to 800Gi while looking into configuring retention on the Observability metrics.
