### PR TITLE
prod: upgrade cluster to version 4.13.13

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.12
+  channel: stable-4.13
   desiredUpdate:
-    version: 4.12.33
+    version: 4.13.13
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982

--- a/cluster-scope/overlays/nerc-ocp-prod/configmaps/admin-acks.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/configmaps/admin-acks.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 data:
   ack-4.11-kube-1.25-api-removals-in-4.12: "true"
+  ack-4.12-kube-1.26-api-removals-in-4.13: "true"
 metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"


### PR DESCRIPTION
This is the final recommended step for upgrading to the latest 4.13.13 verison according to the following tool:

https://access.redhat.com/labs/ocpupgradegraph/update_path

Using parameters:
  - channel=stable-4.10
  - arch=x86_64
  - is_show_hot_fix=false
  - current_ocp_version=4.10.60
  - target_ocp_version=4.13.13