### PR TITLE
fix: patch obs odf-operator from 4.13 to 4.14

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: odf-operator
+spec:
+    channel: stable-4.14


### PR DESCRIPTION
# fix: patch obs odf-operator from 4.13 to 4.14

- This commit patches the odf-operator subscription in the GitOps overlay for the nerc-ocp-obs cluster.
- The odf-operator was previously stuck on version 4.13. This patch updates the subscription to use the `stable-4.14` channel.

- triggered by
  - https://github.com/nerc-project/operations/issues/689