### PR TITLE
Disable rhods-notebooks RHOAI notebook server in nerc-ocp-prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -49,7 +49,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: true
+    enabled: false
     notebookNamespace: rhods-notebooks
     pvcSize: 1Gi
   notebookSizes:


### PR DESCRIPTION
Disabling notebook server to clean up the namespace before classes begin and test spawning notebooks with notebook spawner.

@Milstein ^