### PR TITLE
feat: add ext.secret for acm-metrics objectstorage

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage/externalsecret.yaml
@@ -1,0 +1,44 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: open-cluster-management-observability-acm-metrics-object-storage
+  namespace: open-cluster-management-observability
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: acm-metrics-object-storage
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        acm-metrics.yaml: |
+          type: s3
+          config:
+            bucket: "{{ .bucket }}"
+            endpoint: "{{ .endpoint }}"
+            insecure: false
+            access_key: "{{ .access_key }}"
+            secret_key: "{{ .secret_key }}"
+            http_config:
+              tls_config:
+                ca_file: "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+  data:
+  - secretKey: bucket
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics/object-storage    # the path-details will be replaced in the overlay patch
+      property: bucket
+  - secretKey: endpoint
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics/object-storage
+      property: endpoint
+  - secretKey: access_key
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics/object-storage
+      property: access_key
+  - secretKey: secret_key
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics/object-storage
+      property: secret_key

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+  - externalsecret.yaml

--- a/cluster-scope/bundles/acm-observability/kustomization.yaml
+++ b/cluster-scope/bundles/acm-observability/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base/core/namespaces/open-cluster-management-observability
   - ../../base/objectbucket.io/objectbucketclaims/observability
   - ../../base/objectbucket.io/objectbucketclaims/acm-metrics
+  - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: open-cluster-management-observability-thanos-object-storage
+  namespace: open-cluster-management-observability
+spec:
+  data:
+  - secretKey: bucket
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics/object-storage
+      property: bucket
+  - secretKey: endpoint
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics/object-storage
+      property: endpoint
+  - secretKey: access_key
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics/object-storage
+      property: access_key
+  - secretKey: secret_key
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics/object-storage
+      property: secret_key

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -58,6 +58,7 @@ patches:
 - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
 - path: machineconfigs/hostpath-provisioner-selinux_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml
+- path: externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-thanos-object-storage_patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1


### PR DESCRIPTION
- Added new ExternalSecret and kustomization files for acm-metrics object storage stored in vault.
- Modified kustomization.yaml to include new resources.
- Added new ExternalSecret patch for acm-metrics object storage in overlays/nerc-ocp-infra.
- Modified kustomization.yaml in overlays/nerc-ocp-infra to apply the new patch.
- OUT OF github: Added secret to vault: nerc-ocp-infra/open-cluster-management-observability/acm-metrics/object-storage