### PR TITLE
fix: 6am status not showing each percentage

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -90,10 +90,8 @@ spec:
                 matchers:
                   - alertname =~ "(CustomOpeLimitsCpu)"
               - receiver: slack-notifications-prod-rhods-ope
-                group_by: [team]
-                group_wait: 45s
-                group_interval: 45s
-                repeat_interval: 1m
+                group_by: ['...']
+                group_wait: 0s
                 # repeat_interval cannot be zero, group_interval cannot be zero
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"


### PR DESCRIPTION
The grouping by org and time reduced the alerts too much. Removing the grouping by team.