### PR TITLE
Fix duration in ingress cert on beta cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-beta-test/certificates/default-ingress-certificate.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/certificates/default-ingress-certificate.yaml
@@ -2,13 +2,13 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: default-ingress-certificate
-  namespace: openshift-config
+  namespace: openshift-ingress
 spec:
   issuerRef:
     name: letsencrypt-production-dns01
     kind: Issuer
   secretName: default-ingress-certificate
-  duration: 360h0m0s
+  duration: 2160h0m0s
   renewBefore: 360h0m0s
   dnsNames:
     - "*.apps.ocp-beta-test.nerc.mghpcc.org"


### PR DESCRIPTION
Correct multiple issues with default-ingress-certificate

- This Certificate resource was created in the `openshift-config` namespace,
  but it needs to be created in the `openshift-ingress` namespace [1].

- This Certificate was created with a duration of `360h0m0s` (15 days), but
  it should have a duration of `2160h0m0s` (90 days).

[1]: https://docs.openshift.com/container-platform/4.8/security/certificates/replacing-default-ingress-certificate.html

Signed-off-by: tssala23 <tsalawu@redhat.com>
Signed-off-by: Lars Kellogg-Stedman <lars@redhat.com>