### PR TITLE
Explicitly enable Dex

### DIFF
--- a/openshift-gitops/base/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/base/argocds/openshift-gitops.yaml
@@ -106,6 +106,7 @@ spec:
     service:
       type: ""
   sso:
+    provider: dex
     dex:
       openShiftOAuth: true
       resources:


### PR DESCRIPTION
Along with the changes to the ArgoCD manifest in 35dc803668, it is now also
necessary to explicitly enable Dex follow the procedure in [1].

[1]: https://docs.openshift.com/container-platform/4.10/cicd/gitops/configuring-sso-on-argo-cd-using-dex.html#gitops-disable-dex-using-spec-sso_configuring-sso-for-argo-cd-using-dex
