### PR TITLE
Correct issuer reference for obs default-api-certificate

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/certificates/default-api-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/certificates/default-api-certificate.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-production-http01
-    kind: Issuer
+    kind: ClusterIssuer
   secretName: default-api-certificate
   duration: 2160h0m0s
   renewBefore: 360h0m0s


### PR DESCRIPTION
The default-api-certificate manifest had:

    spec:
      issuerRef:
        name: letsencrypt-production-http01
        kind: Issuer

But we are using a ClusterIssuer, so we need:

    spec:
      issuerRef:
        name: letsencrypt-production-http01
        kind: ClusterIssuer
