### PR TITLE
fix: sync gitops with manual settings

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-storage/backingstore.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 1
+    numVolumes: 2
     resources:
       requests:
         storage: 1Ti


### PR DESCRIPTION
# fix: sync gitops with manual settings
- infra has 2 vol each 1Ti, but github config still is set to 1
- this pr documents/syncs this setting