### PR TITLE
switch GPU operator to stable channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
@@ -3,9 +3,8 @@ kind: Subscription
 metadata:
   name: gpu-operator-certified
 spec:
-  channel: "v23.3"
-  installPlanApproval: Manual
+  channel: stable
+  installPlanApproval: Automatic
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "gpu-operator-certified.v23.3.2"


### PR DESCRIPTION
This will update clusters with the GPU operator to the latest stable version (v23.6.1 at the time of writing). Also switched to Automatic upgrade stategy for this channel.