### PR TITLE
Revert "Fix attribute name in nfd manifest"

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -9,7 +9,7 @@ spec:
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
     imagePullPolicy: Always
     servicePort: 0
-  topologyupdater: false
+  topologyUpdater: false
   workerConfig:
     configData: |
       core:


### PR DESCRIPTION
This reverts commit 15e425cd449ea3e10a989485f9c541388245f1a8.

The nfd operator crd is a dirty lie.
