### PR TITLE
ACM: add nerc-ocp-test managedcluster

### DIFF
--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/klusterletaddonconfig.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/klusterletaddonconfig.yaml
@@ -1,0 +1,23 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: nerc-ocp-test
+  namespace: nerc-ocp-test
+spec:
+  clusterName: nerc-ocp-test
+  clusterNamespace: nerc-ocp-test
+  clusterLabels:
+    name: nerc-ocp-test
+    cloud: auto-detect
+    vendor: auto-detect
+    cluster.open-cluster-management.io/clusterset: default
+  applicationManager:
+    enabled: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - nerc-ocp-prod
-  - nerc-ocp-test
+- klusterletaddonconfig.yaml
+- managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/managedcluster.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/managedcluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: nerc-ocp-test
+  labels:
+    name: nerc-ocp-test
+    cloud: BareMetal
+    vendor: OpenShift
+    cluster.open-cluster-management.io/clusterset: argocd-managed
+  annotations: {}
+spec:
+  hubAcceptsClient: true


### PR DESCRIPTION
We noticed this cluster wasn't defined in the repo while working on the following ACM issue:

https://github.com/nerc-project/operations/issues/262