### PR TITLE
Increasing log storage from 6 to 12 400Gi volumes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 6
+    numVolumes: 12
     resources:
       requests:
         storage: 400Gi


### PR DESCRIPTION
The logs ran out of disk space in the metrics-backing-store for Ceph. We need to determine the right amount of storage and volumes for logs. As a temporary solution, we will increase the log storage from 6 to 12 400Gi volumes. For a longer term solution, we have created this issue:

https://github.com/OCP-on-NERC/operations/issues/151