### PR TITLE
use latest v0.3.4 of openshift-acct-mgt image

### DIFF
--- a/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
+++ b/acct-mgt/overlays/nerc-ocp-prod/patches/deployment_patch.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
         - name: acct-mgt
-          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.3"
+          image: "ghcr.io/cci-moc/openshift-acct-mgt:v0.3.4"


### PR DESCRIPTION
Mostly just pulls in default limits and quotas for GPUs:

https://github.com/CCI-MOC/openshift-acct-mgt/releases/tag/v0.3.4