### PR TITLE
Revert nvidia gpu mig strategy to single

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-cluster-policy
 spec:
   mig:
-    strategy: mixed
+    strategy: single
   migManager:
     config:
       default: all-disabled


### PR DESCRIPTION
Mixed mig breaks gpu availability for the current version of rhods. We cant upgrade the rhods version until after the semester so we need to revert back to the single mig mode to allow for testing rhods workloads using the gpu