### PR TITLE
fix: increase storememcache to support #473

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -38,6 +38,7 @@ spec:
     store:
       replicas: 3
     storeMemcached:
+      connectionLimit: 2048
       replicas: 3
     queryFrontendMemcached:
       replicas: 3


### PR DESCRIPTION
- Working on https://github.com/nerc-project/operations/issues/473.
- Following https://access.redhat.com/solutions/7050015.
- ACM Observability Thanos Memcached Pods are showing: Too many open connections.

Increasing it to 2048 manually solved the Too Many Open Connections for the last two days and brought all observability-thanos-store-memcached-x and observability-thanos-store-shard-x-0 in a running state.

Now, adding it to the gitops config.