### PR TITLE
Add Ansible Automation Platform Operator bundle to nerc-ocp-test overlay

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
 resources:
 - clusterversion.yaml
 - ../common
+- ../../bundles/ansible-automation-platform-operator
 - ../../bundles/koku-metrics-operator
 - ../../bundles/curator
 - ../../bundles/patch-operator


### PR DESCRIPTION
This commit is related to: https://github.com/nerc-project/operations/issues/537 Adding the aap operator to the test cluster to to match the prod software list