### PR TITLE
Allow users to create certificate issuers

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-restricted-runtime-default-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-restricted-runtime-default-scc
+subjects:
+  - kind: ServiceAccount
+    namespace: openshift-operators
+    name: cert-manager
+  - kind: ServiceAccount
+    namespace: openshift-operators
+    name: cert-manager-cainjector
+  - kind: ServiceAccount
+    namespace: openshift-operators
+    name: cert-manager-webhook

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-restricted-runtime-default-scc
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - restricted-runtime-default
+    verbs:
+      - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/securitycontextconstraints.yaml
@@ -1,0 +1,39 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: restricted-runtime-default
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+  - system:authenticated
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+seccompProfiles:
+  - runtime/default

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -5,3 +5,6 @@ commonLabels:
 resources:
 - ../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../base/cert-manager.io/clusterissuers/selfsigned
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/
+- ../../base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/


### PR DESCRIPTION
This adds the necessary RBAC and SCCs to permit a user to deploy cert-manager
issuers and create certificates. We create a custom SCC based on the
existing `restricted` SCC following the directions in [1], and then add the
necessary RBAC to allow the cert-manager serviceaccounts to use the new
SCC.

This addresses some of the discussion in nerc-project/operations#215.

[1]: https://cert-manager.io/docs/release-notes/release-notes-1.10/
