### PR TITLE
Forward infra cluster logs to obs cluster

### DIFF
--- a/logging/overlays/nerc-ocp-infra/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-infra/clusterlogforwarders/instance_patch.yaml
@@ -1,0 +1,38 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: loki-app
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/application
+      secret:
+        name: lokistack-gateway-bearer-token
+    - name: loki-infra
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/infrastructure
+      secret:
+        name: lokistack-gateway-bearer-token
+    - name: loki-audit
+      type: loki
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/audit
+      secret:
+        name: lokistack-gateway-bearer-token
+  pipelines:
+    - name: send-app-logs
+      inputRefs:
+        - application
+      outputRefs:
+        - loki-app
+    - name: send-infra-logs
+      inputRefs:
+        - infrastructure
+      outputRefs:
+        - loki-infra
+    - name: send-audit-logs
+      inputRefs:
+        - audit
+      outputRefs:
+        - loki-audit

--- a/logging/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-infra/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 patches:
   - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml
+  - path: clusterlogforwarders/instance_patch.yaml


### PR DESCRIPTION
- **Forward infra cluster logs to obs cluster**
To lighten the network traffic on the infra cluster, we will forward the
infra cluster logs to the LokiStack deployed on the obs cluster.