### PR TITLE
add node feature discovery operator and install on nerc-ocp-test

### DIFF
--- a/cluster-scope/base/core/namespaces/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/node-feature-discovery/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/node-feature-discovery/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nfd
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nfd
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/node-feature-discovery/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/node-feature-discovery/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nfd
+spec:
+  targetNamespaces:
+    - openshift-nfd

--- a/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nfd
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: nfd.4.10.0-202306170106

--- a/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: node-feature-discovery
+resources:
+- ../../base/core/namespaces/node-feature-discovery
+- ../../base/operators.coreos.com/operatorgroups/node-feature-discovery
+- ../../base/operators.coreos.com/subscriptions/node-feature-discovery

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../bundles/patch-operator
 - externalsecrets/
 - ../../bundles/rhods-operator
+- ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
 - feature/odf
 - machineconfigs/disable-net-ifnames
@@ -17,6 +18,7 @@ resources:
 - nodenetworkconfigurationpolicies/vlan-2175-nese.yaml
 - secretstores
 - clusterpolicies
+- nodefeaturediscoveries
 
 patches:
 - path: oauths/cluster_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/nodefeaturediscoveries/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/nodefeaturediscoveries/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfd-instance.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/nodefeaturediscoveries/nfd-instance.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/nodefeaturediscoveries/nfd-instance.yaml
@@ -1,0 +1,60 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  customConfig:
+    configData: ""
+  instance: ""
+  operand:
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
+    imagePullPolicy: Always
+    servicePort: 0
+  topologyupdater: false
+  workerConfig:
+    configData: |
+      core:
+        sleepInterval: 60s
+      sources:
+        cpu:
+          cpuid:
+      #     NOTE: whitelist has priority over blacklist
+            attributeBlacklist:
+              - "BMI1"
+              - "BMI2"
+              - "CLMUL"
+              - "CMOV"
+              - "CX16"
+              - "ERMS"
+              - "F16C"
+              - "HTT"
+              - "LZCNT"
+              - "MMX"
+              - "MMXEXT"
+              - "NX"
+              - "POPCNT"
+              - "RDRAND"
+              - "RDSEED"
+              - "RDTSCP"
+              - "SGX"
+              - "SSE"
+              - "SSE2"
+              - "SSE3"
+              - "SSE4.1"
+              - "SSE4.2"
+              - "SSSE3"
+            attributeWhitelist:
+        kernel:
+          configOpts:
+            - "NO_HZ"
+            - "X86"
+            - "DMI"
+        pci:
+          deviceClassWhitelist:
+          - "0200"
+          - "0300"
+          - "0302"
+          deviceLabelFields:
+          - "vendor"
+          - "class"


### PR DESCRIPTION
This appears to be required by the nvidia-gpu-operator that we're currently in the middle of testing on `nerc-ocp-test`. This adds the operator, bundle, and also installs the operator and NodeFeatureDiscovery resource required for the `nvidia-gpu-operator` on `nerc-ocp-test`.

See: https://github.com/NVIDIA/gpu-operator/issues/438

Related:

- #261