### PR TITLE
Fix access for loki logs in LOKI 5.8

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-5.7
+  channel: stable-5.8
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators

--- a/loki/base/lokistacks/lokistack.yaml
+++ b/loki/base/lokistacks/lokistack.yaml
@@ -32,5 +32,8 @@ spec:
       caName: openshift-service-ca.crt
   tenants:
     mode: openshift-logging
+    openshift:
+      adminGroups:
+      - nerc-logs-metrics
   size: 1x.medium
   storageClassName: ocs-external-storagecluster-ceph-rbd


### PR DESCRIPTION
This PR deploys LOKI latest version (5.8) and makes the access of the logs to the nerc-logs-metrics group.