### PR TITLE
Grant additional permissions to the metrics reader clusterrole

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/xdmod-permissions/clusterrole.yaml
@@ -10,3 +10,11 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses
+  - prometheuses/api
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
These permissions are now needed to query from thanos-querier

closes: https://github.com/nerc-project/operations/issues/683

