### PR TITLE
Resize image registry volume to 300Gi

### DIFF
--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Gi
+      storage: 300Gi


### PR DESCRIPTION
We had run out of space on the image-registry-storage pv. This commit
increases the volume size from 100Gi to 300Gi.

Closes: nerc-project/operations#454
