### PR TITLE
Fix openapi schema handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: check-added-large-files
+        exclude: '^cluster-scope/base/openapi/openshift-api-schema.json$'
       - id: check-case-conflict
       - id: check-json
       - id: check-symlinks

--- a/cluster-scope/base/openapi/kustomization.yaml
+++ b/cluster-scope/base/openapi/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 openapi:
-  path: https://github.com/nerc-project/openshift-schemas/raw/main/openshift-api-schema.json
+  path: openshift-api-schema.json


### PR DESCRIPTION
So #314 was totally broken; Kustomize can't import an openapi schema
from a URL (which is annoying), so this includes the schema directly
in the repository. Sorry for the noise!
