### PR TITLE
test cluster: Upgrade cluster to OCP version 4.13.40

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.13
   desiredUpdate:
-    version: 4.13.13
+    version: 4.13.40
   clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72


### PR DESCRIPTION
This is the first step of our upgrade path en route to OCP v4.15

This update includes only bug fixes and security updates, so no deprecated apis or anything to consider.

![upgrade-path](https://github.com/OCP-on-NERC/nerc-ocp-config/assets/84931428/532e993f-334a-4629-b55e-763859e65f6c)
