### PR TITLE
test cluster: Fix alert manager config

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,15 @@
+prometheusK8s:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: ocs-external-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 100Gi
+alertmanagerMain:
+  enabled: true
+  volumeClaimTemplate:
+    spec:
+      storageClassName: ocs-external-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 20Gi

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -36,6 +36,10 @@ configMapGenerator:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
     - ack-4.13-kube-1.27-api-removals-in-4.14=true
+- files:
+  - config.yaml=configmaps/cluster-monitoring-config.yaml
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
 
 patches:
 - target:


### PR DESCRIPTION
Upgrading the test cluster to OCP 4.14 broke our cluster alerting setup since we didnt explicitely hand cluster-monitoring-config cm. All values were overwritten to null. Adding this configMap to the test cluster overlay eliminates this issue