### PR TITLE
Disable automatic operator updates on rhods subscriptions

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: redhat-ods-operator
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: rhods-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This change disables automatic updates to the rhods operator I've changed the base subscription resource here to make this effective anywhere the operator bundle is deployed since we want to have a stable consistent production and test cluster deployment and have full control over operator updates