### PR TITLE
feat: upgrd nerc-ocp-obs from 4.14.5 to 4.14.28

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.14
   desiredUpdate:
-    version: 4.14.5
+    version: 4.14.28
   clusterID: 760c86f3-95a0-489e-b72a-2938bb80bcea


### PR DESCRIPTION
MUST BE DONE BEFORE
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/499

# feat: upgrd nerc-ocp-obs from 4.14.5 to 4.14.28

- This commit upgrades the nerc-ocp-obs cluster from OpenShift version 4.14.5 to 4.14.28.
- This step is part of the process to align the OBS cluster with the managing infra cluster, which is currently running OpenShift 4.15.16.

---

- ToDo Step 1 of 2 from
  - https://github.com/nerc-project/operations/issues/689