### PR TITLE
Fake metrics endpoint to make ODF happy in obs cluster

### DIFF
--- a/fake-metrics-server/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+resources:
+- ../nerc-ocp-infra


### PR DESCRIPTION
While the "monitoring-endpoint" configuration in OCS 4.8 was optional,
it appears to be required in 4.10, and ODF refuses to deploy if it
can't reach the endpoint.

This commit provides a fake metrics endpoint to make the ODF operator
happy.
