### PR TITLE
obs keycloak permissions

### DIFF
--- a/cluster-scope/base/core/namespaces/prom-keycloak-proxy/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/prom-keycloak-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/prom-keycloak-proxy/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/prom-keycloak-proxy/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prom-keycloak-proxy
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rhbk-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rhbk-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rhbk-operator
   namespace: keycloak
 spec:
-  channel: stable-v22
+  channel: stable-v24
   installPlanApproval: Automatic
   name: rhbk-operator
   source: redhat-operators

--- a/cluster-scope/bundles/keycloak/kustomization.yaml
+++ b/cluster-scope/bundles/keycloak/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
-  nerc.mghpcc.org/bundle: logging
+  nerc.mghpcc.org/bundle: keycloak
 resources:
 - ../../base/core/namespaces/keycloak
 - ../../base/operators.coreos.com/operatorgroups/keycloak

--- a/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
+++ b/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: prom-keycloak-proxy
+resources:
+- ../../base/core/namespaces/prom-keycloak-proxy

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ../../bundles/grafana
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/keycloak
+- ../../bundles/prom-keycloak-proxy
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/core/namespaces/dex
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac

--- a/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
@@ -16,13 +16,37 @@ spec:
   realm:
     id: NERC
     clients:
-      - id: ai4cloudops
+      - id: nerc
         authorizationSettings:
+          scopes:
+
+            - id: namespace-all
+              name: all namespaces
+              displayName: all namespaces
+            - id: namespace-rhods-notebooks
+              name: rhods-notebooks
+              displayName: rhods-notebooks namespace
+
+            - id: cluster-all
+              name: all clusters
+              displayName: all clusters
+            - id: cluster-nerc-ocp-infra
+              name: nerc-ocp-infra
+              displayName: nerc-ocp-infra cluster
+            - id: cluster-nerc-ocp-obs
+              name: nerc-ocp-obs
+              displayName: nerc-ocp-obs cluster
+            - id: cluster-nerc-ocp-prod
+              name: nerc-ocp-prod
+              displayName: nerc-ocp-prod cluster
+            - id: cluster-nerc-ocp-test
+              name: nerc-ocp-test
+              displayName: nerc-ocp-test cluster
+
           resources:
             - name: cluster
               displayName: cluster
               scopes:
-
                 - id: cluster-all
                   name: all clusters
                   displayName: all clusters
@@ -50,6 +74,16 @@ spec:
                   displayName: rhods-notebooks namespace
 
           policies:
+
+            - id: group-nerc-ops
+              name: group-nerc-ops
+              logic: POSITIVE
+              decisionStrategy: UNANIMOUS
+              type:
+                group:
+                  groups:
+                    - id: nerc-ops
+
             - id: client-ai4cloudops
               name: client-ai4cloudops
               logic: POSITIVE
@@ -66,39 +100,43 @@ spec:
                 group:
                   groups:
                     - id: nerc-ai4cloudops
-            - id: group-nerc-ops
-              name: group-nerc-ops
+
+            - id: client-oct
+              name: client-oct
               logic: POSITIVE
               decisionStrategy: UNANIMOUS
               type:
-                group:
-                  groups:
-                    - id: nerc-ops
+                client:
+                  clients:
+                    - oct
 
           permissions:
+
             - name: group-nerc-ops-cluster-all
-              client: ai4cloudops
               policy: group-nerc-ops
               resource: cluster
             - name: group-nerc-ops-namespace-all
-              client: ai4cloudops
               policy: group-nerc-ops
               resource: namespace
+
             - name: group-nerc-ai4cloudops-namespace-all
-              client: ai4cloudops
               policy: group-nerc-ai4cloudops
               resource: namespace
             - name: client-ai4cloudops-namespace-all
-              client: ai4cloudops
               policy: client-ai4cloudops
               resource: namespace
             - name: group-nerc-ai4cloudops-cluster-nerc-ocp-prod
-              client: ai4cloudops
               policy: group-nerc-ai4cloudops
               resource: cluster
               scope: nerc-ocp-prod
             - name: client-ai4cloudops-cluster-nerc-ocp-prod
-              client: ai4cloudops
               policy: client-ai4cloudops
               resource: cluster
               scope: nerc-ocp-prod
+
+            - name: client-oct-namespace-all
+              policy: client-oct
+              resource: namespace
+            - name: client-oct-cluster-all
+              policy: client-oct
+              resource: cluster

--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -277,6 +277,19 @@ spec:
     defaultDefaultClientScopes:
       - nerc
     clients:
+      - id: nerc
+        clientId: nerc
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        authorizationServicesEnabled: true
+        frontchannelLogout: true
+        protocol: openid-connect
+        redirectUris: []
+        defaultClientScopes:
+          - profile
+          - ai4cloudops
+        authorizationSettings:
+          decisionStrategy: AFFIRMATIVE
       - id: ai4cloudops
         clientId: ai4cloudops
         standardFlowEnabled: true
@@ -284,15 +297,25 @@ spec:
         authorizationServicesEnabled: true
         frontchannelLogout: true
         protocol: openid-connect
-        redirectUris:
-          - http://localhost:12080/logout
-          - http://localhost:12080/callback
+        redirectUris: []
         defaultClientScopes:
           - profile
           - ai4cloudops
         authorizationSettings:
           decisionStrategy: AFFIRMATIVE
-
+      - id: oct
+        clientId: oct
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        authorizationServicesEnabled: true
+        frontchannelLogout: true
+        protocol: openid-connect
+        redirectUris: []
+        defaultClientScopes:
+          - profile
+          - oct
+        authorizationSettings:
+          decisionStrategy: AFFIRMATIVE
   instanceSelector:
     matchLabels:
       app: keycloak

--- a/keycloak/overlays/nerc-ocp-obs/keycloaks/keycloak/keycloak.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloaks/keycloak/keycloak.yaml
@@ -6,10 +6,6 @@ metadata:
     app: keycloak
 spec:
   instances: 2
-  externalAccess:
-    enabled: true
-  externalDatabase:
-    enabled: true
   db:
     vendor: postgres
     host: postgres-primary

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prom-keycloak-proxy/

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/prom-keycloak-proxy/deployment.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/prom-keycloak-proxy/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-keycloak-proxy
+  namespace: prom-keycloak-proxy
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: prom-keycloak-proxy
+    spec:
+      containers:
+        - name: prom-keycloak-proxy
+          envFrom:
+            - secretRef:
+                name: prom-keycloak-proxy-secrets
+          env:
+            - name: PROXY_AUTH_REALM
+              value: NERC
+            - name: PROXY_AUTH_BASE_URL
+              value: https://keycloak.apps.obs.nerc.mghpcc.org
+            - name: PROXY_AUTH_TLS_VERIFY
+              value: 'true'
+            - name: PROXY_PROMETHEUS_CA_CRT
+              value: /opt/prom-keycloak-proxy-certs/ca.crt
+            - name: PROXY_PROMETHEUS_TLS_CRT
+              value: /opt/prom-keycloak-proxy-certs/tls.crt
+            - name: PROXY_PROMETHEUS_TLS_KEY
+              value: /opt/prom-keycloak-proxy-certs/tls.key
+          image: quay.io/nerc-images/prom-keycloak-proxy:1.0.1
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/curl
+                - http://localhost:8080
+            failureThreshold: 6
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/curl
+                - http://localhost:8080
+            failureThreshold: 6
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: '1'
+          volumeMounts:
+            - mountPath: /opt/prom-keycloak-proxy-certs
+              name: prom-keycloak-proxy-certs
+              readOnly: true
+      volumes:
+        - name: prom-keycloak-proxy-certs
+          secret:
+            secretName: prom-keycloak-proxy-certs
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/prom-keycloak-proxy/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/deployments/prom-keycloak-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prom-keycloak-proxy-certs/
+  - prom-keycloak-proxy-secrets/

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-certs/externalsecret.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-certs/externalsecret.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prom-keycloak-proxy-certs
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: prom-keycloak-proxy-certs
+  dataFrom:
+  - extract:
+      key: nerc/nerc-ocp-obs/prom-keycloak-proxy/certs

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-certs/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-certs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- externalsecret.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-secrets/externalsecret.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-secrets/externalsecret.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prom-keycloak-proxy-secrets
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: prom-keycloak-proxy-secrets
+  dataFrom:
+  - extract:
+      key: nerc/nerc-ocp-obs/prom-keycloak-proxy/secrets

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-secrets/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/externalsecrets/prom-keycloak-proxy-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- externalsecret.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prom-keycloak-proxy
+commonLabels:
+  app: prom-keycloak-proxy
+  deployment: prom-keycloak-proxy
+
+resources:
+  - externalsecrets/
+  - deployments/
+  - services/
+  - routes/

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prom-keycloak-proxy/

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/prom-keycloak-proxy/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/prom-keycloak-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - route.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/prom-keycloak-proxy/route.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/routes/prom-keycloak-proxy/route.yaml
@@ -1,0 +1,16 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: prom-keycloak-proxy
+spec:
+  host: metrics.apps.obs.nerc.mghpcc.org
+  to:
+    kind: Service
+    name: prom-keycloak-proxy
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prom-keycloak-proxy/

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/prom-keycloak-proxy/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/prom-keycloak-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/prom-keycloak-proxy/service.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/services/prom-keycloak-proxy/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prom-keycloak-proxy
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: prom-keycloak-proxy
+    deployment: prom-keycloak-proxy
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
- **Upgrade Keycloak operator version from v22 to latest v24**
- **Adding prom-keycloak-proxy to obs cluster**
- Adding a new `nerc` client to Keycloak to contain all of the authorization resources, scopes, policies, and permissions to query against with prom-keycloak-proxy. 
- Add `ai4cloudops` and `oct` clients linked to their client permissions in the `nerc` client authorization configuration.
- Add the prom-keycloak-proxy Deployment, Service, Route, and ExternalSecrets already configured in vault to connect to Keycloak and ACM Observatorium on the infra cluster. 
- Find the [repo and docs about the prom-keycloak-proxy here](https://github.com/nerc-images/prom-keycloak-proxy).
- See the [keycloak-permissions-operator in ](https://operatorhub.io/operator/keycloak-permissions-operator)[operatorhub.io](http://operatorhub.io/), and it's also available in all OpenShift Cluster Operator Hubs.
- Find the [repo and docs about the keycloak-permissions-operator here](https://github.com/nerc-images/keycloak-permissions-operator).

closes nerc-project/operations#493