### PR TITLE
odf: upgrade to latest stable-4.13 version

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.12
+    channel: stable-4.13
     installPlanApproval: Automatic
     name: odf-operator
     source: redhat-operators


### PR DESCRIPTION
This is the latest stable version and also will likely be needed in order to upgrade past OpenShift cluster version 4.13 in the future.