### PR TITLE
odf: upgrade to latest stable-4.12 version

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.11
+    channel: stable-4.12
     installPlanApproval: Automatic
     name: odf-operator
     source: redhat-operators


### PR DESCRIPTION
This is needed in order to upgrade past OpenShift cluster version 4.12:

```
Cluster operator operator-lifecycle-manager should not be upgraded between minor versions: ClusterServiceVersions 
blocking cluster upgrade: openshift-storage/odf-operator.v4.11.10 is incompatible with OpenShift minor versions greater 
than 4.12
```