### PR TITLE
Rollback changes made in PR #340

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/cs210/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs210/group.yaml
@@ -1,5 +1,0 @@
-apiVersion: user.openshift.io/v1
-kind: Group
-metadata:
-  name: cs210
-users: []

--- a/cluster-scope/base/user.openshift.io/groups/cs210/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs210/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-    - group.yaml

--- a/cluster-scope/base/user.openshift.io/groups/ee440/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/ee440/group.yaml
@@ -1,5 +1,0 @@
-apiVersion: user.openshift.io/v1
-kind: Group
-metadata:
-  name: ee440
-users: []

--- a/cluster-scope/base/user.openshift.io/groups/ee440/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/ee440/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-    - group.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -21,8 +21,6 @@ resources:
 - ../../bundles/nvidia-gpu-operator
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/user.openshift.io/groups/cs210
-- ../../base/user.openshift.io/groups/ee440
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops


### PR DESCRIPTION
https://github.com/OCP-on-NERC/nerc-ocp-config/pull/340/

We will be making manual syncs of students added to their course namespace to these OCP groups. We aren't tracking users in these groups via github so any changes to the group in the live cluster are overwritten by argoCD

We will still be tracking the group manifets themselves albeit in a different ope dedicated repo: https://github.com/OCP-on-NERC/BU-RHOAI