### PR TITLE
Upgrading serverless-operator to version stable-1.32

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: serverless-operator
   namespace: openshift-serverless
 spec:
-  channel: stable-1.31
+  channel: stable-1.32
   installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators


### PR DESCRIPTION
First we upgrade serverless-operator from stable-1.31 to stable-1.32,
with the goal to reach stable-1.33 for the fix to KNative Deployment
Pipelines. See nerc-project/operations#597
