### PR TITLE
Increase rhods-notebooks requests.storage to 10Ti

### DIFF
--- a/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/resourcequota.yaml
@@ -10,5 +10,5 @@ spec:
     limits.memory: 3000000Mi
     limits.nvidia.com/gpu: "0"
     persistentvolumeclaims: '600'
-    requests.storage: 600Gi
+    requests.storage: 10Ti
     requests.nvidia.com/gpu: "0"


### PR DESCRIPTION
With 140 students starting Prof. Leonidas Rust course requiring 20Gi PVC
per student (140 students × 20Gi = 2,800Gi) We should increase the
rhods-notebooks requests.storage to at least 4Ti.
