### PR TITLE
ocp-prod: upgrade to 4.15.23

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.14
+  channel: stable-4.15
   desiredUpdate:
-    version: 4.14.33
+    version: 4.15.23
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.14
+    channel: stable-4.15


### PR DESCRIPTION
For 20240805 maintenance. Also bumps the ODF operator to stable-4.15 channel.

There is no need to provide admin ack for k8s api removals as none are [removed in this upgrade](https://docs.openshift.com/container-platform/4.15/updating/preparing_for_updates/updating-cluster-prepare.html#kube-api-removals_updating-cluster-prepare)

**NOTE**: This branch will need to be rebased before merging once https://github.com/OCP-on-NERC/nerc-ocp-config/pull/485 gets merged