### PR TITLE
Add fake metrics endpoint for nerc-ocp-test-2

### DIFF
--- a/fake-metrics-server/overlays/nerc-ocp-test-2/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-test-2/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+resources:
+- ../nerc-ocp-infra


### PR DESCRIPTION
Add nerc-ocp-test-2 overlay to fake-metrics-server dir.
This is to make the ODF operator happy.
