### PR TITLE
feat: Enhance retention configuration

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -41,3 +41,7 @@ spec:
       replicas: 3
     queryFrontendMemcached:
       replicas: 3
+    retentionConfig:
+      retentionResolutionRaw: 30d   # default is 30d
+      retentionResolution5m: 90d    # default is 180d
+      retentionResolution1h: 180d   # default is 0d


### PR DESCRIPTION
closes https://github.com/nerc-project/operations/issues/353
- https://github.com/nerc-project/operations/issues/353

Updated the MultiClusterObservability configuration to specify retention periods for different data resolutions.
Issue 353 defined smaller periods, based on smaller default assumptions.
This PR sets the [defaults](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/apis/apis#rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability) (raw: 30d & 5m: 90d) and recommendations/requests (1h: 180d).

Changes include:
- Added `retentionConfig` with specific retention periods for `resolutionRaw`, `resolution5m`, and `resolution1h`.