### PR TITLE
feat: Implement OpenShift Slack alert for status updates

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -204,7 +204,7 @@ data:
         - alert: Custom6amOpeLimitsCpu
           # A percentage of limit
           expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
-          # No 'for' clause when firing immediatley, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
+          # No 'for' clause when firing immediately, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
           labels:
             severity: info
           annotations:

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -188,7 +188,7 @@ data:
 
         - alert: CustomOpeLimitsCpu
           annotations:
-            summary: "{{ $labels.cluster }} container CPU usage above 80%"
+            summary: "{{ $labels.cluster }} - ope CPU usage above 80% of limit"
             description: |
               <https://grafana-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22sum(avg_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate%5B1h%5D))%20by%20(cluster,%20namespace,%20pod)%20%2F%20avg(kube_pod_container_resource_limits%7Bresource%3D%5C%22cpu%5C%22%7D)%20by%20(cluster,%20namespace,%20pod)%20%3E%200.80%22%7D%5D|Click here to see these metrics in Observability Monitoring>
               CPU usage is at {{ $value | humanizePercentage }} in namespace {{ $labels.namespace }}, cluster {{ $labels.cluster }}.
@@ -197,6 +197,20 @@ data:
           labels:
             severity: warning
             cpu: limit
+
+      - name: ope6amStatus
+        rules:
+
+        - alert: Custom6amOpeLimitsCpu
+          # A percentage of limit
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          # No 'for' clause when firing immediatley, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
+          labels:
+            severity: info
+          annotations:
+            summary: "{{ $labels.cluster }} - ope daily status current CPU usage"
+            description: |
+              CPU usage is at {{ $value | humanizePercentage }} in namespace {{ $labels.namespace }}, cluster {{ $labels.cluster }}.
 
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -89,7 +89,15 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "(CustomContainerCpuUsage)"
+                  - alertname =~ "(CustomOpeLimitsCpu)"
+              - receiver: slack-notifications-prod-rhods-ope
+                group_by: [cluster]
+                group_wait: 0s
+                group_interval: 5m
+                repeat_interval: 7d
+                matchers:
+                  - alertname =~ "(Custom6amOpeLimitsCpu)"
+
           receivers:
           - name: default
           - name: slack-notifications


### PR DESCRIPTION
feat: Implement Slack alert for status updates

A new Slack alert to provide **status updates at specified times**. This implementation serves as a proof of concept (PoC) for potential future alerts of similar nature, contingent upon successful operation and utility of this initial setup.
