### PR TITLE
Forward prod cluster logs to obs cluster

### DIFF
--- a/logging/overlays/nerc-ocp-prod/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-prod/clusterlogforwarders/instance_patch.yaml
@@ -7,22 +7,19 @@ spec:
   outputs:
     - name: loki-app
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-infra.rc.fas.harvard.edu/api/logs/v1/application
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/application
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
     - name: loki-infra
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-infra.rc.fas.harvard.edu/api/logs/v1/infrastructure
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/infrastructure
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
     - name: loki-audit
       type: loki
-      url: https://logging-loki-openshift-logging.apps.nerc-ocp-infra.rc.fas.harvard.edu/api/logs/v1/audit
+      url: https://logging-loki-openshift-logging.apps.obs.nerc.mghpcc.org/api/logs/v1/audit
       secret:
         name: lokistack-gateway-bearer-token
-      loki:
   pipelines:
     - name: send-app-logs
       inputRefs:


### PR DESCRIPTION
- **Forward prod cluster logs to obs cluster**
To lighten the network traffic on the infra cluster, we will forward the
prod cluster logs to the LokiStack deployed on the obs cluster.