### PR TITLE
feat: Add ACM metrics storage 1Ti

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/backingstore.yaml
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: acm-metrics-backing-store
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 1
+    resources:
+      requests:
+        storage: 1Ti
+    storageClass: ocs-external-storagecluster-ceph-rbd
+  type: pv-pool

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/bucketclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/bucketclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: acm-metrics-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - acm-metrics-backing-store

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: noobaa
+resources:
+- backingstore.yaml
+- bucketclass.yaml
+- storageclass.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/storageclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/storageclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    description: Provides Object Bucket Claims (OBCs) for ACM metrics
+  name: acm-metrics-bucket-storage
+parameters:
+  bucketclass: acm-metrics-bucket-class
+provisioner: openshift-storage.noobaa.io/obc
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - grafana-dashboards
 - persistentvolumeclaims
 - nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
+- acm-metrics-storage
 
 components:
   - ../../components/nerc-oauth-github


### PR DESCRIPTION
- Added ACM metrics storage configuration under nerc-ocp-infra
- backingstore, bucketclass, kustomization, storageclass
- 1Vol for first test, 1Ti for future scalibility through changing volumes