### PR TITLE
Update resourcequota ope-course-quota to prevent course related gpu usage

### DIFF
--- a/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
@@ -8,5 +8,7 @@ spec:
     limits.cpu: '1000'
     limits.ephemeral-storage: 30Gi
     limits.memory: 3000000Mi
+    limits.nvidia.com/gpu: "0"
     persistentvolumeclaims: '600'
     requests.storage: 600Gi
+    requests.nvidia.com/gpu: "0"


### PR DESCRIPTION
With gpu Accelerators enabled in the nerd-ocp-prod RHOAI cluster, students technically have the ability to allocate gpus to their notebooks in the rhode-notebooks namespace. This quota will prevent gpu workloads from spawning in the rods-notebooks namespace while still allowing gpu allocation elsewhere in RHOAI the the NVIDIA GPU accelerator profile.