### PR TITLE
ocp-prod: upgrade to 4.13.45

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.13
   desiredUpdate:
-    version: 4.13.13
+    version: 4.13.45
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982


### PR DESCRIPTION
For 20240805 maintenance. This is a required first step before upgrading to 4.14 and then 4.15.