### PR TITLE
Grant nerc-ops read permissions on RHOAI resources

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+  name: nerc-ops-rhoai
+rules:
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  - serving.kserve.io
+  resources:
+  - '*'
+  verbs:
+  - list
+  - get
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig
+- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai


### PR DESCRIPTION
This grants us read permissions on resources in the
`datasciencepipelinesapplications.opendatahub.io` and `serving.kserve.io`
API groups, which will permit us to view items in the "Data Science
Projects" and "Model Serving" tabs of the RHOAI web interface.
