### PR TITLE
Add missing admin-acks

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -23,6 +23,14 @@ resources:
 components:
   - ../../components/nerc-oauth-github
 
+configMapGenerator:
+- name: admin-acks
+  namespace: openshift-config
+  behavior: merge
+  literals:
+    - ack-4.11-kube-1.25-api-removals-in-4.12=true
+    - ack-4.12-kube-1.26-api-removals-in-4.13=true
+
 patches:
 - target:
     kind: SecretStore


### PR DESCRIPTION
The config for nerc-ocp-test appears to have lost some admin-acks values;
these are set in the cluster but not in the repository. This commit makes
the repository match.
