### PR TITLE
Increase resourceQuota in rhods-notebooks namespace

### DIFF
--- a/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
@@ -8,5 +8,5 @@ spec:
     limits.cpu: '1000'
     limits.ephemeral-storage: 30Gi
     limits.memory: 3000000Mi
-    persistentvolumeclaims: '400'
-    requests.storage: 400Gi
+    persistentvolumeclaims: '600'
+    requests.storage: 600Gi


### PR DESCRIPTION
Closes: https://github.com/nerc-project/operations/issues/392

This PR expands the resource limist in rhods-notebooks, namely the storage and pvcs For now the other fields look okay (cpu and memory are under 2% usage) though we'll want to keep an eye on these as the workload ramps up