### PR TITLE
Add Serverless/Knative CRDs aggregate-to-edit ClusterRole

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/knative-edit/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/knative-edit/clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - 'sources.knative.dev/v1'
+      - 'serving.knative.dev/v1'
+      - 'messaging.knative.dev/v1'
+      - 'eventing.knative.dev/v1'
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - update
+      - patch
+      - get
+      - watch
+      - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/knative-edit/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/knative-edit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 commonLabels:
   nerc.mghpcc.org/bundle: openshift-serverless-operator
 resources:
+- ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
 - ../../base/core/namespaces/openshift-serverless
 - ../../base/operators.coreos.com/operatorgroups/openshift-serverless
 - ../../base/operators.coreos.com/subscriptions/red-hat-camel-k


### PR DESCRIPTION
- **Add Serverless/Knative CRDs aggregate-to-edit ClusterRole**
Grant Users access to create and edit Knative CRDs in their namespace like PingSource, ApiServerSource, ContainerSource, SinkBinding, Channel, Broker. 

Closes https://github.com/nerc-project/operations/issues/519