### PR TITLE
Enable mixed MIG strategy in nerc-ocp-test cluster

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  mig:
+    strategy: mixed
+  migManager:
+    config:
+      default: all-disabled
+      name: test-mig-parted-config

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/configmaps/mig-manager-config.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/configmaps/mig-manager-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-mig-parted-config
+data:
+  config.yaml: |
+    version: v1
+    mig-configs:
+      # This config disables mig on all GPUs
+      all-disabled:
+        - devices: all
+          mig-enabled: false
+
+      # This is the geometry we tested in single MIG mode
+      # A100-40GB, A800-40GB
+      all-1g.5gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.5gb": 7
+
+      all-balanced-test
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.5gb": 2
+            "2g.10gb": 1
+            "3g.20gb": 1

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
   - ../../base
+  - configmaps/mig-manager-config.yaml
+patches:
+  - path: clusterpolicy/clusterpolicy_patch.yaml


### PR DESCRIPTION
Addresses: [https://github.com/nerc-project/operations/issues/468](https://github.com/nerc-project/operations/issues/468)

Patch nvidia gpu operator clusterpolicy in nerc-ocp-test overlay

Add custom MIG config to nerc-ocp-test overlay

Properly add mig config to kustomization