### PR TITLE
Upgrade loki-operator to 5.7 on obs, leave logging operator for now

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -110,3 +110,10 @@ patches:
             kubernetes:
               mountPath: kubernetes/nerc-ocp-obs
           server: https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/
+- target:
+    kind: Subscription
+    name: loki-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-5.7


### PR DESCRIPTION
Changing this PR to just focus on the obs loki-operator as the beginning of some follow up PRs to update step by step.


old idea:
```
The Loki Operator Subscription on the obs cluster is unable to install
because of an error: constraints not satisfiable: no operators found in
channel stable-5.6 of package loki-operator in the catalog referenced by
subscription loki-operator, subscription loki-operator exists.

We will upgrade Loki on the infra cluster and obs cluster because
version 5.6 is no longer supported.
```
