### PR TITLE
Beautify regex for GPU and DCGM metrics in custom allowlist

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -22,5 +22,5 @@ data:
       - __name__=~"(ipmi_.*)"
       - __name__=~"(ceph_.*)"
       - __name__=~"(log_.*)"
-      - __name__=~"gpu_operator_.*"
-      - __name__=~"DCGM_FI_.*"
+      - __name__=~"(gpu_operator_.*)"
+      - __name__=~"(DCGM_FI_.*)"


### PR DESCRIPTION
Beautify regex for GPU and DCGM metrics in custom allowlist ConfigMap

The update doesn't change the current behaviour (include metrics starting with "gpu_operator_" and "DCGM_FI_"). But it now follows the syntax of earlier rules by adding parentheses.