### PR TITLE
upgrage nerc-ocp-test cluster to OCP v4.11.46

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.11
+  desiredUpdate:
+    version: 4.11.46
+  clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -5,6 +5,7 @@ commonLabels:
 
 resources:
 - apiserver/cluster.yaml
+- clusterversion.yaml
 - ../common
 - ../../bundles/koku-metrics-operator
 - ../../bundles/curator


### PR DESCRIPTION
Addresses issue: https://github.com/nerc-project/operations/issues/158 This commit adds a clusterversion resource to the nerc-ocp-test overlay The version of OCP we're upgrading to was determined by the tool at this link: https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.10&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.10.60&target_ocp_version=4.13.8