### PR TITLE
Add overlay for nerc-ocp-test-2

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test-2/certificates/default-api-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/certificates/default-api-certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: default-api-certificate
+  namespace: openshift-config
+spec:
+  issuerRef:
+    name: letsencrypt-production-dns01
+    kind: Issuer
+  secretName: default-api-certificate
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
+  dnsNames:
+    - "api.nerc-ocp-test-2.nerc.mghpcc.org"

--- a/cluster-scope/overlays/nerc-ocp-test-2/certificates/default-ingress-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/certificates/default-ingress-certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: default-ingress-certificate
+  namespace: openshift-config
+spec:
+  issuerRef:
+    name: letsencrypt-production-dns01
+    kind: Issuer
+  secretName: default-ingress-certificate
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
+  dnsNames:
+    - "*.apps.nerc-ocp-test-2.nerc.mghpcc.org"

--- a/cluster-scope/overlays/nerc-ocp-test-2/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/certificates/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- default-api-certificate.yaml
+- default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/externalsecrets/github-group-sync.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/externalsecrets/github-group-sync.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-group-sync
+  namespace: group-sync-operator
+spec:
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  target:
+    name: github-group-sync
+  data:
+  - secretKey: appId
+    remoteRef:
+      key: nerc/nerc-ocp-test-2/group-sync-operator/github-group-sync-token
+      property: appId
+  - secretKey: privateKey
+    remoteRef:
+      key: nerc/nerc-ocp-test-2/group-sync-operator/github-group-sync-token
+      property: privateKey

--- a/cluster-scope/overlays/nerc-ocp-test-2/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/externalsecrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namespace: openshift-storage
+spec:
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  target:
+    name: rook-ceph-external-cluster-details
+  data:
+  - secretKey: external_cluster_details
+    remoteRef:
+      key: nerc/nerc-ocp-test-2/openshift-storage/rook-ceph-external-cluster-details
+      property: external_cluster_details

--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+
+components:
+  - ../../../../components/nerc-secret-store
+
+resources:
+  - ../../../../bundles/odf-external
+  - externalsecrets/rook-ceph-external-cluster-details.yaml
+  - redhatcop.redhat.io/odf-node-patcher.yaml
+
+patches:
+  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/redhatcop.redhat.io/odf-node-patcher.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/redhatcop.redhat.io/odf-node-patcher.yaml
@@ -1,0 +1,21 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  name: odf-node-label-workers
+  namespace: openshift-storage
+spec:
+  serviceAccountRef:
+    name: patcher
+  patches:
+    odf-node-label-workers:
+      targetObjectRef:
+        apiVersion: v1
+        kind: Node
+        labelSelector:
+          matchLabels:
+            node-role.kubernetes.io/worker: ""
+      patchType: application/strategic-merge-patch+json
+      patchTemplate: |
+        metadata:
+          labels:
+            "cluster.ocs.openshift.io/openshift-storage": ""

--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
@@ -1,0 +1,17 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-external-storagecluster-ceph-rbd
+parameters:
+  clusterID: openshift-storage
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: moc-rbd-openshift-test2

--- a/cluster-scope/overlays/nerc-ocp-test-2/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/issuers/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- openshift-config
+- openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-test-2/issuers/openshift-config/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/issuers/openshift-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+components:
+  - ../../../../components/nerc-certificate-issuer

--- a/cluster-scope/overlays/nerc-ocp-test-2/issuers/openshift-ingress/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/issuers/openshift-ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress
+components:
+  - ../../../../components/nerc-certificate-issuer

--- a/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
@@ -1,0 +1,69 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../common
+- ../../bundles/node-feature-discovery
+- ../../bundles/patch-operator
+- ../../bundles/clusterissuer-http01
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+- ../../base/core/namespaces/openshift-gitops
+- externalsecrets
+- issuers
+- feature/odf
+- certificates
+- nodenetworkconfigurationpolicies
+- secretstores
+
+components:
+  - ../../components/nerc-oauth-github
+
+  # this must come last in order to apply
+  # to all resources.
+  - ../../components/argocd-skip-dryrun
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+
+- patch: |
+    apiVersion: config.openshift.io/v1
+    kind: OAuth
+    metadata:
+      name: cluster
+    spec:
+      identityProviders:
+      - name: github
+        github:
+          clientID: Ov23liGZVyeMB2D96Wiq
+- target:
+    kind: ExternalSecret
+    name: github-client-secret
+  patch: |
+    - op: replace
+      path: /spec/data/0/remoteRef/key
+      value: nerc/nerc-ocp-test-2/openshift-config/github-client-secret
+
+- target:
+    kind: SecretStore
+  patch: |
+    - op: replace
+      path: /spec/provider/vault/auth/kubernetes/mountPath
+      value: kubernetes/nerc-ocp-test-2
+- target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+  patch: |
+    - op: replace
+      path: /spec/dataFrom/0/extract/key
+      value: nerc/nerc-ocp-test-2/aws-route53-credentials
+- target:
+    kind: APIServer
+    name: cluster
+  patch: |
+    - op: replace
+      path: /spec/servingCerts/namedCertificates/0/names/0
+      value: api.nerc-ocp-test-2.nerc.mghpcc.org

--- a/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/eth-nese.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/eth-nese.yaml
@@ -1,0 +1,17 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: eth-nese
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+    - name: eno2
+      type: ethernet
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+        auto-routes: true
+      mtu: 9000

--- a/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- eth-nese.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/secretstores/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/secretstores/group-sync-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: group-sync-operator
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-test-2/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/secretstores/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- openshift-config
+- openshift-ingress
+- openshift-logging
+- group-sync-operator

--- a/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-config/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-ingress/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-logging/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/secretstores/openshift-logging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-logging
+components:
+  - ../../../../components/nerc-secret-store


### PR DESCRIPTION
Add overlay for the new test cluster created using the [templates](https://github.com/tssala23/nerc-cluster-templating/tree/work). Variables used in the template:
```
clusters:
  - name: nerc-ocp-test-2
    address_type: external
    access_type: public
    oauth: [github]
    githubClientID: Ov23liGZVyeMB2D96Wiq
    keycloakClientID:
    vlanID: 211
    cephstoragePool: moc-rbd-openshift-test2
    apiCertDuration: 2160h0m0s
    apiCertRenewBefore: 360h0m0s
    apiCertDnsName: api.nerc-ocp-test-2.nerc.mghpcc.org
    ingressCertDuration: 2160h0m0s
    ingressCertRenewBefore: 360h0m0s
    ingressCertDnsName: "*.apps.nerc-ocp-test-2.nerc.mghpcc.org"
```