### PR TITLE
Adding a Container Metric to Observability

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -15,6 +15,7 @@ data:
       - node_network_transmit_bytes_total
       - node_network_transmit_errs_total
       - node_network_transmit_packets_total
+      - kube_pod_container_info
     matches:
       - __name__=~"(ipmi_.*)"
       - __name__=~"(ceph_.*)"


### PR DESCRIPTION
My intern project focuses on scanning the vulnerabilities in the containers running in the cluster. One step is to retrieve the images used by the containers running in the cluster and then we will analyse the dependencies in the image. Adding `kube_pod_container_info` to Observation exposes the container image sources to further introspection.
For example, similar to the code below I would be able to query `image_name` from Grafana.
```
prothemus_server_addr = 'localhost'
name_space = "default"
kube_pod_container_info = requests.get("http://"+prothemus_server_addr+":9090/api/v1/query?query=kube_pod_container_info{namespace='"+name_space+"'}&start=1687801230.165&end=1687804830.165&step=14")
image_name = kube_pod_container_info.json()['data']['result'][0]['metric']['image']
```
@computate @larsks @jtriley @OCP-on-NERC/nerc-ops Could you please review and consider approving it?
Thank you.