### PR TITLE
prod: fix system-reserved kubeletconfig patch

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kubeletconfigs/system-reserved-patch.yaml
@@ -6,4 +6,5 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      $patch: delete
+      $patch: replace
+      machineconfiguration.openshift.io/mco-built-in: ""


### PR DESCRIPTION
After attempting to set both `matchLabels` and `matchExpressions` in the `machineConfigPoolSelector` to an empty map and empty array respectively, we were unable to get the `KubeletConfig` to match both the master and worker MCPs. (see #243 and #249)

This patch replaces the label in `matchLabels` to be a common label between master and pool labels in order to achieve the desired result:

`machineconfiguration.openshift.io/mco-built-in`

With this in place:
```
$ kustomize build | kfilt -k kubeletconfig
---
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  labels:
    nerc.mghpcc.org/kustomized: "true"
  name: system-reserved
  namespace: openshift-config-operator
spec:
  kubeletConfig:
    systemReserved:
      cpu: "4"
      memory: 4Gi
  machineConfigPoolSelector:
    matchLabels:
      machineconfiguration.openshift.io/mco-built-in: ""
 ```