### PR TITLE
Upgrade test cluster from 4.13.40 -> 4.14.21

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.13
+  channel: stable-4.14
   desiredUpdate:
-    version: 4.13.40
+    version: 4.14.21
   clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -35,6 +35,7 @@ configMapGenerator:
   literals:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
+    - ack-4.13-kube-1.27-api-removals-in-4.14=true
 
 patches:
 - target:


### PR DESCRIPTION
Reviewed OCP 4.14 upgrade and evaluated in this issue: [https://github.com/nerc-project/operations/issues/286](https://github.com/nerc-project/operations/issues/286)