### PR TITLE
ocp-test: add missing curator-system secretstore

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - openshift-config
 - group-sync-operator
 - openshift-logging
+- curator-system


### PR DESCRIPTION
External secrets are failing to sync in the curator-system namespace on the OCP-test cluster due to a missing secretstore. Turns out the secretstore was already defined in the overlay but not listed in kustomization.yaml