### PR TITLE
Change nncp to match new label added to nodes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-beta-test/nodenetworkconfigurationpolicies/eth-nese.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/nodenetworkconfigurationpolicies/eth-nese.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eth-nese
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker: ""
+    gpu: "false"
   desiredState:
     interfaces:
     - name: mlx1


### PR DESCRIPTION
There are two types of worker nodes, non-GPUs and GPUs. The GPUs on this cluster only have one interface, this means that networking for these nodes are slightly different. This change makes it so this nncp is only applied to the non-GPU nodes.
Labels were added to the non-gpu nodes:
`kubectl label node <non-gpu-wrk> gpu=false --as system:admin`