### PR TITLE
feat: Add odf subscription patch for nerc-ocp-infra overlay

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+
+commonLabels:
+  nerc.mghpcc.org/feature: odf
+
+resources:
+  - ../../../../bundles/odf-external
+
+patches:
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/odf/subscriptions/subscription-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.15

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 - ../../bundles/acm-observability
 - ../../bundles/hostpath-provisioner
 - ../../bundles/patch-operator
-- ../../bundles/odf-external
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/multicluster-engine-operator
 - ../../bundles/grafana
@@ -19,6 +18,7 @@ resources:
 - ../../base/core/namespaces/nerc-ocp-obs
 - ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
 - ../../base/operators.coreos.com/subscriptions/loki-operator
+- feature/odf
 - clusterversion.yaml
 - machineconfigs/disable-net-ifnames.yaml
 - machineconfigs/refresh-storage-interface.yaml


### PR DESCRIPTION
The infra cluster was upgraded to OCP 4.15 in #464 
The odf operator needs it's channel updated to 4.15 as a result
This PR adds the odf-external bundle through a feature dir
 and adds a patch to allow for easy odf subscription changes like the other clusters have
