### PR TITLE
Add nncp for gpu node

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - eth-nese.yaml
+- vlan-211.yaml

--- a/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/vlan-211.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/vlan-211.yaml
@@ -1,0 +1,34 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-211
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: "wrk-5"
+  desiredState:
+    interfaces:
+    - name: eno1np0.211
+      type: vlan
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: false
+        auto-routes: false
+        address:
+        - ip: 10.0.120.39
+          prefix-length: 22
+      vlan:
+        base-iface: eno1np0
+        id: 211
+      mtu: 9000
+    routes:
+      config:
+      - destination: 10.255.116.0/23
+        next-hop-address: 10.0.120.1
+        next-hop-interface: vlan-211
+      - destination: 10.247.236.0/25
+        next-hop-address: 10.0.120.1
+        next-hop-interface: vlan-211
+      - destination: 140.247.236.0/25
+        next-hop-address: 10.0.120.1
+        next-hop-interface: vlan-211

--- a/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/vlan-211.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test-2/nodenetworkconfigurationpolicies/vlan-211.yaml
@@ -11,6 +11,9 @@ spec:
       type: vlan
       state: up
       ipv4:
+        # DHCP for this network is currently managed by Neutron, and Neutron is
+        # unable to provide DHCP service to trunked interfaces. We need to manually
+        # manage address assignment here until we move DHCP away from Neutron.
         enabled: true
         dhcp: false
         auto-routes: false


### PR DESCRIPTION
This node network configuration policy is needed for the GPU node to gain access to NESE storage. Unlike the other nodes on the cluster the GPU node only has a single interface, this meant that we created a trunk port in order to gain access to the private network that the node are on and the nese storage network.
Additional configuration is need on the node for this to work; create a vlan interface with a tag on the host and attach it to the trunk port. 