### PR TITLE
Remove cluster specific config from secretstore component

### DIFF
--- a/cluster-scope/components/nerc-secret-store/secretstore.yaml
+++ b/cluster-scope/components/nerc-secret-store/secretstore.yaml
@@ -10,7 +10,7 @@ spec:
       version: "v2"
       auth:
         kubernetes:
-          mountPath: kubernetes/nerc-ocp-prod
+          mountPath: UPDATE IN OVERLAY
           role: secret-reader
           secretRef:
             name: "vault-secret-reader"

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -43,3 +43,9 @@ patches:
 - path: ingresscontrollers/default_patch.yaml
 - path: oauths/cluster_patch.yaml
 - path: kubeletconfigs/system-reserved-patch.yaml
+- target:
+    kind: SecretStore
+  patch: |
+    - op: replace
+      path: /spec/provider/vault/auth/kubernetes/mountPath
+      value: kubernetes/nerc-ocp-prod

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -23,3 +23,9 @@ resources:
 
 patches:
 - path: oauths/cluster_patch.yaml
+- target:
+    kind: SecretStore
+  patch: |
+    - op: replace
+      path: /spec/provider/vault/auth/kubernetes/mountPath
+      value: kubernetes/nerc-ocp-test


### PR DESCRIPTION
Remove the vault auth mountPath for nerc-ocp-prod from the secretstore component.
This will result in an invalid configuration unless the value is changed in
an overlay.

Closes ocp-on-nerc/operations#130
