### PR TITLE
nerc-ocp-obs: set mountPath on all secretstores

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -33,6 +33,12 @@ configMapGenerator:
   namespace: openshift-monitoring
 
 patches:
+- target:
+    kind: SecretStore
+  patch: |
+    - op: replace
+      path: /spec/provider/vault/auth/kubernetes/mountPath
+      value: kubernetes/nerc-ocp-obs
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth


### PR DESCRIPTION
Without a correct mountPath set the secretstores will fail to sync secrets. This sets the mountPath to restrict secret fetching to the `nerc/nerc-ocp-obs` namespace/path in vault.

closes nerc-project/operations#381