### PR TITLE
Ensure that we deploy a MetalLB resource

### DIFF
--- a/cluster-scope/base/metallb.io/metallbs/metallb/kustomization.yaml
+++ b/cluster-scope/base/metallb.io/metallbs/metallb/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - metallb.yaml

--- a/cluster-scope/base/metallb.io/metallbs/metallb/metallb.yaml
+++ b/cluster-scope/base/metallb.io/metallbs/metallb/metallb.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - ../../base/core/namespaces/metallb-system
 - ../../base/operators.coreos.com/subscriptions/metallb-operator
 - ../../base/operators.coreos.com/operatorgroups/metallb-system
+- ../../base/metallb.io/metallbs/metallb


### PR DESCRIPTION
After installing the MetalLB operator, we must create a "MetalLB" resource instance. See [1] for documentation.

[1]: https://docs.openshift.com/container-platform/4.14/networking/metallb/about-metallb.html