### PR TITLE
Add koku-metrics operator manifests and add operator to nerc-ocp-test overlays

### DIFF
--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: koku-metrics-operator
+resources:
+    - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+    name: koku-metrics-operator
+spec:
+    targetNamespaces:
+        - koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: koku-metrics-operator
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: koku-metrics-operator
+spec:
+    channel: beta
+    installPlanApproval: Automatic
+    name: koku-metrics-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/bundles/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/core/namespaces/koku-metrics-operator/
+  - ../../base/operators.coreos.com/operatorgroups/koku-metrics-operator/
+  - ../../base/operators.coreos.com/subscriptions/koku-metrics-operator/

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - apiserver/cluster.yaml
 - ../common
+- ../../bundles/koku-metrics-operator
 - ../../bundles/patch-operator
 - externalsecrets/
 - ../../bundles/rhods-operator

--- a/koku-metrics-operator/base/kokumetricscfg.yaml
+++ b/koku-metrics-operator/base/kokumetricscfg.yaml
@@ -1,0 +1,14 @@
+apiVersion: koku-metrics-cfg.openshift.io/v1beta1
+kind: KokuMetricsConfig
+metadata:
+  name: kokumetricscfg
+spec:
+  authentication: {}
+  packaging:
+    max_reports_to_store: 25
+    max_size_MB: 100
+  prometheus_config: {}
+  source: {}
+  upload:
+    upload_cycle: 360
+    upload_toggle: false

--- a/koku-metrics-operator/base/kustomization.yaml
+++ b/koku-metrics-operator/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kokumetricscfg.yaml

--- a/koku-metrics-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/koku-metrics-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: koku-metrics-operator
+resources:
+  - ../../base


### PR DESCRIPTION
Adding koku-metrics operator subscription to test cluster to work with the curator deployement