### PR TITLE
add nvidia-gpu-operator resources and bundle

### DIFF
--- a/cluster-scope/base/core/namespaces/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-gpu-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/nvidia-gpu-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-gpu-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-gpu-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-gpu-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+spec:
+  targetNamespaces:
+    - nvidia-gpu-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-gpu-operator
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+spec:
+  channel: "v23.3"
+  installPlanApproval: Manual
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: "gpu-operator-certified.v23.3.2"

--- a/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nvidia-gpu-operator
+resources:
+- ../../base/core/namespaces/nvidia-gpu-operator
+- ../../base/operators.coreos.com/operatorgroups/nvidia-gpu-operator
+- ../../base/operators.coreos.com/subscriptions/nvidia-gpu-operator


### PR DESCRIPTION
This adds a bundle to facilitate the base installation of the nvidia-gpu-operator:

https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/openshift/install-gpu-ocp.html

NOTE: Once this is merged we need to add this to `nerc-ocp-test` overlay along with a `ClusterPolicy`. This specifies the driver installation repo, version, and other details. See the above doc for more info.

Related:
- https://github.com/OCP-on-NERC/operations/issues/82
- https://github.com/OCP-on-NERC/operations/issues/119
- https://github.com/OCP-on-NERC/operations/issues/163
- https://github.com/OCP-on-NERC/operations/issues/164