### PR TITLE
add pipelines and ODS operators to nerc-ocp-prod

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/operatorgroup.yaml
@@ -3,5 +3,3 @@ kind: OperatorGroup
 metadata:
   name: redhat-ods-operator
 spec:
-  targetNamespaces:
-    - redhat-ods-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: openshift-pipelines-operator-rh
 spec:
-  channel: stable
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
@@ -9,4 +9,3 @@ spec:
   name: rhods-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhods-operator.1.23.0

--- a/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: openshift-pipelines-operator
+resources:
+- ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator

--- a/cluster-scope/bundles/rhods-operator/kustomization.yaml
+++ b/cluster-scope/bundles/rhods-operator/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 commonLabels:
   nerc.mghpcc.org/bundle: rhods-operator
 resources:
-- ../../base/core/namespaces/redhat-ods-operator
-- ../../base/operators.coreos.com/operatorgroups/redhat-ods-operator
-- ../../base/operators.coreos.com/subscriptions/redhat-ods-operator
+  - ../../base/core/namespaces/redhat-ods-operator
+  - ../../base/operators.coreos.com/operatorgroups/redhat-ods-operator
+  - ../../base/operators.coreos.com/subscriptions/redhat-ods-operator

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - ../../bundles/amq-broker-rhel8-operator
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/amq-streams-operator
+- ../../bundles/openshift-pipelines-operator
 - ../../bundles/rhods-operator
 - feature/odf
 - feature/custom-routes

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
 - clusterversion.yaml
 - certificates
 - consolelinks
+- odhdashboardconfigs
 
 components:
   - ../../components/argocd-skip-dryrun

--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - odh-dashboard-config.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -1,0 +1,87 @@
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  labels:
+    nerc.mghpcc.org/kustomized: "true"
+  name: odh-dashboard-config
+  namespace: redhat-ods-applications
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableCustomServingRuntimes: false
+    disableISVBadges: false
+    disableInfo: true
+    disableModelServing: false
+    disablePipelines: false
+    disableProjectSharing: false
+    disableProjects: false
+    disableSupport: true
+    disableTracking: false
+    enablement: false
+    modelMetricsNamespace: ""
+  groupsConfig:
+    adminGroups: rhods-admins
+    allowedGroups: system:authenticated
+  modelServerSizes:
+  - name: Small
+    resources:
+      limits:
+        cpu: "2"
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 4Gi
+  - name: Medium
+    resources:
+      limits:
+        cpu: "8"
+        memory: 10Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+  - name: Large
+    resources:
+      limits:
+        cpu: "10"
+        memory: 20Gi
+      requests:
+        cpu: "6"
+        memory: 16Gi
+  notebookController:
+    enabled: false
+    notebookNamespace: nerc-dev-null
+    pvcSize: 20Gi
+  notebookSizes:
+  - name: Small
+    resources:
+      limits:
+        cpu: "2"
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 8Gi
+  - name: Medium
+    resources:
+      limits:
+        cpu: "6"
+        memory: 24Gi
+      requests:
+        cpu: "3"
+        memory: 24Gi
+  - name: Large
+    resources:
+      limits:
+        cpu: "14"
+        memory: 56Gi
+      requests:
+        cpu: "7"
+        memory: 56Gi
+  - name: X Large
+    resources:
+      limits:
+        cpu: "30"
+        memory: 120Gi
+      requests:
+        cpu: "15"
+        memory: 120Gi


### PR DESCRIPTION
This adds the necessary changes and config to enable RHODS on the production cluster in a manner that restricts ODS workloads to coldfront-allocated namespaces.