### PR TITLE
Allow user project edit privileges for monitoring and alerts

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit/clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-monitoring-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - verbs:
+      - '*'
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+      - alertmanagerconfigs

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 commonLabels:
   nerc.mghpcc.org/bundle: openshift-serverless-operator
 resources:
+- ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
 - ../../base/core/namespaces/openshift-serverless
 - ../../base/operators.coreos.com/operatorgroups/openshift-serverless


### PR DESCRIPTION
Based on the Red Hat documentation for Granting users permission to
monitor user-defined projects.

[1] https://docs.openshift.com/container-platform/4.16/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects
