### PR TITLE
Configure certificate trust for infra services accessing the vault

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clustersecretstores/nerc-cluster-secrets_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clustersecretstores/nerc-cluster-secrets_patch.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   provider:
     vault:
+      caProvider:
+        type: "Secret"
+        namespace: "external-secrets-operator"
+        name: "vault-tls"
+        key: "ca.crt"
+      server: https://vault.vault.svc.cluster.local:8200
       auth:
         kubernetes:
           mountPath: kubernetes/nerc-ocp-infra/

--- a/vault/backup-job/base/scripts/create-snapshot.sh
+++ b/vault/backup-job/base/scripts/create-snapshot.sh
@@ -3,10 +3,6 @@ set -eu
 
 snapshot_file_name=$(date +"snapshot-%F_T%H-%M-%S.snap")
 
-# Set vault addr to the current leader
-VAULT_ADDR="http://vault:8200"
-export VAULT_ADDR
-
 # Grab jwt token from the backup-job serviceaccount, and make the vault token request using k8s login method
 VAULT_TOKEN=$(vault write -field=token auth/kubernetes/backup/login role=nerc-vault-backup jwt="$(cat /run/secrets/kubernetes.io/serviceaccount/token)")
 export VAULT_TOKEN

--- a/vault/backup-job/base/task.yaml
+++ b/vault/backup-job/base/task.yaml
@@ -8,6 +8,8 @@ spec:
       - name: "HOME"
         value: "/tekton/home"
   workspaces:
+    - name: vault-tls
+      mountPath: /vault/tls
     - name: snapshots
       mountPath: /snapshots
     - name: backup-job
@@ -19,6 +21,10 @@ spec:
       image: docker.io/hashicorp/vault:1.15.5
       workingDir: /workspace
       env:
+        - name: VAULT_CACERT
+          value: /vault/tls/ca.crt
+        - name: VAULT_ADDR
+          value: https://vault:8200
         - name: SNAPSHOT_PATH
           value: $(workspaces.snapshots.path)
       script: |

--- a/vault/backup-job/base/trigger/triggertemplate.yaml
+++ b/vault/backup-job/base/trigger/triggertemplate.yaml
@@ -22,3 +22,6 @@ spec:
         - name: backup-scripts
           configMap:
             name: backup-scripts
+        - name: vault-tls
+          secret:
+            secretName: vault-tls

--- a/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
@@ -15,3 +15,14 @@ patches:
       name: vault
     spec:
       host: vault.apps.nerc-ocp-infra.rc.fas.harvard.edu
+
+- patch: |
+    apiVersion: vault.banzaicloud.com/v1alpha1
+    kind: Vault
+    metadata:
+      name: vault
+    spec:
+      # The vault operator will create a secret with the generated
+      # ca.crt in the following namespaces.
+      caNamespaces:
+        - "external-secrets-operator"


### PR DESCRIPTION
Now that most vault access is over tls, we need to configure certificate
trust between services on the infra cluster and the vault (services
external to the infra cluster see the default ingress certificate rather
than the internal vault certificate).

This commit modifies the external secrets operator and the backup job so
that they can interact with vault's https endpoint.

