### PR TITLE
[DO NOT MERGE] Create a generic, re-usable ops role

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ops/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ops/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ops
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: ops

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-pod-exec/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-pod-exec/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-ops: "true"
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops-pod-exec
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-pod-exec/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-pod-exec/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-portforward/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-portforward/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-ops: "true"
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops-portforward
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - '*'

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-portforward/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-portforward/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-secrets-reader/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-secrets-reader/clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-ops: "true"
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops-secrets-reader
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - get
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-secrets-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-secrets-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-sudoer/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-sudoer/clusterrole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-ops: "true"
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops-sudoer
+rules:
+  - apiGroups:
+      - ""
+      - user.openshift.io
+    resourceNames:
+      - system:admin
+    resources:
+      - systemusers
+      - users
+    verbs:
+      - impersonate
+  - apiGroups:
+      - ""
+      - user.openshift.io
+    resourceNames:
+      - system:masters
+    resources:
+      - groups
+      - systemgroups
+    verbs:
+      - impersonate

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-sudoer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops-sudoer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops/clusterrole.yaml
@@ -1,0 +1,14 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        nerc.mghpcc.org/aggregate-to-ops: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/bundle: ops-rbac
+  name: ops

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/local-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/local-ops-rbac/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
-  nerc.mghpcc.org/bundle: nerc-ops-rbac
+  nerc.mghpcc.org/bundle: local-ops-rbac
 
-namePrefix: nerc-
+namePrefix: local-
 
 resources:
   - ../ops-rbac
@@ -15,30 +15,18 @@ patches:
       - op: remove
         path: /metadata/labels/nerc.mghpcc.org~1aggregate-to-ops
       - op: add
-        path: /metadata/labels/nerc.mghpcc.org~1aggregate-to-nerc-ops
+        path: /metadata/labels/nerc.mghpcc.org~1aggregate-to-local-ops
         value: "true"
   - patch: |
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        labels:
-          nerc.mghpcc.org/bundle: nerc-ops-rbac
         name: ops
       aggregationRule:
         clusterRoleSelectors:
         - matchLabels:
-            nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+            nerc.mghpcc.org/aggregate-to-local-ops: "true"
         - matchLabels:
             rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
         - matchLabels:
             rbac.authorization.k8s.io/aggregate-to-view: "true"
-  - target:
-      kind: ClusterRoleBinding
-      name: ops
-    patch: |
-      - op: replace
-        path: /subjects
-        value:
-          - apiGroup: rbac.authorization.k8s.io
-            kind: Group
-            name: nerc-ops

--- a/cluster-scope/bundles/ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/ops-rbac/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: ops-rbac
+
+resources:
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/ops
+- ../../base/rbac.authorization.k8s.io/clusterroles/ops
+- ../../base/rbac.authorization.k8s.io/clusterroles/ops-pod-exec
+- ../../base/rbac.authorization.k8s.io/clusterroles/ops-portforward
+- ../../base/rbac.authorization.k8s.io/clusterroles/ops-secrets-reader
+- ../../base/rbac.authorization.k8s.io/clusterroles/ops-sudoer

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/operators.coreos.com/subscriptions/loki-operator
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-sudoer
+- ../../bundles/local-ops-rbac
 - clusterversion.yaml
 - externalsecrets
 - logs-storage
@@ -118,3 +118,13 @@ patches:
     - op: replace
       path: /spec/channel
       value: stable-5.7
+- target:
+    kind: ClusterRoleBinding
+    name: local-ops
+  patch: |
+    - op: replace
+      path: /subjects
+      value:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: nerc-obs-admins


### PR DESCRIPTION
@schwesig @computate this is the idea I was talking aboutin #381. We create a generic "ops" role, and then use kustomize patching magic to re-create our existing "nerc-ops" role as well as a new "local-ops" role, and then we make use of that "local-ops" role on the obs cluster.

This was a quick hack so I'm not actually suggesting we merge this now, but I wanted to put it out here for folks to see.