### PR TITLE
Adding the missing dex namespace on obs cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../../bundles/nerc-certificate-clusterissuers
 - ../../bundles/external-secrets-clustersecretstore
 - ../../base/core/namespaces/openshift-gitops
+- ../../base/core/namespaces/dex
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/operators.coreos.com/subscriptions/loki-operator
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-ops


### PR DESCRIPTION
- **Adding the missing dex namespace on obs cluster**
