### PR TITLE
style: Improve readability of 6am alerts

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -203,7 +203,22 @@ data:
 
         - alert: Custom6amOpeLimitsCpu
           # A limits.cpu percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          expr: >-
+            (
+              max_over_time(
+                sum(
+                  kube_resourcequota{
+                    cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"
+                  }
+                )[10m:5m]
+              )/max_over_time(
+                sum(
+                  kube_resourcequota{
+                    cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"
+                  }
+                )[10m:5m]
+              )
+            ) and (hour()-5+(minute()/60)==6.0)
           # No 'for' clause when firing immediately, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
           labels:
             severity: info
@@ -214,7 +229,22 @@ data:
 
         - alert: Custom6amOpeLimitsEphemeralStorage
           # B limits.ephemeral-storage percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          expr: >-
+            (
+              max_over_time(
+                sum(
+                  kube_resourcequota{
+                    cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="used"
+                  }
+                )[10m:5m]
+              )/max_over_time(
+                sum(
+                  kube_resourcequota{
+                    cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="hard"
+                  }
+                )[10m:5m]
+              )
+            ) and (hour()-5+(minute()/60)==6.0)
           labels:
             severity: info
           annotations:

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -91,10 +91,9 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
-                group_by: [cluster, namespace]
                 group_wait: 0s
-                group_interval: 5m
-                repeat_interval: 7d
+                group_interval: 0s
+                repeat_interval: 0s
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"
 


### PR DESCRIPTION
Refactored the 6am alert expressions using YAML's folding style. This enhances the readability of complex alert expressions. Special thanks to Lars for suggesting this improvement.

- just changing the first 2 expressions for testing, before rolling it out to all
- removing group_by and time-group/delay to send every status for sure