### PR TITLE
Grant robbie-job-runner access to anyuid scc

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -42,7 +42,7 @@ resources:
 - consolelinks
 - rhoai
 - object-storage
-- clusterrolebindings
+- rolebindings
 
 components:
   - ../../components/nerc-oauth-keycloak

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- project-robbioe-allow-sys-admin.yaml
+- project-robbie-b4784c

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: project-robbie-b4784c
+resources:
+- project-robbie-allow-anyuid.yaml
+- project-robbie-allow-sys-admin.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/project-robbie-allow-anyuid.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/project-robbie-allow-anyuid.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-robbie-allow-anyuid
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  namespace: project-robbie-b4784c
+  name: robbie-job-runner

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/project-robbie-allow-sys-admin.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/project-robbie-allow-sys-admin.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: project-robbie-allow-sys-admin
 roleRef:


### PR DESCRIPTION
This grants the `robbie-job-runner` in project `project-robbie-b4784c` use
of the `anyuid` scc. This allows Matt Brewster's container(s) to run using
predefined UIDs.

Closes: nerc-project/operations#734
