### PR TITLE
nfd: /spec.customConfig/d

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nfd-instance
   namespace: openshift-nfd
 spec:
-  customConfig:
-    configData: ""
   instance: ""
   operand:
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11


### PR DESCRIPTION
This applied initially but is now causing sync failures in argocd given that the spec has changed after an automatic update of the NFD operator to 4.13.x. This field no longer exists.