### PR TITLE
Deploy Koku Metrics Operator & Curator Operator to nerc-ocp-prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
 - ../../bundles/nvidia-gpu-operator
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
 - ../../bundles/clusterissuer-http01
+- ../../bundles/curator
+- ../../bundles/koku-metrics-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - feature/odf
 - feature/custom-routes

--- a/curator/base/configmaps/kustomization.yaml
+++ b/curator/base/configmaps/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - postgres-config.yaml

--- a/curator/base/configmaps/postgres-config.yaml
+++ b/curator/base/configmaps/postgres-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: koku-metrics-config
+data:
+  pg_hba.conf: |
+    host all all 0.0.0.0/0 md5

--- a/curator/base/deployments/deployment.yaml
+++ b/curator/base/deployments/deployment.yaml
@@ -71,28 +71,28 @@ spec:
         - name: DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              key: DatabaseName
-              name: postgres-config
+              key: dbname
+              name: curatordb-pguser-curator
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
-              key: DatabaseUser
-              name: postgres-config
+              key: user
+              name: curatordb-pguser-curator
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              key: DatabasePassword
-              name: postgres-config
+              key: password
+              name: curatordb-pguser-curator
         - name: DATABASE_HOST_NAME
           valueFrom:
             secretKeyRef:
-              key: DatabaseHostName
-              name: postgres-config
+              key: host
+              name: curatordb-pguser-curator
         - name: PORT_NUMBER
           valueFrom:
             secretKeyRef:
-              key: DatabasePort
-              name: postgres-config
+              key: port
+              name: curatordb-pguser-curator
         image: ghcr.io/ocp-on-nerc/curator-operator/curator-manager:latest
         livenessProbe:
           httpGet:

--- a/curator/base/kustomization.yaml
+++ b/curator/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: curator-system
 resources:
+  - configmaps
   - deployments
   - externalsecrets
+  - postgrescluster
   - pvcs
   - rolebindings
   - roles

--- a/curator/base/postgrescluster/cluster.yaml
+++ b/curator/base/postgrescluster/cluster.yaml
@@ -1,0 +1,58 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: curatordb-cluster
+  namespace: koku-metrics-operator
+spec:
+  port: 5432
+  users:
+    - databases:
+        - curatordb
+      password:
+        type: ASCII
+      options: "SUPERUSER"
+      name: curator
+  standby:
+    enabled: false
+  proxy:
+    pgBouncer:
+      port: 5432
+      service:
+        type: ClusterIP
+      replicas: 1
+  backups:
+    pgbackrest:
+      repos:
+        - volume:
+            volumeClaimSpec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Gi
+          name: repo1
+  service:
+    type: ClusterIP
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        pg_hba:
+          - postgres-config
+    leaderLeaseDurationSeconds: 30
+    port: 8008
+    switchover:
+      type: Switchover
+      enabled: true
+    syncPeriodSeconds: 10
+  instances:
+    - dataVolumeClaimSpec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: ocs-external-storagecluster-ceph-rbd
+      replicas: 1
+  postgresVersion: 15
+  imagePullPolicy: IfNotPresent
+  openshift: true

--- a/curator/base/postgrescluster/kustomization.yaml
+++ b/curator/base/postgrescluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml

--- a/curator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/curator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: curator
+resources:
+  - ../../base
+namespace: curator-system


### PR DESCRIPTION
This PR deploys koku-metrics-operator and curator operator to the prod cluster for NERC folks to explore

Also configures a crunchy Postgres cluster to serve curator operator

Add koku-metrics-operator and curator bundles to nerc-ocp-prod

Configure crunchy postres cluster for curator