### PR TITLE
Deploy operators to test cluster to match prod and test cluster software

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
 - ../../bundles/rhods-operator
 - ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
+- ../../bundles/openshift-custom-metrics-autoscaler-operator
+- ../../bundles/openshift-serverless-operator
+- ../../bundles/openshift-opentelemetry-operator
 - feature/odf
 - machineconfigs/disable-net-ifnames
 - machineconfigs/udev-rules


### PR DESCRIPTION
Installs 5 operators accorording to the list marked not installed in: https://github.com/nerc-project/operations/issues/537 These are the final operators that were missing from test cluster

Operators installed are:

1. tempo-product.openshift-tempo-operator
2. opentelemetry-product.openshift-opentelemetry-operator
3. red-hat-camel-k.openshift-operators
4. serverless-operator.openshift-serverless
5. openshift-custom-metrics-autoscaler-operator.openshift-keda