### PR TITLE
Fix test cluster ClusterLogForwarder url

### DIFF
--- a/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
@@ -7,22 +7,19 @@ spec:
   outputs:
     - name: loki-app
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/application
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/application
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
     - name: loki-infra
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/infrastructure
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/infrastructure
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
     - name: loki-audit
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-obs.rc.fas.harvard.edu/api/logs/v1/audit
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/audit
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
   pipelines:
     - name: send-app-logs
       inputRefs:


### PR DESCRIPTION
- **Fix test cluster ClusterLogForwarder url**
Update the url of the test cluster ClusterLogForwarder to the correct
URL.