### PR TITLE
Allow nerc-ops members to view machineconfigs

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+  name: nerc-ops-machineconfig
+rules:
+  - apiGroups:
+      - "machineconfiguration.openshift.io"
+    resources:
+      - "machineconfigs"
+    verbs:
+      - list
+      - get
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring
+- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig


### PR DESCRIPTION
Allow members of the nerc-ops group to view machineconfig resources.
