### PR TITLE
Add ece440spring2024-619f12 secret store

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/ece440spring2024-619f12/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/ece440spring2024-619f12/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ece440spring2024-619f12
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - openshift-ingress
 - openshift-logging
 - group-sync-operator
+- ece440spring2024-619f12

--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-prod.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-prod.yaml
@@ -16,6 +16,7 @@ auth:
     - openshift-ingress
     - openshift-logging
     - openshift-ingress-operator
+    - ece440spring2024-619f12
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
In order to deploy the OPEautograder, we need to have a secret for the ssh-privatekey that can be automatically deployed.