### PR TITLE
Start importing hypershift1 cluster to nerc-ocp-config

### DIFF
--- a/acm/overlays/nerc-ocp-infra/clusters/hypershift1/klusterletaddonconfig.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/hypershift1/klusterletaddonconfig.yaml
@@ -1,0 +1,23 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: hypershift1
+  namespace: hypershift1
+spec:
+  clusterName: hypershift1
+  clusterNamespace: hypershift1
+  clusterLabels:
+    name: hypershift1
+    cloud: auto-detect
+    vendor: auto-detect
+    cluster.open-cluster-management.io/clusterset: default
+  applicationManager:
+    enabled: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true

--- a/acm/overlays/nerc-ocp-infra/clusters/hypershift1/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/hypershift1/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - nerc-ocp-prod
-  - nerc-ocp-test
-  - nerc-ocp-obs
-  - hypershift1
+- klusterletaddonconfig.yaml
+- managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/hypershift1/managedcluster.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/hypershift1/managedcluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: hypershift1
+  labels:
+    name: hypershift1
+    cloud: BareMetal
+    vendor: OpenShift
+    cluster.open-cluster-management.io/clusterset: argocd-managed
+  annotations: {}
+spec:
+  hubAcceptsClient: true

--- a/cluster-scope/overlays/hypershift1/clusterversion.yaml
+++ b/cluster-scope/overlays/hypershift1/clusterversion.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.15
+  clusterID: 2246c137-f5bf-45fb-b4f6-ccee7949273f

--- a/cluster-scope/overlays/hypershift1/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- clusterversion.yaml


### PR DESCRIPTION
This pull request begins the process of adding the `hypershift1` cluster to nerc-ocp-config by (a) adding it to ACM and (b) adding a stub `cluster-scope` overlay so that we can create an app in `nerc-ocp-apps`.