### PR TITLE
upgrage nerc-ocp-test cluster to OCP v4.12.28

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.11
+  channel: stable-4.12
   desiredUpdate:
-    version: 4.11.46
+    version: 4.12.28
   clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72


### PR DESCRIPTION
Addresses issue: nerc-project/operations#158
This commit sets up the test cluster to move to the next minor version of OCP The version of OCP we're upgrading to was determined by the tool at this link: https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.10&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.10.60&target_ocp_version=4.13.8