### PR TITLE
Adding dex configuration with GRAFANA_SECRET on obs

### DIFF
--- a/dex/overlays/nerc-ocp-obs/configmaps/files/config.yaml
+++ b/dex/overlays/nerc-ocp-obs/configmaps/files/config.yaml
@@ -1,0 +1,35 @@
+issuer: https://dex-dex.apps.obs.nerc.mghpcc.org
+
+storage:
+  type: memory
+
+web:
+  http: "0.0.0.0:5556"
+
+grpc:
+  addr: "0.0.0.0:5557"
+
+telemetry:
+  http: "0.0.0.0:5558"
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: grafana
+    name: Grafana
+    redirectURIs:
+      - https://grafana.apps.obs.nerc.mghpcc.org/login/generic_oauth
+    secretEnv: GRAFANA_SECRET
+
+connectors:
+  - type: openshift
+    id: openshift
+    name: OpenShift
+    config:
+      issuer: https://kubernetes.default.svc
+      clientID: system:serviceaccount:dex:dex
+      clientSecret: $OPENSHIFT_CLIENT_SECRET
+      redirectURI: https://dex-dex.apps.obs.nerc.mghpcc.org/callback
+      groups:
+        - system:authenticated

--- a/dex/overlays/nerc-ocp-obs/configmaps/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-obs/configmaps/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  kustomize.config.k8s.io/behavior: merge
+
+configMapGenerator:
+  - files:
+      - files/config.yaml
+    name: dex

--- a/dex/overlays/nerc-ocp-obs/externalsecrets/dex-clients_patch.yaml
+++ b/dex/overlays/nerc-ocp-obs/externalsecrets/dex-clients_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-clients
+spec:
+  dataFrom:
+    - extract:
+        key: nerc-ocp-obs/dex/dex-clients

--- a/dex/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+resources:
+  - ../../base
+  - configmaps
+patches:
+  - path: externalsecrets/dex-clients_patch.yaml


### PR DESCRIPTION
We need a dex authentication tool on the obs cluster to authenticate
OpenShift users to grafana for role-based access control.
