### PR TITLE
fix issuer(s) secret ref

### DIFF
--- a/cluster-scope/components/nerc-certificate-issuer/issuer-dns01-prod.yaml
+++ b/cluster-scope/components/nerc-certificate-issuer/issuer-dns01-prod.yaml
@@ -14,10 +14,10 @@ spec:
         route53:
           region: us-east-1
           accessKeyIDSecretRef:
-            key: aws_access_key_id
+            key: AWS_ACCESS_KEY_ID
             name: aws-route53-credentials
           secretAccessKeySecretRef:
-            key: aws_secret_access_key
+            key: AWS_SECRET_ACCESS_KEY
             name: aws-route53-credentials
       selector:
         dnsZones:

--- a/cluster-scope/components/nerc-certificate-issuer/issuer-dns01-staging.yaml
+++ b/cluster-scope/components/nerc-certificate-issuer/issuer-dns01-staging.yaml
@@ -14,10 +14,10 @@ spec:
         route53:
           region: us-east-1
           accessKeyIDSecretRef:
-            key: aws_access_key_id
+            key: AWS_ACCESS_KEY_ID
             name: aws-route53-credentials
           secretAccessKeySecretRef:
-            key: aws_secret_access_key
+            key: AWS_SECRET_ACCESS_KEY
             name: aws-route53-credentials
       selector:
         dnsZones:


### PR DESCRIPTION
The issuer secret refs are case-sensitive and the keys within the vault/externalsecret are all upper case.

closes https://github.com/OCP-on-NERC/operations/issues/144