### PR TITLE
Fix attribute name in nfd manifest

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -9,7 +9,7 @@ spec:
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
     imagePullPolicy: Always
     servicePort: 0
-  topologyUpdater: false
+  topologyupdater: false
   workerConfig:
     configData: |
       core:


### PR DESCRIPTION
According to `kubectl explain nodefeaturediscovery.spec`, `topologyUpdater`
should be spelled `topologyupdater`. The mismatch is making this resource
show up as out-of-sync in argocd.

