### PR TITLE
nerc-ocp-prod: upgrade rhoai operator to 2.8.2

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -67,6 +67,7 @@ configMapGenerator:
 
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
+- path: subscriptions/rhoai-operator-patch.yaml
 - target:
     kind: SecretStore
   patch: |

--- a/cluster-scope/overlays/nerc-ocp-prod/subscriptions/rhoai-operator-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/subscriptions/rhoai-operator-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec:
+  startingCSV: rhods-operator.2.8.2


### PR DESCRIPTION
With the prod cluster upgraded to OCP 4.15, upgrade rhoai to reflect the version tested in the nerc-ocp-test cluster