### PR TITLE
Configure test cluster to use loki

### DIFF
--- a/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
@@ -1,0 +1,41 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: loki-app
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/application
+      secret:
+        name: lokistack-gateway-bearer-token
+      loki:
+    - name: loki-infra
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/infrastructure
+      secret:
+        name: lokistack-gateway-bearer-token
+      loki:
+    - name: loki-audit
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/audit
+      secret:
+        name: lokistack-gateway-bearer-token
+      loki:
+  pipelines:
+    - name: send-app-logs
+      inputRefs:
+        - application
+      outputRefs:
+        - loki-app
+    - name: send-infra-logs
+      inputRefs:
+        - infrastructure
+      outputRefs:
+        - loki-infra
+    - name: send-audit-logs
+      inputRefs:
+        - audit
+      outputRefs:
+        - loki-audit

--- a/logging/overlays/nerc-ocp-test/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+++ b/logging/overlays/nerc-ocp-test/externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openshift-logging-lokistack-gateway-bearer-token
+  namespace: openshift-logging
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: nerc-secret-store
+  dataFrom:
+    - extract:
+        # Command to extract the JSON pull secret: oc extract secret/pull-secret -n openshift-config --to=-
+        key: nerc/nerc-ocp-test/lokistack-gateway-bearer-token

--- a/logging/overlays/nerc-ocp-test/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patches:
+  - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+  - path: clusterlogforwarders/instance_patch.yaml


### PR DESCRIPTION
This PR configures the test cluster to use the LOKI installed in the obs cluster

fixes https://github.com/nerc-project/operations/issues/324
Referring to https://github.com/nerc-project/operations/issues/324