### PR TITLE
Remove startingCSV field from nfd sub

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/node-feature-discovery/subscription.yaml
@@ -8,4 +8,3 @@ spec:
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: nfd.4.10.0-202306170106


### PR DESCRIPTION
The infra and obs cluster are having problems getting the nfd operator running. 

```'Warning' reason: 'ResolutionFailed' constraints not satisfiable: no operators found with name nfd.4.10.0-202306170106 in channel stable of package nfd in the catalog referenced by subscription nfd, subscription nfd exists```

Removing the startingCSV field from the subscription should remedy this.
[Issue](https://github.com/nerc-project/operations/issues/599)