### PR TITLE
ocp-test: match all nodes in system-reserved

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kubeletconfigs/system-reserved-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved
+  namespace: openshift-config-operator
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      $patch: replace
+      machineconfiguration.openshift.io/mco-built-in: ""

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -52,7 +52,7 @@ generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-
+- path: kubeletconfigs/system-reserved-patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth


### PR DESCRIPTION
Update the system-reserved kubeletconfig to match both control-plane and worker nodes. The same patch is used on the nerc-ocp-prod cluster.

See: #250