### PR TITLE
fix ucsls F24 imagestream

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/ucsls-f24-imagestream.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/ucsls-f24-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: 'http://quay.io/opeffort/nerc:beta-base-ope-image_07.31.24_12.45.52'
+        name: 'quay.io/opeffort/nerc:beta-base-ope-image_07.31.24_12.45.52'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
The ucsls-f24 ImageStream DockerImage was configured incorrectly
starting with https://