### PR TITLE
nerc-ocp-infra: Upgrade cluster to OCP v4.13.41

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.13
   desiredUpdate:
-    version: 4.13.13
+    version: 4.13.41
   clusterID: b3c6e302-f119-4adb-bc48-e04c6aa2eaa5


### PR DESCRIPTION
This is the first step in upgrading the nerc-ocp-infra cluster:

![Screenshot from 2024-06-11 15-02-27](https://github.com/OCP-on-NERC/nerc-ocp-config/assets/84931428/ee21a083-f650-43c4-8656-702d583bbb5b)

Related to this issue: [605](https://github.com/nerc-project/operations/issues/605)