### PR TITLE
update ACM to latest 2.8 release channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: acm
 spec:
-    channel: release-2.6
+    channel: release-2.8
     installPlanApproval: Automatic
     name: advanced-cluster-management
     source: redhat-operators


### PR DESCRIPTION
After upgrading to the latest 4.13.13 OpenShift version, the release-2.6 channel for the ACM subscription no longer exists. This updates to the latest release-2.8 channel.