### PR TITLE
fix: 6am status alert disable grouping

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -91,8 +91,8 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
+                group_by: ['...']
                 group_wait: 0s
-                group_interval: 0s
                 repeat_interval: 0s
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
# fix: 6am status alert disable grouping

This commit updates the Alertmanager configuration to disable the grouping of alerts. By setting 'group_by' to an empty list, each alert is now treated individually and will trigger its own notification.

The first idea to ommit the group_by wasn't working:
```By default, Alertmanager groups alerts to reduce noise. If group_by is not explicitly set, Alertmanager groups by all common labels.```
```However, it's important to note that group_interval being 0s might not entirely prevent grouping due to how Alertmanager internally aggregates alerts based on their labels and matchers.```