### PR TITLE
ocp-test: add udev rules for v100 worker nics

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -16,3 +16,8 @@ spec:
             source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWxkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018SSNu6FmIvXvYAAAAD//9CsdZdgAQAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
+        - contents:
+            compression: gzip
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VUrKqyiJT81T0vF2DfJz9QEJGRgYGFgZWlgZGOgZKOk4Ood4+vvZ2iolpqQo6fg5+rraKuVlJhsqcZFtqiFOU42UuAABAAD//64yhGWsAAAA
+          mode: 420
+          path: /etc/udev/rules.d/90-bnxt_en.rules

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/bnxt_en.rules
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/bnxt_en.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="net",DRIVERS=="bnxt_en",KERNELS=="0000:18:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="bnxt_en",KERNELS=="0000:18:00.1",ACTION=="add",NAME="nic2"

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
@@ -10,3 +10,7 @@ storage:
       contents:
         local: mlx5_core.rules
       mode: 0644
+    - path: /etc/udev/rules.d/90-bnxt_en.rules
+      contents:
+        local: bnxt_en.rules
+      mode: 0644


### PR DESCRIPTION
This is needed in order to properly configure the bond and tagged storage NICs on the V100 GPU worker node `wrk-3`

(I also verified these NICs do not exist on the other 3x worker nodes so there shouldn't be any changes on the other host aside from a reboot to pick up the new udev rules which will do nothing on those hosts)