### PR TITLE
Set observability memcached connection limit to 4096

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -38,7 +38,7 @@ spec:
     store:
       replicas: 3
     storeMemcached:
-      connectionLimit: 2048
+      connectionLimit: 4096
       replicas: 3
     queryFrontendMemcached:
       replicas: 3


### PR DESCRIPTION
After adding the 3 new worker nodes, the [observability-thanos-store-memcached pods](https://console-openshift-console.apps.nerc-ocp-infra.rc.fas.harvard.edu/k8s/ns/open-cluster-management-observability/pods/observability-thanos-store-memcached-0/logs) are again showing the logs:

```
accept4(): Too many open files
Too many open connections
```

So we will set observability memcached connection limit to 4096, see the [Red Hat Solution for this error](https://access.redhat.com/solutions/7050015).