### PR TITLE
Allow role based access control to Loki logs

### DIFF
--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - clusterloggings
   - clusterlogforwarders
   - externalsecrets
+  - rolebindings
 commonLabels:
   app.kubernetes.io/name: logging
   app.kubernetes.io/component: logging

--- a/logging/base/rolebindings/kustomization.yaml
+++ b/logging/base/rolebindings/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding.yaml

--- a/logging/base/rolebindings/rolebinding.yaml
+++ b/logging/base/rolebindings/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: log-collector-privileged-binding-nerc-logs-metrics
+  namespace: openshift-logging
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: nerc-logs-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: log-collector-privileged


### PR DESCRIPTION
Allows users to access application, audit, and infrastructure logs can
be accomplished by creating the this  RoleBinding in the
openshift-logging namespace to grant the nerc-logs-metrics Group to the
log-collector-privileged Role.

closes https://github.com/nerc-project/operations/issues/124