### PR TITLE
refactor: 6am alerts - grouping, intervals, tz

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -218,10 +218,13 @@ data:
                   }
                 )[10m:5m]
               )
-            ) and (hour()-5+(minute()/60)==6.0)
-          # No 'for' clause when firing immediately, time is always utc -5 to calculate New York time (summer winter time switch will be wrong by an hour for a week)
+            ) and (hour()-6+(minute()/60)==6.0)
+          # No 'for' clause when firing immediately, time is always utc -6 to calculate New York time (summer winter time switch will be wrong by an hour)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : cpu
           annotations:
             summary: "{{ $labels.cluster }} - current status in namespace rhods-notebooks, cluster nerc-ocp-prod"
             description: |
@@ -244,54 +247,72 @@ data:
                   }
                 )[10m:5m]
               )
-            ) and (hour()-5+(minute()/60)==6.0)
+            ) and (hour()-6+(minute()/60)==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : ephemeral-storage
           annotations:
             description: |
               info: limits.ephemeral-storage: {{ $value | humanizePercentage }} used
 
         - alert: Custom6amOpeLimitsMemory
           # C limits.memory percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : memory
           annotations:
             description: |
               info: limits.memory: {{ $value | humanizePercentage }} used
 
         - alert: Custom6amOpePersistentVolumeClaims
           # D persistentvolumeclaims percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : persistentvolumeclaims
           annotations:
             description: |
               info: persistentvolumeclaims: {{ $value | humanizePercentage }} used
 
         - alert: Custom6amOpeRequestsStorage
           # E requests.storage percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"})[10m:5m])) and (hour()-5+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : storage
           annotations:
             description: |
               info: requests.storage: {{ $value | humanizePercentage }} used
 
         - alert: Custom6amOpeKubePodContainerInfo
           # F kube_pod_container_info absolute
-          expr: (max_over_time(count(kube_pod_container_info{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-5+(minute()/60))==6.0)
+          expr: (max_over_time(count(kube_pod_container_info{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-6+(minute()/60))==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : container
           annotations:
             description: |
               info: kube_pod_container_info: {{ $value }} containers
 
         - alert: Custom6amOpeKubePodOwner
           # G kube_pod_owner absolute
-          expr: (max_over_time(count(kube_pod_owner{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-5+(minute()/60))==6.0)
+          expr: (max_over_time(count(kube_pod_owner{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-6+(minute()/60))==6.0)
           labels:
             severity: info
+            environment: production
+            team: ope
+            component : pod
           annotations:
             description: |
               info: kube_pod_owner: {{ $value }} pod owners

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -18,7 +18,6 @@ spec:
           global:
           route:
             receiver: default
-            group_by: [cluster, alertname]
             routes:
               - receiver: slack-notifications
                 group_by: [cluster, alertname, namespace, persistentvolumeclaim]
@@ -93,6 +92,7 @@ spec:
               - receiver: slack-notifications-prod-rhods-ope
                 group_by: ['...']
                 group_wait: 0s
+                group_interval: 0s
                 repeat_interval: 0s
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
Changes include `group_interval`, `group_wait`, and `repeat_interval` to 0s, ensuring immediate alert notifications. Additionally, labels for environment, team, and component were unified across status definitions, enhancing filterability.

- Ensure instant slack notifications for 6am status.
- Improve alert labeling.
- Fix 7am to 6am timezone error.