### PR TITLE
Fix ImageStream name ucsls-F24

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/ucsls-f24-imagestream.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/ucsls-f24-imagestream.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: ucsls-F24
+  name: ucsls-f24
   namespace: redhat-ods-applications
   labels:
     opendatahub.io/notebook-image: "true"

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - odhdashboardconfigs/odh-dashboard-config.yaml
-- imagestreams/ucsls-F24-imagestream.yaml
+- imagestreams/ucsls-f24-imagestream.yaml


### PR DESCRIPTION
Image stream ucsls-F24 with an upper case letter is causing argo CD to
fail syncing cluster-scope-prod.

Closes nerc-project/operations#704
