### PR TITLE
Create Kruize-admins cluster roles

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nerc-ops
+  name: kruize-admins
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kruize-admins/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kruize-admins/clusterrole.yaml
@@ -1,0 +1,12 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kruize-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kruize-admins/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kruize-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-manage-olm
+- ../../base/rbac.authorization.k8s.io/clusterroles/kruize-admins
 - ../../base/core/namespaces/openshift-gitops
 - externalsecrets
 - issuers


### PR DESCRIPTION
Previously the kruise admins group was binded to the the nerc-ops cluster role. The PR creates a kruize-admins cluster role which aggregates roles from cluster-admin labels as opposed to cluster-reader. This will give the kruize admin group full admin access to the cluster without having to use the `--as system:admin` flag.