### PR TITLE
Fix metallb operatorgroup install mode

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb-system/operatorgroup.yaml
@@ -2,6 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: metallb-system
-spec:
-  targetNamespaces:
-  - metallb-system
+spec: {}


### PR DESCRIPTION
Since 381d089a, it looks like the metallb operator now *requires* the AllNamespaces install mode. From the packagemanifest:

      installModes:
      - supported: false
        type: OwnNamespace
      - supported: false
        type: SingleNamespace
      - supported: false
        type: MultiNamespace
      - supported: true
        type: AllNamespaces
