### PR TITLE
nfd: s/topologyupdater/topologyUpdater/g

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -11,7 +11,7 @@ spec:
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
     imagePullPolicy: Always
     servicePort: 0
-  topologyupdater: false
+  topologyUpdater: false
   workerConfig:
     configData: |
       core:


### PR DESCRIPTION
This applied initially but is now causing sync failures in argocd given that the spec has changed after an automatic update of the NFD operator to 4.13.x