### PR TITLE
Configure vlan 2177 interface on obs cluster for access to NESE storage

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - feature/odf
 - certificates
 - machineconfigs
+- nodenetworkconfigurationpolicies
 
 components:
   - ../../components/nerc-oauth-github

--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- vlan-2177-nese.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
@@ -1,0 +1,20 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-2177-nese
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker:
+  desiredState:
+    interfaces:
+    - name: bond0.2177
+      type: vlan
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: true
+        auto-routes: true
+      vlan:
+        base-iface: bond0
+        id: 2177
+      mtu: 9000


### PR DESCRIPTION
This provides the obs cluster with access to the NESE ceph service.

Part-of: https://github.com/nerc-project/operations/issues/432