### PR TITLE
Add default Keycloak openid scope to obs NERC realm and clients

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -82,6 +82,13 @@ spec:
         - id: cluster-admin
           name: cluster-admin
     clientScopes:
+      - id: openid
+        name: openid
+        description: The userinfo request will reject access tokens that do not have the openid scope
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: 'true'
+          display.on.consent.screen: 'true'
       - id: nerc
         name: nerc
         description: A client scope for the nerc client
@@ -288,8 +295,9 @@ spec:
         protocol: openid-connect
         redirectUris: []
         defaultClientScopes:
+          - openid
           - profile
-          - ai4cloudops
+          - nerc
         authorizationSettings:
           decisionStrategy: AFFIRMATIVE
       - id: ai4cloudops
@@ -301,6 +309,7 @@ spec:
         protocol: openid-connect
         redirectUris: []
         defaultClientScopes:
+          - openid
           - profile
           - ai4cloudops
         authorizationSettings:
@@ -314,6 +323,7 @@ spec:
         protocol: openid-connect
         redirectUris: []
         defaultClientScopes:
+          - openid
           - profile
           - oct
         authorizationSettings:
@@ -327,6 +337,7 @@ spec:
         protocol: openid-connect
         redirectUris: []
         defaultClientScopes:
+          - openid
           - profile
           - kruizeoptimization
         authorizationSettings:


### PR DESCRIPTION
Add default Keycloak openid scope to obs NERC realm and clients

This relates to the latest updates in the prom-keycloak-proxy that check
the userinfo realm endpoint for the username of the user making requests
with their Authorization header bearer token. We add the openid scope
to all clients in the realm, which is required for using the userinfo
endpoint to check the username of an access token.

See https://github.com/keycloak/keycloak/discussions/8801