### PR TITLE
Set empty node-role.kubernetes.io/worker for obs

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vlan-2177-nese
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker:
+    node-role.kubernetes.io/worker: ""
   desiredState:
     interfaces:
     - name: bond0.2177


### PR DESCRIPTION
The nil value in node-role.kubernetes.io/worker on the obs cluster is
causing an error in argocd: unknown object type "nil"
