### PR TITLE
Set per stream rate limit and burst in LOKI

### DIFF
--- a/loki/base/lokistacks/lokistack.yaml
+++ b/loki/base/lokistacks/lokistack.yaml
@@ -9,6 +9,8 @@ spec:
       ingestion:
         ingestionBurstSize: 10
         ingestionRate: 10
+        perStreamRateLimit: 10
+        perStreamRateLimitBurst: 20
       retention:
         days: 90
     tenants:


### PR DESCRIPTION
Sets perStreamRateLimit to 10 MB and perStreamRateBurst to 20 MB in LokiStack template as the default values for those parameters were not sufficient and resulted in rate limit exceeds issue for prod logs when the number of nodes increased.

Closes nerc-project/operations#121