### PR TITLE
Add allow-edit-rbac role

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-edit-rbac
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - "rbac.authorization.k8s.io/v1"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - update
+      - patch
+      - get
+      - watch
+      - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
 - ../../bundles/rhods-operator
 - ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../../bundles/rhods-operator
 - ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops


### PR DESCRIPTION
This roles aggregates [1] to the "edit" role so that members of
ColdFront-managed projects will be able to create Role and RoleBinding
resources.

[1]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

Closes: nerc-project/operations#128
