### PR TITLE
Upgrade nerc-ocp-test to 4.13.13

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.13
   desiredUpdate:
-    version: 4.13.8
+    version: 4.13.13
   clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72


### PR DESCRIPTION
This brings nerc-ocp-test to the same clusterversion we're running on
nerc-ocp-prod.
