### PR TITLE
feat(monitoring): Add GPU-related metrics

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -22,3 +22,5 @@ data:
       - __name__=~"(ipmi_.*)"
       - __name__=~"(ceph_.*)"
       - __name__=~"(log_.*)"
+      - __name__=~"gpu_operator_.*"
+      - __name__=~"DCGM_FI_.*"


### PR DESCRIPTION
# feat(monitoring): Add GPU-related metrics

This commit introduces a broad range of GPU-related metrics into our monitoring configuration.
Using wildcard patterns for 'gpu_operator_*' and 'DCGM_FI_*' metrics.
List of possible metrics with description can be found here: https://github.com/nerc-project/operations/issues/470#issuecomment-1994284106