### PR TITLE
Enable new ClusterRoleBindings in Logging version 5.8 for fine-grained resource permissions to logs

### DIFF
--- a/logging/base/clusterrolebindings/clusterrolebinding.yaml
+++ b/logging/base/clusterrolebindings/clusterrolebinding.yaml
@@ -1,9 +1,8 @@
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logging-application-view-binding-nerc-logs-metrics
-  namespace: openshift-logging
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -14,11 +13,10 @@ subjects:
     name: nerc-logs-metrics
 
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logging-infrastructure-view-binding-nerc-logs-metrics
-  namespace: openshift-logging
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,11 +27,10 @@ subjects:
     name: nerc-logs-metrics
 
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: logging-audit-view-binding-nerc-logs-metrics
-  namespace: openshift-logging
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/logging/base/clusterrolebindings/kustomization.yaml
+++ b/logging/base/clusterrolebindings/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - rolebinding.yaml
+  - clusterrolebinding.yaml

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - clusterloggings
   - clusterlogforwarders
   - externalsecrets
-  - rolebindings
+  - clusterrolebindings
 commonLabels:
   app.kubernetes.io/name: logging
   app.kubernetes.io/component: logging


### PR DESCRIPTION
- [**Enable new ClusterRoleBindings in Logging version 5.8**](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html-single/logging/index#logging-loki-log-access_cluster-logging-loki)
Enable the new ClusterRoleBindings for fine-grained resource permissions
to Loki logs in Logging version 5.8.