### PR TITLE
Add kruize team and clusterrolebinding

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruize-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nerc-ops
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: kruize-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../bundles/patch-operator
 - ../../bundles/clusterissuer-http01
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins
 - ../../base/core/namespaces/openshift-gitops
 - externalsecrets
 - issuers
@@ -39,6 +40,9 @@ patches:
       - name: github
         github:
           clientID: Ov23liGZVyeMB2D96Wiq
+          teams:
+            - ocp-on-nerc/nerc-ops
+            - ocp-on-nerc/kruize-admins
 - target:
     kind: ExternalSecret
     name: github-client-secret


### PR DESCRIPTION
This commit adds the kruize-admins githuib team to the cluster oauth for nerc-ocp-test-2 and creates a cluster role binding for the kruize teams which leverages the nerc-ops cluster role. This is to allow the kruize team full access to nerc-ocp-test-2 to perform there testing.

Closes: https://github.com/nerc-project/operations/issues/645