### PR TITLE
Allow members of the nerc-rhods team to authenticate

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/oauths/cluster_patch.yaml
@@ -14,3 +14,4 @@ spec:
         teams:
           - ocp-on-nerc/nerc-ops
           - ocp-on-nerc/nerc-logs-metrics
+          - ocp-on-nerc/nerc-rhods


### PR DESCRIPTION
Previously, our GitHub oauth configuration only permitted members of the
nerc-ops and nerc-logs-metrics teams to authenticate to openshift. This
commit adds the nerc-rhods team to the list.

Closes: ocp-on-nerc/operations#137
