### PR TITLE
upgrade Loki on obs and switch Logging Operator from stable to stable-5.8 for all clusters

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable
+  channel: stable-5.8
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -112,10 +112,3 @@ patches:
             kubernetes:
               mountPath: kubernetes/nerc-ocp-obs
           server: https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/
-- target:
-    kind: Subscription
-    name: loki-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-5.7


### PR DESCRIPTION
- **Upgrade Loki operator to stable-5.8 on obs cluster**
- **Change Logging operator version from stable to stable-5.8**
