### PR TITLE
feat: Update retention and concurrency for Thanos

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -43,6 +43,13 @@ spec:
     queryFrontendMemcached:
       replicas: 3
     retentionConfig:
-      retentionResolutionRaw: 30d   # default is 30d
-      retentionResolution5m: 90d    # default is 180d
-      retentionResolution1h: 180d   # default is 0d
+      blockDuration: 2h               # default is 2h
+      cleanupInterval: 5m             # default is 5m
+      deleteDelay: 48h                # default is 48h
+      retentionInLocal: 24h           # default is 24h
+      retentionResolutionRaw: 90d     # default is 30d
+      retentionResolution5m: 360d     # default is 180d
+      retentionResolution1h: 0d       # default is 0d - 0d will retain samples of this resolution forever https://thanos.io/tip/components/compact.md/
+      consistencyDelay: 30m
+      compactConcurrency: 6
+      downsampleConcurrency: 6


### PR DESCRIPTION

- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/462
- https://github.com/nerc-project/operations/issues/618

---

This PR addresses the retention rate issues as discussed in https://github.com/nerc-project/operations/issues/618#issuecomment-2196549051 (having more than 30d raw etc.).
The changes include updating the retention and concurrency settings for the Thanos Compactor to enhance observability and metrics performance.
We will stay with the defaults where possible, adding remarks with the defaults to better understand the next changes or possible errors.

Changes to focus on the needs for class, cost, and invoice analysis, as for future predictions:
- Updated `retentionResolutionRaw` from 30d to 90d (quarterly high details for deep analysis, especially GPUs)
- Updated `retentionResolution5m` from 90d to 360d (for cost, usage, and invoices; 15 minutes could be enough, but is not a default option)
- Set `retentionResolution1h` to 0d (retain forever, following the default and recommendation)
- Added `blockDuration`, `cleanupInterval`, `deleteDelay`, `retentionInLocal`, `consistencyDelay`, `compactConcurrency`, and `downsampleConcurrency` settings: even if staying in the default, making the options visible in case of possible future changes)

These changes aim to optimize data retention & resolution for needed use cases and ensure better performance.

References:
1. [Thanos Compact Component](https://thanos.io/tip/components/compact.md/)
2. [Recommendations for Running Thanos and Prometheus](https://zapier.com/blog/five-recommendations-when-running-thanos-and-prometheus/)
3. [Red Hat Advanced Cluster Management Observability](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/observability/customizing-observability#adding-advanced-config:~:text=is%20not%20displayed.-,4.3.%C2%A0Adding%20advanced%20configuration%20for%20retention,-Add%20the%20advanced)