### PR TITLE
Add delete verb to allow-edit-rbac role

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
       - rolebindings
     verbs:
       - create
+      - delete
       - update
       - patch
       - get


### PR DESCRIPTION
Adds missing `delete` verb to role introduced in #290.

Part-of: nerc-project/operations#128
