### PR TITLE
Enable rhods notebook controller in rhods-notebooks namespace

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -49,8 +49,8 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: false
-    notebookNamespace: nerc-dev-null
+    enabled: true
+    notebookNamespace: rhods-notebooks
     pvcSize: 20Gi
   notebookSizes:
   - name: X Small


### PR DESCRIPTION
This will re-enable the default functionality of the rhods notebook controller in the prod cluster. As a side effect of enabling, the ability to launch a notebook from the jupyter tile will be restored 
Addresses: https://github.com/nerc-project/operations/issues/361