### PR TITLE
fix: 6am status - summer time change & group_interval

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -218,8 +218,8 @@ data:
                   }
                 )[10m:5m]
               )
-            ) and (hour()-6+(minute()/60)==6.0)
-          # No 'for' clause when firing immediately, time is always utc -6 to calculate New York time (summer winter time switch will be wrong by an hour)
+            ) and (hour()-4+(minute()/60)==6.0)
+          # No 'for' clause when firing immediately, time is always utc -4 to calculate New York time (summer winter time switch not yet fixed)
           labels:
             severity: info
             environment: production
@@ -247,7 +247,7 @@ data:
                   }
                 )[10m:5m]
               )
-            ) and (hour()-6+(minute()/60)==6.0)
+            ) and (hour()-4+(minute()/60)==6.0)
           labels:
             severity: info
             environment: production
@@ -259,7 +259,7 @@ data:
 
         - alert: Custom6amOpeLimitsMemory
           # C limits.memory percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"})[10m:5m])) and (hour()-4+(minute()/60)==6.0)
           labels:
             severity: info
             environment: production
@@ -271,7 +271,7 @@ data:
 
         - alert: Custom6amOpePersistentVolumeClaims
           # D persistentvolumeclaims percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"})[10m:5m])) and (hour()-4+(minute()/60)==6.0)
           labels:
             severity: info
             environment: production
@@ -283,7 +283,7 @@ data:
 
         - alert: Custom6amOpeRequestsStorage
           # E requests.storage percentage of limit
-          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"})[10m:5m])) and (hour()-6+(minute()/60)==6.0)
+          expr: (max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"})[10m:5m])/max_over_time(sum(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"})[10m:5m])) and (hour()-4+(minute()/60)==6.0)
           labels:
             severity: info
             environment: production
@@ -295,7 +295,7 @@ data:
 
         - alert: Custom6amOpeKubePodContainerInfo
           # F kube_pod_container_info absolute
-          expr: (max_over_time(count(kube_pod_container_info{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-6+(minute()/60))==6.0)
+          expr: (max_over_time(count(kube_pod_container_info{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-4+(minute()/60))==6.0)
           labels:
             severity: info
             environment: production
@@ -307,7 +307,7 @@ data:
 
         - alert: Custom6amOpeKubePodOwner
           # G kube_pod_owner absolute
-          expr: (max_over_time(count(kube_pod_owner{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-6+(minute()/60))==6.0)
+          expr: (max_over_time(count(kube_pod_owner{cluster="nerc-ocp-prod",namespace="rhods-notebooks"})[10m:5m])) and ((hour()-4+(minute()/60))==6.0)
           labels:
             severity: info
             environment: production

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -92,7 +92,6 @@ spec:
               - receiver: slack-notifications-prod-rhods-ope
                 group_by: ['...']
                 group_wait: 0s
-                group_interval: 0s
                 repeat_interval: 0s
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
# fix: 6am status - summer time & group_interval 

1. Summertime change was calculated compared to Berlin, not UTC.
2. [group_interval cannot be zero](https://github.com/prometheus/alertmanager/blob/14cbe6301c732658d6fe877ec55ad5b738abcf06/config/config.go/#L837)

## Some ideas how to solve this regularly
- https://medium.com/@tom.fawcett/time-of-day-based-notifications-with-prometheus-and-alertmanager-1bf7a23b7695
- https://github.com/prometheus/alertmanager/issues/876
