### PR TITLE
Add missing jaeger and tempo operators for OpenTelemetry

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-distributed-tracing/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-distributed-tracing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-distributed-tracing/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-distributed-tracing/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-distributed-tracing
+spec: {}

--- a/cluster-scope/base/core/namespaces/openshift-tempo-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-tempo-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-tempo-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-tempo-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-distributed-tracing
+  namespace: openshift-distributed-tracing
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-tempo-operator
+  namespace: openshift-tempo-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-product/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-product/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-product/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-product/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-distributed-tracing
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/tempo-product/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/tempo-product/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/tempo-product/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/tempo-product/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,8 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
-  nerc.mghpcc.org/bundle: openshift-serverless-operator
+  nerc.mghpcc.org/bundle: openshift-opentelemetry-operator
 resources:
 - ../../base/core/namespaces/openshift-opentelemetry-operator
+- ../../base/core/namespaces/openshift-distributed-tracing
+- ../../base/core/namespaces/openshift-tempo-operator
 - ../../base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator
+- ../../base/operators.coreos.com/operatorgroups/openshift-distributed-tracing
+- ../../base/operators.coreos.com/operatorgroups/openshift-tempo-operator
 - ../../base/operators.coreos.com/subscriptions/opentelemetry-product
+- ../../base/operators.coreos.com/subscriptions/jaeger-product
+- ../../base/operators.coreos.com/subscriptions/tempo-product


### PR DESCRIPTION
The Red Hat OpenShift distributed tracing data collection operator, which was already installed in NERC prod cluster in this [PR](https://github.com/OCP-on-NERC/nerc-ocp-config/pull/282), was missing two required components for distributed tracing. See the [Red Hat documentation](https://docs.openshift.com/container-platform/4.13/distr_tracing/distr_tracing_arch/distr-tracing-architecture.html#distr-tracing-product-overview_distributed-tracing-architecture) for more details on the other 2 required operators:

- Red Hat OpenShift distributed tracing platform (Jaeger)
- Red Hat OpenShift distributed tracing platform (Tempo)
