### PR TITLE
Allow nerc-ops view access on monitoring resources

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+  name: nerc-ops-monitoring
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - "*"
+    verbs:
+      - list
+      - get
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-portforward
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer
+- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring


### PR DESCRIPTION
Allow members of the nerc-ops group to view/list resources in the
monitoring.coreos.com api group. This is necessary to be able to run e.g.
the `noobaa status` command.
