### PR TITLE
Fixing the loki ingester not ready bug

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-5.8
+  channel: stable-5.9
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators


### PR DESCRIPTION
For issue nerc-project/operations#458 with the loki ingester pod not
becoming ready, the bug has been fixed in  version 458 of Loki.
