### PR TITLE
feat: Add 6am alerts in rhods-notebooks namespace

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -202,15 +202,69 @@ data:
         rules:
 
         - alert: Custom6amOpeLimitsCpu
-          # A percentage of limit
+          # A limits.cpu percentage of limit
           expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
           # No 'for' clause when firing immediately, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
           labels:
             severity: info
           annotations:
-            summary: "{{ $labels.cluster }} - ope daily status current CPU usage"
+            summary: "{{ $labels.cluster }} - current status in namespace rhods-notebooks, cluster nerc-ocp-prod"
             description: |
-              CPU usage is at {{ $value | humanizePercentage }} in namespace {{ $labels.namespace }}, cluster {{ $labels.cluster }}.
+              info: limits.cpu: {{ $value | humanizePercentage }} used
+
+        - alert: Custom6amOpeLimitsEphemeralStorage
+          # B limits.ephemeral-storage percentage of limit
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: limits.ephemeral-storage: {{ $value | humanizePercentage }} used
+
+        - alert: Custom6amOpeLimitsMemory
+          # C limits.memory percentage of limit
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: limits.memory: {{ $value | humanizePercentage }} used
+
+        - alert: Custom6amOpePersistentVolumeClaims
+          # D persistentvolumeclaims percentage of limit
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: persistentvolumeclaims: {{ $value | humanizePercentage }} used
+
+        - alert: Custom6amOpeRequestsStorage
+          # E requests.storage percentage of limit
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: requests.storage: {{ $value | humanizePercentage }} used
+
+        - alert: Custom6amOpeKubePodContainerInfo
+          # F kube_pod_container_info absolute
+          expr: (max_over_time(count(kube_pod_container_info{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-5+(minute()/60))==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: kube_pod_container_info: {{ $value }} containers
+
+        - alert: Custom6amOpeKubePodOwner
+          # G kube_pod_owner absolute
+          expr: (max_over_time(count(kube_pod_owner{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-5+(minute()/60))==6.0)
+          labels:
+            severity: info
+          annotations:
+            description: |
+              info: kube_pod_owner: {{ $value }} pod owners
 
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -91,12 +91,12 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
-                group_by: [cluster]
+                group_by: [cluster, namespace]
                 group_wait: 0s
                 group_interval: 5m
                 repeat_interval: 7d
                 matchers:
-                  - alertname =~ "(Custom6amOpeLimitsCpu)"
+                  - alertname =~ "^Custom6amOpe.*"
 
           receivers:
           - name: default


### PR DESCRIPTION
This commit introduces more ope status alerts in the 'rhods-notebooks' namespace within the 'nerc-ocp-prod' cluster. The alerts are designed to be triggered at 6am and send to Slack channel alerts-prod-rhods-ope, focusing on ephemeral storage, memory usage, PVC claims, storage requests, container counts, and pod owner counts.

Changes made:
1. Rules:
   - Added alerts for monitoring the percentage of limit used for ephemeral storage, memory, PVCs, and storage requests at 6am.
   - Added alerts for counting containers and pod owners at 6am, providing a snapshot of resource utilization.
   - Based on time trigger, providing daily insights into resource usage patterns before classes start.

2. Configuration:
   - Routing to 'slack-notifications-prod-rhods-ope' receiver.
   - Alerts matching `^Custom6amOpe.*` to catch all new rules from 1.