### PR TITLE
Move dex configuration to .spec.sso.dex

### DIFF
--- a/openshift-gitops/base/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/base/argocds/openshift-gitops.yaml
@@ -27,15 +27,6 @@ spec:
       requests:
         cpu: 250m
         memory: 5Gi
-  dex:
-    openShiftOAuth: true
-    resources:
-      limits:
-        cpu: 500m
-        memory: 256Mi
-      requests:
-        cpu: 250m
-        memory: 128Mi
   grafana:
     enabled: false
     ingress:
@@ -114,3 +105,13 @@ spec:
       enabled: true
     service:
       type: ""
+  sso:
+    dex:
+      openShiftOAuth: true
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi

--- a/openshift-gitops/base/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/base/argocds/openshift-gitops.yaml
@@ -105,11 +105,11 @@ spec:
       enabled: false
     resources:
       limits:
-        cpu: 500m
-        memory: 256Mi
+        cpu: 1000m
+        memory: 1Gi
       requests:
-        cpu: 125m
-        memory: 128Mi
+        cpu: 500m
+        memory: 512Mi
     route:
       enabled: true
     service:


### PR DESCRIPTION
The gitops operator was complaining about our argocd manifest:

    Illegal expression of SSO configuration detetected for Argo CD
    openshift-gitops in namespace openshift-gitops. cannot specify
    .spec.Dex fields when dex is configured through .spec.sso.dex

This commit moves the Dex configuration from .spec.dex to .spec.sso.dex to
try to resolve the error.