### PR TITLE
Increase argoCD controller memory quota

### DIFF
--- a/openshift-gitops/base/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/base/argocds/openshift-gitops.yaml
@@ -23,10 +23,10 @@ spec:
     resources:
       limits:
         cpu: "2"
-        memory: 2Gi
+        memory: 10Gi
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 5Gi
   dex:
     openShiftOAuth: true
     resources:


### PR DESCRIPTION
The argoCD application controller sts is in OOM crashLoopBackoff. Over time the load on the controller increases, natually as we onboard more applications. This PR bumps the total memory requested by the controller from 1Gi->5Gi & limit from 2Gi->10Gi