### PR TITLE
nerc-ocp-test-2: Add storage subscription patch

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/feature/odf/subscriptions/subscription-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.16


### PR DESCRIPTION
The kruize cluster is at OCP 4.16 and the odf operator is at 4.15 This is causing multiple errors in OLM
This patch should resolve the errors in the cluster operators

fixes https://github.com/nerc-project/operations/issues/674