### PR TITLE
Update obs namedCertificate to api.obs.nerc.mghpcc.org

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -81,7 +81,7 @@ patches:
   patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.nerc-ocp-obs.rc.fas.harvard.edu
+      value: api.obs.nerc.mghpcc.org
 - target:
     kind: ClusterIssuer
     name: letsencrypt-.*-dns01


### PR DESCRIPTION
The namedCertificate was pointing to a domain that doesn't exist
api.nerc-ocp-obs.rc.fas.harvard.edu