### PR TITLE
serverless operator upgrade

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: serverless-operator
   namespace: openshift-serverless
 spec:
-  channel: stable-1.32
+  channel: stable-1.33
   installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators


### PR DESCRIPTION
Next we upgrade serverless-operator from stable-1.32 to stable-1.33,
with the goal to reach stable-1.33 for the fix to KNative Deployment
Pipelines.