### PR TITLE
Disable rhods-notebooks RHOAI notebook server in nerc-ocp-prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -49,7 +49,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: true
+    enabled: false
     notebookNamespace: rhods-notebooks
     pvcSize: 1Gi
   notebookSizes:


### PR DESCRIPTION
This PR toggles off the rhods-notebooks notebook server in nerc-ocp-prod. By leaving it enabled, any OCP user with access to RHOAI can deploy notebooks here (accidentally or intentionally), as opposed to in their data science projects directly. 

With RHOAI in prod not currently hosting any courses we should disable for now.