### PR TITLE
Patch vault path for route53 key in each overlay

### DIFF
--- a/cluster-scope/components/nerc-certificate-issuer/aws-route53-credentials.yaml
+++ b/cluster-scope/components/nerc-certificate-issuer/aws-route53-credentials.yaml
@@ -18,4 +18,4 @@ spec:
         labels: {}
   dataFrom:
     - extract:
-        key: nerc/nerc-ocp-prod/aws-route53-credentials
+        key: REPLACE_IN_OVERLAY

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -93,6 +93,13 @@ patches:
       value: nerc/nerc-ocp-prod/openshift-config/oauths-clientsecret-nerc
 - target:
     kind: ExternalSecret
+    name: aws-route53-credentials
+  patch: |
+    - op: replace
+      path: /spec/dataFrom/0/extract/key
+      value: nerc/nerc-ocp-prod/aws-route53-credentials
+- target:
+    kind: ExternalSecret
     name: github-client-secret
   patch: |
     - op: replace


### PR DESCRIPTION
While we have a "nerc-certificate-issuer" component, it was only used on
nerc-ocp-prod. In order to use this on other clusters, we'll need to patch
the ExternalSecret resource with a new key path.

This commit implements that behavior for nerc-ocp-prod to keep things
consistent as we add new clusters.
