### PR TITLE
prod: upgrade cluster to version 4.12.33

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.11
+  channel: stable-4.12
   desiredUpdate:
-    version: 4.11.49
+    version: 4.12.33
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982

--- a/cluster-scope/overlays/nerc-ocp-prod/configmaps/admin-acks.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/configmaps/admin-acks.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  ack-4.11-kube-1.25-api-removals-in-4.12: "true"
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: Record administrator acknowledgments of update gates
+      defined in the admin-gates ConfigMap in the openshift-config-managed namespace.
+    release.openshift.io/create-only: "true"
+  name: admin-acks
+  namespace: openshift-config

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
 - machineconfigs/udev-rules
 - machineconfigs/configure-bond0
 - nodenetworkconfigurationpolicies
+- configmaps/admin-acks.yaml
 - clusterversion.yaml
 - certificates
 - consolelinks


### PR DESCRIPTION
This is part of an upgrade to the latest stable 4.13.13 version. This is the second recommended step according to the following tool:

https://access.redhat.com/labs/ocpupgradegraph/update_path

Using parameters:
  - channel=stable-4.10
  - arch=x86_64
  - is_show_hot_fix=false
  - current_ocp_version=4.10.60
  - target_ocp_version=4.13.13