### PR TITLE
Adding 10TiB object storage to prod for user projects

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
 - certificates
 - consolelinks
 - odhdashboardconfigs
+- object-storage
 
 components:
   - ../../components/nerc-oauth-keycloak

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/backingstore.yaml
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: object-backing-store
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 1
+    resources:
+      requests:
+        storage: 10Ti
+    storageClass: ocs-external-storagecluster-ceph-rbd
+  type: pv-pool

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/bucketclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/bucketclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: object-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - object-backing-store

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: noobaa
+resources:
+- backingstore.yaml
+- bucketclass.yaml
+- storageclass.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/storageclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/storageclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    description: Provides Object Bucket Claims (OBCs) specifically for user projects
+  name: object-bucket-storage
+parameters:
+  bucketclass: object-bucket-class
+provisioner: openshift-storage.noobaa.io/obc
+reclaimPolicy: Delete
+volumeBindingMode: Immediate


### PR DESCRIPTION
The default noobaa-default-backing-store was created too small (1 50Gi volume, max 20 50Gi volumes = 1Ti). We will create a larger object-backing-store with 1 10Ti volume up to 20.

Closes nerc-project/operations#222
