### PR TITLE
ocp-infra: upgrade to latest stable 4.13.43

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.13
   desiredUpdate:
-    version: 4.13.41
+    version: 4.13.43
   clusterID: b3c6e302-f119-4adb-bc48-e04c6aa2eaa5


### PR DESCRIPTION
While working on adding 3x worker nodes to nerc-ocp-infra I noticed that the image registry operator was degraded due to failed jobs which prevented the upgrade in #452 from happening. After deleting those jobs, it appears that version has been removed:
```
$ oc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.13.13   True        False         262d    Stopped at 4.13.13: the cluster version is invalid
```

The 4.13.41 version is no longer available in the stable-4.13 at this point and the latest version is now 4.13.43