### PR TITLE
Set Serverless operator version on OpenShift prod to stable-1.31 and add default KnativeServing and KnativeEventing resources

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: serverless-operator
   namespace: openshift-serverless
 spec:
-  channel: stable
+  channel: stable-1.31
   installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators

--- a/serverless/overlays/nerc-ocp-prod/knativeeventing/knativeeventing.yaml
+++ b/serverless/overlays/nerc-ocp-prod/knativeeventing/knativeeventing.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  high-availability:
+    replicas: 3

--- a/serverless/overlays/nerc-ocp-prod/knativeeventing/kustomization.yaml
+++ b/serverless/overlays/nerc-ocp-prod/knativeeventing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - knativeeventing.yaml

--- a/serverless/overlays/nerc-ocp-prod/knativeserving/knativeserving.yaml
+++ b/serverless/overlays/nerc-ocp-prod/knativeserving/knativeserving.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  high-availability:
+    replicas: 3

--- a/serverless/overlays/nerc-ocp-prod/knativeserving/kustomization.yaml
+++ b/serverless/overlays/nerc-ocp-prod/knativeserving/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - knativeserving.yaml

--- a/serverless/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/serverless/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - knativeserving/
+  - knativeeventing/


### PR DESCRIPTION
- **Change serverless-operator version from stable to latest stable-1.31**
BU SAIL team users would like to use the existing OpenShift Serverless
operator in the NERC Prod OpenShift cluster. To ensure a stable
Serverless operator, we will set the version to the latest stable-1.31
version.

- **Add required KnativeServing and KnativeEventing for Serverless**
The BU SAIL team would like to use OpenShift Serverless for a Sign
Language project. To enable this, we add the default KnativeServing and
KnativeEventing resources for Serverless. We set the High Availability
feature to a [recommended 3 replicas](https://access.redhat.com/documentation/en-us/red_hat_openshift_serverless/1.31/html/serving/high-availability-configuration-for-knative-serving#serverless-config-replicas-serving_ha-replicas-serving).
