### PR TITLE
fix: Update retentionConfig to resolve OutOfSync

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -44,12 +44,8 @@ spec:
       replicas: 3
     retentionConfig:
       blockDuration: 2h               # default is 2h
-      cleanupInterval: 5m             # default is 5m
       deleteDelay: 48h                # default is 48h
       retentionInLocal: 24h           # default is 24h
       retentionResolutionRaw: 90d     # default is 30d
       retentionResolution5m: 360d     # default is 180d
       retentionResolution1h: 0d       # default is 0d - 0d will retain samples of this resolution forever https://thanos.io/tip/components/compact.md/
-      consistencyDelay: 30m
-      compactConcurrency: 6
-      downsampleConcurrency: 6


### PR DESCRIPTION
The retentionConfig settings (cleanupInterval, compactConcurrency, consistencyDelay, downsampleConcurrency) are causing an OutOfSync issue in ArgoCD.
Removing these settings to ensure/check compatibility and to resolve the sync issue.

      cleanupInterval: 5m
      compactConcurrency: 6
      consistencyDelay: 30m
      deleteDelay: 48h
      downsampleConcurrency: 6

initial PR here
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/461