### PR TITLE
Add ope-course-quota resourceQuota to cluster-scope components

### DIFF
--- a/cluster-scope/components/resourcequotas/ope-course-quota/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+- resourcequota.yaml

--- a/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
@@ -1,0 +1,12 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: ope-course-quota
+  namespace: rhods-notebooks
+spec:
+  hard:
+    limits.cpu: '1000'
+    limits.ephemeral-storage: 30Gi
+    limits.memory: 3000000Mi
+    persistentvolumeclaims: '400'
+    requests.storage: 400Gi

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
 components:
   - ../../components/nerc-oauth-keycloak
   - ../../components/nerc-oauth-github
+  - ../../components/resourcequotas/ope-course-quota
 
   # this must come last in order to apply
   # to all resources.


### PR DESCRIPTION
Closes: [https://github.com/nerc-project/operations/issues/377](https://github.com/nerc-project/operations/issues/377)

Adding this resourceQuota as a component at the cluster scope and adding it to the rhods-notebooks namespace in the prod cluster. The quota values themselves were determined based on our resourceQuota in the namespace where we did scale testing, with a bump to accomodate all the expected students