### PR TITLE
Enable monitoring of user workloads

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
@@ -1,3 +1,4 @@
+enableUserWorkload: true
 prometheusK8s:
   volumeClaimTemplate:
     spec:


### PR DESCRIPTION
Enabling monitoring for user-defined projects in NERC OCP Prod,
according to the Red Hat documentation [1]

Closes nerc-project/operations#703

[1]: https://docs.openshift.com/container-platform/4.16/observability/monitoring/enabling-monitoring-for-user-defined-projects.html
