### PR TITLE
feat: upgrd nerc-ocp-obs from 4.14.28 to 4.15.16

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.14
+  channel: stable-4.15
   desiredUpdate:
-    version: 4.14.5
+    version: 4.15.16
   clusterID: 760c86f3-95a0-489e-b72a-2938bb80bcea


### PR DESCRIPTION
MUST BE DONE AFTER
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/498

# feat: upgrd nerc-ocp-obs from 4.14.28 to 4.15.16

- This commit upgrades the nerc-ocp-obs cluster from OpenShift version 4.14.28 to 4.15.16.
- This is the final step in aligning the OBS cluster with the managing infra cluster, which is currently running OpenShift 4.15.16.
 
---

- ToDo Step 2 of 2 from
  - https://github.com/nerc-project/operations/issues/689