### PR TITLE
Enable CAP_SYS_ADMIN for project robbie

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nerc-allow-sys-admin
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nerc-allow-sys-admin
+    verbs:
+      - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/securitycontextconstraints.yaml
@@ -1,0 +1,39 @@
+# This is a copy of the restricted-v2 SCC with CAP_SYS_ADMIN enabled.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - NET_BIND_SERVICE
+  - SYS_ADMIN
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+kind: SecurityContextConstraints
+metadata:
+  name: nerc-allow-sys-admin
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- project-robbioe-allow-sys-admin.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/project-robbioe-allow-sys-admin.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/project-robbioe-allow-sys-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: project-robbie-allow-sys-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nerc-allow-sys-admin
+subjects:
+- kind: ServiceAccount
+  namespace: project-robbie-b4784c
+  name: robbie-job-runner

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -24,6 +24,8 @@ resources:
 - ../../bundles/curator
 - ../../bundles/koku-metrics-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
+- ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
 - feature/odf
 - feature/custom-routes
 - ../../base/core/namespaces/openshift-gitops
@@ -39,6 +41,7 @@ resources:
 - consolelinks
 - odhdashboardconfigs
 - object-storage
+- clusterrolebindings
 
 components:
   - ../../components/nerc-oauth-keycloak


### PR DESCRIPTION
Allow Matt Brewster to perform mount operations in the
project-robbie-b4784c namespace with the robbie-job-runner serviceaccount.
See slack conversionation [1] for details.

[1]: https://massopencloud.slack.com/archives/C027TDE52TZ/p1723831923411889

Closes: nerc-project/operations#686
