### PR TITLE
ocp-prod: upgrade to 4.14.33

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.13
+  channel: stable-4.14
   desiredUpdate:
-    version: 4.13.45
+    version: 4.14.33
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.14

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -59,6 +59,7 @@ configMapGenerator:
   literals:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
+    - ack-4.13-kube-1.27-api-removals-in-4.14=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
For 20240805 maintenance. Also bumps the ODF operator to stable-4.14 channel.

**NOTE**: This branch will need to be rebased before merging once https://github.com/OCP-on-NERC/nerc-ocp-config/pull/487 gets merged