### PR TITLE
Allow members of kruize-admins to install operators from web ui

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm/clusterrole.yaml
@@ -1,0 +1,141 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+  name: nerc-ops-manage-olm
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - catalogsources
+      - installplans
+      - subscriptions
+    verbs:
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operators
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - cloudcredential.openshift.io
+    resources:
+      - credentialsrequests
+      - credentialsrequests/status
+      - credentialsrequests/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+      - dnses
+      - featuregates
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusteroperators
+      - clusteroperators/status
+      - authentications
+    verbs:
+      - create
+      - get
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - '*'
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - cloudcredentials
+    verbs:
+      - get
+      - list
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../../bundles/clusterissuer-http01
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins
+- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm
 - ../../base/core/namespaces/openshift-gitops
 - externalsecrets
 - issuers


### PR DESCRIPTION
Add the `nerc-ops-manage-olm` ClusterRole and activate it on the
nerc-ocp-test-2 cluster. This will allow members `nerc-ops` and
`kruize-admins` to install operators using the OperatorHub web UI.
