### PR TITLE
Increase odh dashboard default pvc size to 20g

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -50,7 +50,7 @@ spec:
   notebookController:
     enabled: false
     notebookNamespace: rhods-notebooks
-    pvcSize: 1Gi
+    pvcSize: 20Gi
   notebookSizes:
   - name: X Small
     resources:


### PR DESCRIPTION
Increase the default pvc size when using RHOAI Jupyter tile to launch notebooks