### PR TITLE
fix: _patch.yaml still had old secret name

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: open-cluster-management-observability-thanos-object-storage
+  name: open-cluster-management-observability-acm-metrics-object-storage
   namespace: open-cluster-management-observability
 spec:
   data:


### PR DESCRIPTION
fix: _patch.yaml still had old secret name

- Modified open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
  - metadata:name - replace old naming: thanos to acm-metrics