### PR TITLE
Add http01 letsencrypt ClusterIssuer to prod and obs cluster

### DIFF
--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/clusterissuer.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/clusterissuer.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production-http01
+spec:
+  acme:
+    privateKeySecretRef:
+      name: letsencrypt-production-http01
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - http01:
+          ingress:
+            class: openshift-default

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterissuer.yaml

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/clusterissuer.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/clusterissuer.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging-http01
+spec:
+  acme:
+    privateKeySecretRef:
+      name: letsencrypt-staging-http01
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+      - http01:
+          ingress:
+            class: openshift-default

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterissuer.yaml

--- a/cluster-scope/bundles/clusterissuer-http01/kustomization.yaml
+++ b/cluster-scope/bundles/clusterissuer-http01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/cert-manager.io/clusterissuers/letsencrypt-staging-http01
+- ../../base/cert-manager.io/clusterissuers/letsencrypt-production-http01

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - ../common
 - ../../bundles/node-feature-discovery
+- ../../bundles/clusterissuer-http01
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - clusterversion.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
+- ../../bundles/clusterissuer-http01
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - feature/odf
 - feature/custom-routes


### PR DESCRIPTION
A LetsEncrypt ClusterIssuer with an http01 solver is useful for
acquiring non-wildcard certificates for arbitrary domain names without
requiring any DNS credentials. We still plan on relying on the wildcard
default ingress certificate for most common use cases.

Closes nerc-project/operations#413
