### PR TITLE
Fix erroneous labels on curator deployment

### DIFF
--- a/curator/base/deployments/deployment.yaml
+++ b/curator/base/deployments/deployment.yaml
@@ -4,9 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: curator
-    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: deployment
+    app.kubernetes.io/name: curator
     app.kubernetes.io/part-of: curator
     control-plane: controller-manager
   name: curator-controller-manager


### PR DESCRIPTION
The curator deployment was using labels that are maintained by argocd. This
removes the app.kubernetes.io/instance label and fixes the
app.kubernetes.io/name label.
