### PR TITLE
prod: fix system-reserved kubeletconfig patch

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: openshift-config-operator
 spec:
   machineConfigPoolSelector:
-    $patch: delete
+    matchLabels:
+      $patch: delete


### PR DESCRIPTION
Not having a machineConfigPoolSelector defined in #243 results in the following error:

```
Error: could not find any MachineConfigPool set for KubeletConfig
```

In the spec docs it mentions that an empty label selector matches all objects:

> An empty label selector matches all objects. A null label selector matches no objects.

This patch attempts to set an empty label selector.