### PR TITLE
update aap sub to use 2.4 channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/ansible-automation-platform-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/ansible-automation-platform-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ansible-automation-platform-operator
   namespace: aap
 spec:
-  channel: stable-2.3-cluster-scoped
+  channel: stable-2.4-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators


### PR DESCRIPTION
The stable-2.3-cluster-scoped channel is no longer available after upgrading to 4.13.13