### PR TITLE
feat: Update loki-operator channel to stable-5.7

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-5.6
+  channel: stable-5.7
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators


### PR DESCRIPTION
Final goal, going step by step to loki-operator subscription channel to stable-5.8 5.7 worked fine on OBS after testing it with https://github.com/OCP-on-NERC/nerc-ocp-config/pull/372. Now going to 5.7 on INFRA.