### PR TITLE
Correct typo in allow-edit-rbac: apiGroups should not include version

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
-      - "rbac.authorization.k8s.io/v1"
+      - "rbac.authorization.k8s.io"
     resources:
       - roles
       - rolebindings


### PR DESCRIPTION
This corrects a typo introduced in #290, instead of:

    - apiGroups:
        - "rbac.authorization.k8s.io/v1"

We should have:

    - apiGroups:
        - "rbac.authorization.k8s.io"
