### PR TITLE
Add replication policy to mirror logs content to logsarchive bucket

### DIFF
--- a/loki/overlays/nerc-ocp-obs/objectbucketclaims/logs.yaml
+++ b/loki/overlays/nerc-ocp-obs/objectbucketclaims/logs.yaml
@@ -7,3 +7,10 @@ spec:
   generateBucketName: logs-obc
   # Change this later with the loki-bucket-storage
   storageClassName: logs-bucket-storage
+  additionalConfig:
+    replicationPolicy: |+
+      {
+        "rules": [
+          { "rule_id": "logs-mirroring-rule", "destination_bucket": "logsarchive-obc-928a6f6f-7b86-4b0c-976b-345a529bb994" }
+        ]
+      }


### PR DESCRIPTION
This PR configures the replication of logs from `logs` bucket to `logsarchive` bucket.