### PR TITLE
prod: upgrade acct-mgt service to latest v0.3.2

### DIFF
--- a/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
+++ b/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
         - name: acct-mgt
-          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.2.0"
+          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.2"


### PR DESCRIPTION
This is needed to pull in NERC project labels and also new support for arbitrary namespace labels set from coldfront.