### PR TITLE
Change cluster operator installPlanApproval to Manual to halt automatic upgrades

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: acm
 spec:
     channel: release-2.6
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: advanced-cluster-management
     source: redhat-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/amq-broker-rhel8/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/amq-broker-rhel8/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: 7.11.x
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: amq-broker-rhel8
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/amq-streams/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/amq-streams/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: amq-streams-2.3.x
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: amq-streams
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/ansible-automation-platform-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/ansible-automation-platform-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: aap
 spec:
   channel: stable-2.3-cluster-scoped
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: ansible-automation-platform-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: cert-manager
 spec:
     channel: stable
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: cert-manager
     source: community-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-logging
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/crunchy-postgres-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: v5
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: crunchy-postgres-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: elasticsearch-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: external-secrets-operator
 spec:
     channel: stable
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: external-secrets-operator
     source: community-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: group-sync-operator
 spec:
     channel: alpha
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: group-sync-operator
     source: community-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscriptions.yaml
@@ -4,7 +4,7 @@ metadata:
     name: kubernetes-nmstate-operator
 spec:
     channel: stable
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: kubernetes-nmstate-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable-5.6
-  installPlanApproval: Automatic
+  installPlanApproval: Manaual
   name: loki-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: metallb-operator
 spec:
     channel: stable
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: metallb-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
     name: odf-operator
 spec:
     channel: stable-4.10
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: odf-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-gitops-operator
 spec:
   channel: gitops-1.6
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator-rh
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/patch-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/patch-operator/subscription.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: patch-operator
 spec:
   channel: alpha
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: patch-operator
   source: community-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/red-hat-camel-k/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/red-hat-camel-k/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: 1.10.x
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: red-hat-camel-k
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: redhat-ods-operator
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: rhods-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-serverless
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
With  manual updates, when a newer version of an Operator is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.

Closes: [https://github.com/OCP-on-NERC/operations/issues/148](https://github.com/OCP-on-NERC/operations/issues/148)