### PR TITLE
feat: Increase Prometheus PVC storage

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
@@ -4,7 +4,7 @@ prometheusK8s:
       storageClassName: ocs-external-storagecluster-ceph-rbd
       resources:
         requests:
-          storage: 100Gi
+          storage: 200Gi
 alertmanagerMain:
   volumeClaimTemplate:
     spec:


### PR DESCRIPTION
feat: Increase Prometheus PVC storage

The Prometheus PVC storage utilization has exceeded 85%, triggering regular warnings.
To avoid potential issues in the future and follow [Red Hat's documentation](https://docs.openshift.com/container-platform/4.9/scalability_and_performance/scaling-cluster-monitoring-operator.html#:~:text=Table%201.%20Prometheus%20Database%20storage%20requirements), we are increasing the storage to 200GB.
This proactive adjustment shall ensure stability (upcoming classes).