### PR TITLE
vault: update nerc-ocp-test API URL and namespaces

### DIFF
--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
@@ -2,13 +2,14 @@ auth:
 - type: kubernetes
   path: kubernetes/nerc-ocp-test
   config:
-    kubernetes_ca_cert: "${ file `certs/nerc-internal-root.crt` }"
-    kubernetes_host: https://api.nerc-ocp-test.rc.fas.harvard.edu:6443
+    kubernetes_ca_cert: "${ file `certs/letsencrypt.crt` }"
+    kubernetes_host: https://api.ocp-test.nerc.mghpcc.org:6443
     token_reviewer_jwt: "${ file `creds/nerc-ocp-test-token-reviewer` }"
   roles:
   - bound_service_account_names:
     - vault-secret-reader
     bound_service_account_namespaces:
+    - acct-mgt
     - openshift-storage
     - group-sync-operator
     - openshift-config


### PR DESCRIPTION
The nerc-ocp-test cluster is being rebuilt (see https://github.com/OCP-on-NERC/nerc-ocp-config/pull/514) and has a new DNS name with letsencrypt certs. This also appends acct-mgt namespace to the service account namespaces list in case we decide to allocate projects on nerc-ocp-test via coldfront-staging at some point.