### PR TITLE
refactor: 6am alert update grouping and intervals

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -90,8 +90,10 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
-                group_by: ['...']
-                group_wait: 0s
+                group_by: ['team']
+                group_wait: 15s
+                group_interval: 15s
+                repeat_interval: 2h
                 # repeat_interval cannot be zero, group_interval cannot be zero
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
Adjusted the alertmanager grouped by team: ope. Optimize group notification for the RHODS OPE team.

Changes include:
- Grouping alerts by 'team'
- Setting `group_wait` and `group_interval` to 15s (alerts should be all at 6:00, but catching a possible delay when fetching data)
- Increasing `repeat_interval` to 2h, making sure not te check inside 6am hour again