### PR TITLE
nerc-ocp-test: complete the rhoai/rhods installation

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -1,0 +1,30 @@
+apiVersion: datasciencecluster.opendatahub.io/v1
+kind: DataScienceCluster
+metadata:
+  name: default-dsc
+spec:
+  components:
+    codeflare:
+      managementState: Removed
+    dashboard:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Managed
+    kserve:
+      managementState: Managed
+      serving:
+        ingressGateway:
+          certificate:
+            type: SelfSigned
+        managementState: Managed
+        name: knative-serving
+    kueue:
+      managementState: Removed
+    modelmeshserving:
+      managementState: Managed
+    ray:
+      managementState: Removed
+    trustyai:
+      managementState: Removed
+    workbenches:
+      managementState: Managed

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - datasciencecluster.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/imagestreams/ucsls-f24-imagestream.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/imagestreams/ucsls-f24-imagestream.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ucsls-f24
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "http://quay.io/opeffort/nerc:beta-base-ope-image_07.31.24_12.45.52"
+    opendatahub.io/notebook-image-name: "ucsls-F24"
+    opendatahub.io/notebook-image-desc: "ucsls-F24"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: 'quay.io/opeffort/nerc:beta-base-ope-image_07.31.24_12.45.52'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -6,6 +6,8 @@ commonLabels:
 
 resources:
   - ../../../../bundles/rhods-operator
+  - datascienceclusters
+  - odhdashboardconfigs
 
 patches:
   - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  nerc.mghpcc.org/feature: rhoai
+
+resources:
+  - ../../../../bundles/rhods-operator
+
+patches:
+  - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../../bundles/rhods-operator
   - datascienceclusters
   - odhdashboardconfigs
+  - imagestreams/ucsls-f24-imagestream.yaml
 
 patches:
   - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - odh-dashboard-config.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -1,0 +1,94 @@
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  labels:
+    nerc.mghpcc.org/kustomized: "true"
+  name: odh-dashboard-config
+  namespace: redhat-ods-applications
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableCustomServingRuntimes: false
+    disableISVBadges: false
+    disableInfo: true
+    disableModelServing: false
+    disablePipelines: false
+    disableProjectSharing: false
+    disableProjects: false
+    disableSupport: true
+    disableTracking: false
+    enablement: false
+  groupsConfig:
+    adminGroups: rhods-admins
+    allowedGroups: system:authenticated
+  modelServerSizes:
+  - name: Small
+    resources:
+      limits:
+        cpu: "2"
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 4Gi
+  - name: Medium
+    resources:
+      limits:
+        cpu: "8"
+        memory: 10Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+  - name: Large
+    resources:
+      limits:
+        cpu: "10"
+        memory: 20Gi
+      requests:
+        cpu: "6"
+        memory: 16Gi
+  notebookController:
+    enabled: false
+    notebookNamespace: rhods-notebooks
+    pvcSize: 20Gi
+  notebookSizes:
+  - name: X Small
+    resources:
+      limits:
+        cpu: '1'
+        memory: 4Gi
+      requests:
+        cpu: '100m'
+        memory: 1Gi
+  - name: Small
+    resources:
+      limits:
+        cpu: "2"
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 8Gi
+  - name: Medium
+    resources:
+      limits:
+        cpu: "6"
+        memory: 24Gi
+      requests:
+        cpu: "3"
+        memory: 24Gi
+  - name: Large
+    resources:
+      limits:
+        cpu: "14"
+        memory: 56Gi
+      requests:
+        cpu: "7"
+        memory: 56Gi
+  - name: X Large
+    resources:
+      limits:
+        cpu: "30"
+        memory: 120Gi
+      requests:
+        cpu: "15"
+        memory: 120Gi

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec:
+  channel: stable
+  startingCSV: rhods-operator.2.8.2

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - machineconfigs
 - nodenetworkconfigurationpolicies
 - feature/odf
+- feature/rhoai
 - ../../bundles/clusterissuer-http01
 - ../../bundles/hostpath-provisioner
 - ../../bundles/node-feature-discovery
@@ -23,7 +24,6 @@ resources:
 - ../../bundles/koku-metrics-operator
 - ../../bundles/curator
 - ../../bundles/ansible-automation-platform-operator
-- ../../bundles/rhods-operator
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
 - ../../bundles/openshift-serverless-operator
 - ../../bundles/openshift-opentelemetry-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
 - ../../bundles/openshift-serverless-operator
 - ../../bundles/openshift-opentelemetry-operator
+- ../../bundles/openshift-pipelines-operator
 
 components:
   - ../../components/nerc-oauth-github


### PR DESCRIPTION
- Add missing pipelines operator
- Downgrade RHOAI/RHODS to match the version in production (v2.8.2)
- Add missing DSC and ODH configs (matches prod)
- Add course image streams (matches prod)