### PR TITLE
Add fine-grained access to LOKI logs

### DIFF
--- a/logging/base/rolebindings/rolebinding.yaml
+++ b/logging/base/rolebindings/rolebinding.yaml
@@ -1,13 +1,44 @@
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: log-collector-privileged-binding-nerc-logs-metrics
+  name: logging-application-view-binding-nerc-logs-metrics
   namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: nerc-logs-metrics
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: logging-infrastructure-view-binding-nerc-logs-metrics
+  namespace: openshift-logging
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: log-collector-privileged
+  kind: ClusterRole
+  name: cluster-logging-infrastructure-view
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: nerc-logs-metrics
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: logging-audit-view-binding-nerc-logs-metrics
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-audit-view
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: nerc-logs-metrics


### PR DESCRIPTION
Allows users to access application, audit and infrastructure logs
by creating 3 RoleBinding in the openshift-logging namespace to
grant the nerc-logs-metrics Group to the already existing roles
available in logging 5.8

Closes https://github.com/nerc-project/operations/issues/124