### PR TITLE
test cluster: upgrade cluster v4.14.21 -> v4.15.11

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.14
+  channel: stable-4.15
   desiredUpdate:
-    version: 4.14.21
+    version: 4.15.11
   clusterID: f43ef758-01e7-42f8-9474-aaeb53188d72


### PR DESCRIPTION
This PR is related to issues:
https://github.com/nerc-project/operations/issues/527 https://github.com/nerc-project/operations/issues/286

There is no need to provide admin ack for k8s api removals as none are removed in this upgrade: https://docs.openshift.com/container-platform/4.15/updating/preparing_for_updates/updating-cluster-prepare.html#kube-api-removals_updating-cluster-prepare