### PR TITLE
nerc obs admins sudoer

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-obs-admins-sudoer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sudoer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: nerc-obs-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/operators.coreos.com/subscriptions/loki-operator
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer
 - clusterversion.yaml
 - externalsecrets
 - logs-storage


### PR DESCRIPTION
**Grant sudoer to nerc-obs-admins on obs cluster**

The NERC Observability admins should have sudoer access on the obs cluster to access secrets in openshift-logging and open-cluster-management-observability namespace.
