### PR TITLE
refactor: adjust 6am alerts grouping settings

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -90,10 +90,10 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
-                group_by: ['team']
-                group_wait: 15s
-                group_interval: 15s
-                repeat_interval: 2h
+                group_by: [team]
+                group_wait: 45s
+                group_interval: 45s
+                repeat_interval: 1m
                 # repeat_interval cannot be zero, group_interval cannot be zero
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
Updated the `group_by`, `group_wait`, `group_interval`, and `repeat_interval` settings for `slack-notifications-prod-rhods-ope` in `externalsecret.yaml`.

- `group_by` modified from ['team'] to [team] for consistent syntax.
- Increased `group_wait` and `group_interval` to 45s to catch delayed metrics.
- Decreased `repeat_interval` to 1m in case a metric delivery got stucked and would not be caught by the first grouping.