### PR TITLE
Adding support for OpenShift Virtualization in test cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-cnv/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-cnv/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-cnv/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-cnv/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+    - openshift-cnv

--- a/cluster-scope/base/operators.coreos.com/subscriptions/hco-operatorhub/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/hco-operatorhub/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/hco-operatorhub/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/hco-operatorhub/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: openshift-cnv
+spec:
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: kubevirt-hyperconverged
+  channel: "stable"

--- a/cluster-scope/bundles/virt/kustomization.yaml
+++ b/cluster-scope/bundles/virt/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: virt
+resources:
+  - ../../base/core/namespaces/openshift-cnv
+  - ../../base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group
+  - ../../base/operators.coreos.com/subscriptions/hco-operatorhub

--- a/virt/base/kubevirt-hyperconverged.yaml
+++ b/virt/base/kubevirt-hyperconverged.yaml
@@ -1,0 +1,5 @@
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec: {}

--- a/virt/base/kustomization.yaml
+++ b/virt/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-cnv
+resources:
+  - kubevirt-hyperconverged.yaml

--- a/virt/overlays/nerc-ocp-test/kustomization.yaml
+++ b/virt/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-cnv
+resources:
+  - ../../base


### PR DESCRIPTION
As documented in the Red Hat OpenShift Virtualization docs[1].

Closes nerc-project/operations#489

[1] https://docs.openshift.com/container-platform/4.15/virt/install/installing-virt.html
