### PR TITLE
feat: add argocd metrics to the OBS

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -24,3 +24,4 @@ data:
       - __name__=~"(log_.*)"
       - __name__=~"(gpu_operator_.*)"
       - __name__=~"(DCGM_FI_.*)"
+      - __name__=~"(argoc_.*)"


### PR DESCRIPTION
https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/

 - __name__=~"(argocd_.*)"
 
| Metric                            | Type      | Description                                                                                       |
|-----------------------------------|-----------|---------------------------------------------------------------------------------------------------|
| argocd_app_info                   | gauge     | Information about Applications. It contains labels such as sync_status and health_status that reflect the application state in Argo CD. |
| argocd_app_k8s_request_total      | counter   | Number of Kubernetes requests executed during application reconciliation                         |
| argocd_app_labels                 | gauge     | Argo Application labels converted to Prometheus labels. Disabled by default. See section below about how to enable it. |
| argocd_app_reconcile              | histogram | Application reconciliation performance.                                                           |
| argocd_app_sync_total             | counter   | Counter for application sync history                                                              |
| argocd_cluster_api_resource_objects | gauge     | Number of k8s resource objects in the cache.                                                      |
| argocd_cluster_api_resources      | gauge     | Number of monitored Kubernetes API resources.                                                     |
| argocd_cluster_cache_age_seconds  | gauge     | Cluster cache age in seconds.                                                                     |
| argocd_cluster_connection_status  | gauge     | The k8s cluster current connection status.                                                        |
| argocd_cluster_events_total       | counter   | Number of processes k8s resource events.                                                          |
| argocd_cluster_info               | gauge     | Information about cluster.                                                                        |
| argocd_kubectl_exec_pending       | gauge     | Number of pending kubectl executions                                                              |
| argocd_kubectl_exec_total         | counter   | Number of kubectl executions                                                                      |
| argocd_redis_request_duration     | histogram | Redis requests duration.                                                                          |
| argocd_redis_request_total        | counter   | Number of redis requests executed during application reconciliation                               |
