### PR TITLE
nerc-ocp-infra: OCP upgrade 4.13.43 -> 4.14.28

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.13
+  channel: stable-4.14
   desiredUpdate:
-    version: 4.13.43
+    version: 4.14.28
   clusterID: b3c6e302-f119-4adb-bc48-e04c6aa2eaa5

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -45,6 +45,7 @@ configMapGenerator:
   literals:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
+    - ack-4.13-kube-1.27-api-removals-in-4.14=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
Part of issue: [https://github.com/nerc-project/operations/issues/605](https://github.com/nerc-project/operations/issues/605)

Move update channel from 4.13 -> 4.14 and provide admin acks for the OCP upgrade.