### PR TITLE
Increase the Postgres DB storage for NooBaa

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
 - metrics-bucket-storage
 - redhatcop.redhat.io/odf-node-patcher.yaml
 - grafana-dashboards
+- persistentvolumeclaims
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - openshift-storage-db-noobaa-db-pg-0.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/openshift-storage-db-noobaa-db-pg-0.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/openshift-storage-db-noobaa-db-pg-0.yaml
@@ -1,0 +1,16 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: db-noobaa-db-pg-0
+  namespace: openshift-storage
+  labels:
+    app: noobaa
+    noobaa-db: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: ocs-external-storagecluster-ceph-rbd
+  volumeMode: Filesystem


### PR DESCRIPTION
The noobaa-db-pg-0 pod in the openshift-storage namespace has run out of 100Gi storage. The recommended fix for this from Red Hat [1] is to scale down NooBaa pods and resize the PVC. Here we increase the NooBaa DB storage to 200Gi.

[1] https://access.redhat.com/solutions/6976547