### PR TITLE
Fix patroni config for postgres

### DIFF
--- a/curator/base/configmaps/kustomization.yaml
+++ b/curator/base/configmaps/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - postgres-config.yaml

--- a/curator/base/configmaps/postgres-config.yaml
+++ b/curator/base/configmaps/postgres-config.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: postgres-config
-  namespace: koku-metrics-config
-data:
-  pg_hba.conf: |
-    host all all 0.0.0.0/0 md5

--- a/curator/base/kustomization.yaml
+++ b/curator/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: curator-system
 resources:
-  - configmaps
   - deployments
   - externalsecrets
   - postgrescluster

--- a/curator/base/postgrescluster/cluster.yaml
+++ b/curator/base/postgrescluster/cluster.yaml
@@ -37,7 +37,7 @@ spec:
     dynamicConfiguration:
       postgresql:
         pg_hba:
-          - postgres-config
+        - host      all  all  0.0.0.0/0   md5
     leaderLeaseDurationSeconds: 30
     port: 8008
     switchover:


### PR DESCRIPTION
The postgres resource was not allowing a config map to be passed.
Removed config map and added config to postgres manifest.