### PR TITLE
add operators for nvidia gpus

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - certificates
 - consolelinks
 - odhdashboardconfigs
+- nodefeaturediscoveries
 
 components:
   - ../../components/argocd-skip-dryrun

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 - ../../bundles/amq-streams-operator
 - ../../bundles/openshift-pipelines-operator
 - ../../bundles/rhods-operator
+- ../../bundles/node-feature-discovery
+- ../../bundles/nvidia-gpu-operator
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops

--- a/cluster-scope/overlays/nerc-ocp-prod/nodefeaturediscoveries/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/nodefeaturediscoveries/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfd-instance.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/nodefeaturediscoveries/nfd-instance.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/nodefeaturediscoveries/nfd-instance.yaml
@@ -1,0 +1,60 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  customConfig:
+    configData: ""
+  instance: ""
+  operand:
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
+    imagePullPolicy: Always
+    servicePort: 0
+  topologyupdater: false
+  workerConfig:
+    configData: |
+      core:
+        sleepInterval: 60s
+      sources:
+        cpu:
+          cpuid:
+      #     NOTE: whitelist has priority over blacklist
+            attributeBlacklist:
+              - "BMI1"
+              - "BMI2"
+              - "CLMUL"
+              - "CMOV"
+              - "CX16"
+              - "ERMS"
+              - "F16C"
+              - "HTT"
+              - "LZCNT"
+              - "MMX"
+              - "MMXEXT"
+              - "NX"
+              - "POPCNT"
+              - "RDRAND"
+              - "RDSEED"
+              - "RDTSCP"
+              - "SGX"
+              - "SSE"
+              - "SSE2"
+              - "SSE3"
+              - "SSE4.1"
+              - "SSE4.2"
+              - "SSSE3"
+            attributeWhitelist:
+        kernel:
+          configOpts:
+            - "NO_HZ"
+            - "X86"
+            - "DMI"
+        pci:
+          deviceClassWhitelist:
+          - "0200"
+          - "0300"
+          - "0302"
+          deviceLabelFields:
+          - "vendor"
+          - "class"


### PR DESCRIPTION
This adds the following bundles to the nerc-ocp-prod overlay:

- node-feature-discovery (used by gpu operator to find GPU nodes)
- nvidia-gpu-operator