### PR TITLE
Remove modelMetricsNamespace from odh dashboard config

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -19,7 +19,6 @@ spec:
     disableSupport: true
     disableTracking: false
     enablement: false
-    modelMetricsNamespace: ""
   groupsConfig:
     adminGroups: rhods-admins
     allowedGroups: system:authenticated


### PR DESCRIPTION
This was causing the argocd app to fail to sync:

> error validating data:
> ValidationError(OdhDashboardConfig.spec.dashboardConfig): unknown field
> "modelMetricsNamespace" in
> io.opendatahub.v1alpha.OdhDashboardConfig.spec.dashboardConfig
