### PR TITLE
Patch server name in ClusterSecretStore

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -105,4 +105,5 @@ patches:
         vault:
           auth:
             kubernetes:
-              mountPath: kubernetes/nerc-ocp-obs/
+              mountPath: kubernetes/nerc-ocp-obs
+          server: https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/


### PR DESCRIPTION
The ClusterSecretStore was originally created for the infra cluster, where
we access the vault via its in-cluster address. We need to modify that when
using the manifest on other clusters.

Probably we should swap our logic at some point in the future (that is,
default to using the externally visible name), but right now it's the same
amount of work either way.
