### PR TITLE
ocp-test: add missing kubevirt manifests

### DIFF
--- a/cluster-scope/base/core/configmaps/kubevirt/configmap-ui-settings.yaml
+++ b/cluster-scope/base/core/configmaps/kubevirt/configmap-ui-settings.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-ui-features
+  namespace: default
+data:
+  autocomputeCPULimitsEnabled: "false"
+  autocomputeCPULimitsPreviewEnabled: "false"
+  automaticSubscriptionActivationKey: ""
+  automaticSubscriptionOrganizationId: ""
+  disabledGuestSystemLogsAccess: "false"
+  kubevirtApiserverProxy: "true"
+  loadBalancerEnabled: "false"
+  nodePortAddress: ""
+  nodePortEnabled: "false"

--- a/cluster-scope/base/core/configmaps/kubevirt/configmap-user-settings.yaml
+++ b/cluster-scope/base/core/configmaps/kubevirt/configmap-user-settings.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-user-settings
+  namespace: default
+data:
+  ignored_placeholder: ''

--- a/cluster-scope/base/core/configmaps/kubevirt/kustomization.yaml
+++ b/cluster-scope/base/core/configmaps/kubevirt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap-ui-settings.yaml
+  - configmap-user-settings.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-kubevirt-ui-features-reader.yaml
+  - rolebinding-kubevirt-user-settings-reader.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/rolebinding-kubevirt-ui-features-reader.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/rolebinding-kubevirt-ui-features-reader.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-ui-features-reader-binding
+  namespace: default
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirt-ui-features-reader

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/rolebinding-kubevirt-user-settings-reader.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kubevirt/rolebinding-kubevirt-user-settings-reader.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-user-settings-reader-binding
+  namespace: default
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirt-user-settings-reader

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role-kubevirt-ui-features-reader.yaml
+  - role-kubevirt-user-settings-reader.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/role-kubevirt-ui-features-reader.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/role-kubevirt-ui-features-reader.yaml
@@ -1,0 +1,17 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-ui-features-reader
+  namespace: default
+rules:
+- verbs:
+  - list
+  - get
+  - watch
+  apiGroups:
+  - ''
+  resources:
+  - configmaps
+  resourceNames:
+  - kubevirt-ui-features

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/role-kubevirt-user-settings-reader.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/kubevirt/role-kubevirt-user-settings-reader.yaml
@@ -1,0 +1,18 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-user-settings-reader
+  namespace: default
+rules:
+- verbs:
+  - list
+  - get
+  - update
+  - patch
+  apiGroups:
+  - ''
+  resources:
+  - configmaps
+  resourceNames:
+  - kubevirt-user-settings

--- a/cluster-scope/bundles/virt/kustomization.yaml
+++ b/cluster-scope/bundles/virt/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - ../../base/core/namespaces/openshift-cnv
   - ../../base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged-group
   - ../../base/operators.coreos.com/subscriptions/hco-operatorhub
+  - ../../base/core/configmaps/kubevirt
+  - ../../base/rbac.authorization.k8s.io/roles/kubevirt
+  - ../../base/rbac.authorization.k8s.io/rolebindings/kubevirt


### PR DESCRIPTION
The default install of the kubevirt/cnv operator seems to be missing several manifests that should be in the default namespace. Adding them to the nerc-ocp-test overlay for now until we hear back from RH support on whether these should come out of the box or if we're expected to configure these ourselves.

See:

- https://github.com/redhat-cop/agnosticd/blob/development/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml#L22
- https://github.com/redhat-cop/agnosticd/tree/development/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/templates