### PR TITLE
obs cluster default-api-certificate to use http01 issuer

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/certificates/default-api-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/certificates/default-api-certificate.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-config
 spec:
   issuerRef:
-    name: letsencrypt-production-dns01
+    name: letsencrypt-production-http01
     kind: Issuer
   secretName: default-api-certificate
   duration: 2160h0m0s


### PR DESCRIPTION
We set the default API certificate in the obs cluster to use an http01 letsencrypt issuer without requiring any DNS credentials.