### PR TITLE
update: Point rhods og to correct namespace

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-storage
+namespace: redhat-ods-operator
 resources:
 - operatorgroup.yaml


### PR DESCRIPTION
The rhods operatorGroup was being deployed in the openshift-storage namespace via the kustomization.yaml This PR updates the target namespace to redhat-ods-operator