### PR TITLE
Add odf operator patches for nerc-rhoai-test and nerc-obs clusters

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.13
+    channel: <PATCH IN CLUSTER OVERLAYS>
     installPlanApproval: Automatic
     name: odf-operator
     source: redhat-operators

--- a/cluster-scope/overlays/nerc-rhoai-test/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-rhoai-test/feature/odf/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-rhoai-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-rhoai-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.16


### PR DESCRIPTION
These PRs doesn't change the operators on the clusters, they just add a version explicitly in the overlays for them since we have to upgrade odf at each OCP upgrade. 