### PR TITLE
Increase number of volumes in metrics-bucket-storage backing store

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 12
+    numVolumes: 20
     resources:
       requests:
         storage: 400Gi

--- a/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/metrics-bucket-storage/backingstore.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 24
+    numVolumes: 12
     resources:
       requests:
         storage: 400Gi


### PR DESCRIPTION
This increases the number of volumes in the metrics-bucket-storage
backing store from 12 to 20. This is the maximum number of volumes
we can have in this backing store.

Closes nerc-project/operations#226
See also ocp-on-nerc/nerc-ocp-config#257, nerc-project/operations#151