### PR TITLE
test cluster: Move odf update channel stable 4.13 -> stable 4.15

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.14
+    channel: stable-4.15


### PR DESCRIPTION
OLM cluster operator is reporting as failing since odf 4.14 isn't compatible with OCP 4.15.11, this will alleviate that condition