### PR TITLE
Update limitrange

### DIFF
--- a/acct-mgt/base/configmaps.yaml
+++ b/acct-mgt/base/configmaps.yaml
@@ -54,14 +54,18 @@ data:
         {
             "type": "Container",
             "default": {
-                "cpu": "2",
-                "memory": "1024Mi",
+                "cpu": "1",
+                "memory": "4096Mi",
                 "nvidia.com/gpu": "0"
             },
             "defaultRequest": {
-                "cpu": "1",
-                "memory": "512Mi",
+                "cpu": "500m",
+                "memory": "2048Mi",
                 "nvidia.com/gpu": "0"
+            },
+            "min": {
+              "cpu": "1m",
+              "memory": "1Mi"
             }
         }
     ]


### PR DESCRIPTION
The default container size aligns with our SU definitions and now there's a minimum size for a container.

Related: https://github.com/CCI-MOC/openshift-acct-mgt/pull/102

It's not clear to me how the existing limitranges will be updated with the new values.