### PR TITLE
Fix a misspelling of labels in the CustomNodeLowAvailableMemory alert

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -174,7 +174,7 @@ data:
 
         - alert: CustomNodeLowAvailableMemory
           annotations:
-            summary: "{{ $labels.cluster}} node {{$lables.instance }} low on memory"
+            summary: "{{ $labels.cluster}} node {{$labels.instance }} low on memory"
             description: |
               <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22node_memory_MemAvailable_bytes%2Fnode_memory_MemTotal_bytes%20%3C%200.2%22%7D%5D|Click here to see these metrics in Observability Monitoring>
               {{ $labels.cluster}} node {{$labels.instance}} is low on memory.


### PR DESCRIPTION
There is a typo where "$lables" should be "$labels".