### PR TITLE
Add: ai4dd namespace admin crb to ai4dd-admins group

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project-robbioe-allow-sys-admin.yaml
+- project-ai4dd-namespace-admin.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/project-ai4dd-namespace-admin.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterrolebindings/project-ai4dd-namespace-admin.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ai4dd-admin-rolebinding
+  namespace: ai4dd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: admin
+subjects:
+- kind: Group
+  name: ai4dd-admins
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This adds a clusterrolebingding to grant ai4dd team admin access in their namespace. This should be held from merging until [https://github.com/nerc-project/operations/issues/731](https://github.com/nerc-project/operations/issues/731) is resolved. 