### PR TITLE
fix: typo in regex for argocd metrics

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -24,4 +24,4 @@ data:
       - __name__=~"(log_.*)"
       - __name__=~"(gpu_operator_.*)"
       - __name__=~"(DCGM_FI_.*)"
-      - __name__=~"(argoc_.*)"
+      - __name__=~"(argocd_.*)"


### PR DESCRIPTION
follow up on typo in https://github.com/OCP-on-NERC/nerc-ocp-config/pull/427
`name=~"(argoc_.*)"` to `name=~"(argocd_.*)"`

thanks to @computate