### PR TITLE
obs keycloak permissions

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -316,6 +316,3 @@ spec:
           - oct
         authorizationSettings:
           decisionStrategy: AFFIRMATIVE
-  instanceSelector:
-    matchLabels:
-      app: keycloak


### PR DESCRIPTION
- **Remove the obsolete instanceSelector from KeycloakRealmImport**
Removing the obsolete KeycloakRealmImport instanceSelector from previous
versions of the Keycloak operator to resolve sync issues in ArgoCD. 
