### PR TITLE
Standardize our handling of custom certificates

### DIFF
--- a/cluster-scope/base/config.openshift.io/apiservers/cluster/apiserver.yaml
+++ b/cluster-scope/base/config.openshift.io/apiservers/cluster/apiserver.yaml
@@ -6,9 +6,3 @@ metadata:
 spec:
   audit:
     profile: Default
-  servingCerts:
-    namedCertificates:
-      - names:
-          - UPDATE_IN_OVERLAY
-        servingCertificate:
-          name: default-api-certificate

--- a/cluster-scope/components/custom-certificates/kustomization.yaml
+++ b/cluster-scope/components/custom-certificates/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ../../base/operator.openshift.io/ingresscontrollers/default
+- ../../base/config.openshift.io/apiservers/cluster
+
+patches:
+- path: patches/custom_ingress_certificate.yaml
+- path: patches/custom_apiserver_certificate.yaml

--- a/cluster-scope/components/custom-certificates/patches/custom_apiserver_certificate.yaml
+++ b/cluster-scope/components/custom-certificates/patches/custom_apiserver_certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  namespace: openshift-config
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+          - UPDATE_IN_OVERLAY
+        servingCertificate:
+          name: default-api-certificate

--- a/cluster-scope/components/custom-certificates/patches/custom_ingress_certificate.yaml
+++ b/cluster-scope/components/custom-certificates/patches/custom_ingress_certificate.yaml
@@ -4,5 +4,7 @@ metadata:
   name: default
   namespace: openshift-ingress-operator
 spec:
+  httpEmptyRequestsPolicy: Respond
+  replicas: 2
   defaultCertificate:
     name: default-ingress-certificate

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -16,12 +16,13 @@ resources:
 - ../../bundles/image-registry
 - ../../bundles/logging
 - ../../bundles/group-sync-operator
-- ../../base/operator.openshift.io/ingresscontrollers/default
 - ../../base/operator.openshift.io/networks/cluster
-- ../../base/config.openshift.io/apiservers/cluster
 - clusterrolebindings/nerc-ops-cluster-reader.yaml
 - clusterrolebindings/nerc-ops-sudoers.yaml
 - clusterrolebindings/nerc-ops-portforward.yaml
 - clusterrolebindings/nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
 - groupsyncs
 - machineconfigs
+
+components:
+- ../../components/custom-certificates

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -47,7 +47,6 @@ patches:
 - path: consoles.operator.openshift.io/cluster_patch.yaml
 - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
 - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
-- path: ingresscontrollers/default_patch.yaml
 - path: machineconfigs/hostpath-provisioner-selinux_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-thanos-object-storage_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/ingresscontrollers/default_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/ingresscontrollers/default_patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  defaultCertificate:
-    name: default-ingress-certificate

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -55,7 +55,6 @@ configMapGenerator:
   namespace: openshift-monitoring
 
 patches:
-- path: ingresscontrollers/default_patch.yaml
 - path: kubeletconfigs/system-reserved-patch.yaml
 - target:
     kind: SecretStore


### PR DESCRIPTION
We were handling custom ingress and apiserver certificates in different ways, and we were also applying identical patches in multiple overlays.

This commit re-organizes custom API and Ingress certificates into a single "custom-certificates" component, and arranges to include that in our common overlay.

Part-of: nerc-project/operations#285