### PR TITLE
Reduce default notebook PVC size in rhods-notebooks namespace

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -51,7 +51,7 @@ spec:
   notebookController:
     enabled: true
     notebookNamespace: rhods-notebooks
-    pvcSize: 20Gi
+    pvcSize: 1Gi
   notebookSizes:
   - name: X Small
     resources:


### PR DESCRIPTION
This will change the size of PVC attached to notebooks in rhods-notebooks that are created in rhods with the jupyter tile