### PR TITLE
Add empty overlay for nerc-ocp-obs cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"


### PR DESCRIPTION
This will allow us to get the ArgoCD app configured.
