### PR TITLE
Increase buckets in metrics backing store

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 3
+    numVolumes: 6
     resources:
       requests:
         storage: 400Gi

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -8,6 +8,6 @@ spec:
     numVolumes: 3
     resources:
       requests:
-        storage: 800Gi
+        storage: 400Gi
     storageClass: ocs-external-storagecluster-ceph-rbd
   type: pv-pool


### PR DESCRIPTION
Implement the spirit of 70ac9945 (#246) by doubling the number of buckets in metrics-backing-store.

---

I believe it is not possible to change the volume size of volumes in a Noobaa backing store. Your options are (a) increase the number of volumes or (b) create a new backing store.