### PR TITLE
Remove deprecated syntax

### DIFF
--- a/acct-mgt/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/acct-mgt/overlays/nerc-ocp-prod/kustomization.yaml
@@ -4,6 +4,6 @@ namespace: acct-mgt
 resources:
   - ../../base
   - externalsecret.yaml
-patchesStrategicMerge:
-  - patches/configmap_patch.yaml
-  - patches/deployment_patch.yaml
+patches:
+  - path: patches/configmap_patch.yaml
+  - path: patches/deployment_patch.yaml

--- a/dex/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-infra/kustomization.yaml
@@ -4,5 +4,5 @@ namespace: dex
 resources:
   - ../../base
   - configmaps
-patchesStrategicMerge:
-  - externalsecrets/dex-clients_patch.yaml
+patches:
+  - path: externalsecrets/dex-clients_patch.yaml

--- a/logging/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-infra/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 resources:
 - ../../base
 
-patchesStrategicMerge:
-  - externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+patches:
+  - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml

--- a/logging/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-prod/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
 - ../../base
 
-patchesStrategicMerge:
-  - externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
-  - clusterlogforwarders/instance_patch.yaml
+patches:
+  - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+  - path: clusterlogforwarders/instance_patch.yaml

--- a/loki/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/loki/overlays/nerc-ocp-infra/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 resources:
 - ../../base
 
-patchesStrategicMerge:
-  - externalsecrets/loki-thanos-object-storage_patch.yaml
+patches:
+  - path: externalsecrets/loki-thanos-object-storage_patch.yaml


### PR DESCRIPTION
The `patchesStrategicMerge` keyword has been deprecated for a while [1]; we
should be using the `patches` keyword for both strategic merge and
JSONPatch patches.

[1]: https://github.com/kubernetes-sigs/kustomize/issues/5052
