### PR TITLE
ocp-prod: add nics for Lenovo SD650 A100 workers

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-controller.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-controller.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjZS4AAEAAP//AAlzT7AAAAA=
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018yUNu6FmIvXvYAAAAD//1CIi59gAQAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
         - contents:

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjZS4AAEAAP//AAlzT7AAAAA=
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018yUNu6FmIvXvYAAAAD//1CIi59gAQAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
         - contents:

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
@@ -1,2 +1,4 @@
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.0",ACTION=="add",NAME="nic1"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.1",ACTION=="add",NAME="nic2"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.1",ACTION=="add",NAME="nic2"


### PR DESCRIPTION
**WARNING**: This will update machineconfigs which will cause a rolling reboot of all hosts in the cluster. This will be merged and deployed during a planned maintenance event.

This adds a udev rule for the NICs on the new Lenovo SD530 (with 4xA100s per node) worker hosts.

https://github.com/nerc-project/operations/issues/442