### PR TITLE
Moving user project monitoring to the nerc-ocp-prod

### DIFF
--- a/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 commonLabels:
   nerc.mghpcc.org/bundle: openshift-serverless-operator
 resources:
-- ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
 - ../../base/core/namespaces/openshift-serverless
 - ../../base/operators.coreos.com/operatorgroups/openshift-serverless

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - ../../bundles/curator
 - ../../bundles/koku-metrics-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+- ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
 - ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
 - feature/odf


### PR DESCRIPTION
- **Allow user project edit privileges for monitoring and alerts**
- **Moving user project monitoring to the nerc-ocp-prod**
