### PR TITLE
infra: upgrade cluster to version 4.11.49

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -3,5 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.10
+  channel: stable-4.11
+  desiredUpdate:
+    version: 4.11.49
   clusterID: b3c6e302-f119-4adb-bc48-e04c6aa2eaa5


### PR DESCRIPTION
This is part of an upgrade to the latest stable 4.13.13 version. This is the first recommended step according to the following tool:

https://access.redhat.com/labs/ocpupgradegraph/update_path

Using parameters:
  - channel=stable-4.10
  - arch=x86_64
  - is_show_hot_fix=false
  - current_ocp_version=4.10.60
  - target_ocp_version=4.13.13