### PR TITLE
nerc-ocp-infra: upgrade OCP 4.14.28 -> 4.15.16

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.14
+  channel: stable-4.15
   desiredUpdate:
-    version: 4.14.28
+    version: 4.15.16
   clusterID: b3c6e302-f119-4adb-bc48-e04c6aa2eaa5


### PR DESCRIPTION
There is no admin ack required for this upgrade, since no apis are removed