### PR TITLE
Add Red Hat OpenShift distributed tracing data collection operator to NERC Prod

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-opentelemetry-operator
+  namespace: openshift-opentelemetry-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-product/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-product/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-product/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/opentelemetry-product/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: openshift-serverless-operator
+resources:
+- ../../base/core/namespaces/openshift-opentelemetry-operator
+- ../../base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator
+- ../../base/operators.coreos.com/subscriptions/opentelemetry-product

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/amq-streams-operator
 - ../../bundles/openshift-pipelines-operator
+- ../../bundles/openshift-opentelemetry-operator
 - ../../bundles/rhods-operator
 - feature/odf
 - feature/custom-routes


### PR DESCRIPTION
The Red Hat OpenShift distributed tracing data collection operator will allow the Smart Village project, as well as other projects to produce metrics and traces for understanding the performance of our applications. @syedmohdqasim is also interested in using distributed tracing data. 