### PR TITLE
ocp-test: enable kubevirt console plugin

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -103,3 +103,10 @@ patches:
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - ocp-test.nerc.mghpcc.org
+- target:
+    kind: Console
+    name: cluster
+  patch: |
+    - op: add
+      path: /spec/plugins/-
+      value: kubevirt-plugin


### PR DESCRIPTION
This should enable kubevirt/cnv features in the openshift console.

See: https://github.com/kubevirt-ui/kubevirt-plugin?tab=readme-ov-file#deployment-on-cluster