### PR TITLE
nerc-ocp-test: add gpu operator and clusterpolicy

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterpolicies/gpu-cluster-policy.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterpolicies/gpu-cluster-policy.yaml
@@ -1,0 +1,91 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  cdi:
+    default: false
+    enabled: false
+  daemonsets:
+    rollingUpdate:
+      maxUnavailable: "1"
+    updateStrategy: RollingUpdate
+  dcgm:
+    enabled: true
+  dcgmExporter:
+    config:
+      name: ""
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  devicePlugin:
+    config:
+      default: ""
+      name: ""
+    enabled: true
+  driver:
+    certConfig:
+      name: ""
+    enabled: true
+    kernelModuleConfig:
+      name: ""
+    licensingConfig:
+      configMapName: ""
+      nlsEnabled: false
+    repoConfig:
+      configMapName: ""
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        deleteEmptyDir: false
+        enable: false
+        force: false
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+      maxUnavailable: 25%
+      podDeletion:
+        deleteEmptyDir: false
+        force: false
+        timeoutSeconds: 300
+      waitForCompletion:
+        timeoutSeconds: 0
+    virtualTopology:
+      config: ""
+  gds:
+    enabled: false
+  gfd:
+    enabled: true
+  mig:
+    strategy: single
+  migManager:
+    config:
+      default: all-disabled
+      name: default-mig-parted-config
+    enabled: true
+  nodeStatusExporter:
+    enabled: true
+  operator:
+    defaultRuntime: crio
+    runtimeClass: nvidia
+    use_ocp_driver_toolkit: true
+  sandboxDevicePlugin:
+    enabled: true
+  sandboxWorkloads:
+    defaultWorkload: container
+    enabled: false
+  toolkit:
+    enabled: true
+    installDir: /usr/local/nvidia
+  validator:
+    plugin:
+      env:
+      - name: WITH_WORKLOAD
+        value: "true"
+  vfioManager:
+    enabled: true
+  vgpuDeviceManager:
+    config:
+      default: default
+    enabled: true
+  vgpuManager:
+    enabled: false

--- a/cluster-scope/overlays/nerc-ocp-test/clusterpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gpu-cluster-policy.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -9,12 +9,14 @@ resources:
 - ../../bundles/patch-operator
 - externalsecrets/
 - ../../bundles/rhods-operator
+- ../../bundles/nvidia-gpu-operator
 - feature/odf
 - machineconfigs/disable-net-ifnames
 - machineconfigs/udev-rules
 - machineconfigs/configure-bond0
 - nodenetworkconfigurationpolicies/vlan-2175-nese.yaml
 - secretstores
+- clusterpolicies
 
 patches:
 - path: oauths/cluster_patch.yaml


### PR DESCRIPTION
This installs the nvidia-gpu-operator bundle and a ClusterPolicy resource on the nerc-ocp-test cluster for testing out GPU support on OpenShift.