### PR TITLE
Add rhods bundle to nerc-ocp-prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - ../../bundles/amq-broker-rhel8-operator
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/amq-streams-operator
+- ../../bundles/rhods-operator
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops


### PR DESCRIPTION
This just installs the rhods operator subscription in nerc-ocp-prod