### PR TITLE
nerc-ocp-prod: add udev rules for v100 ixgbe nics

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -26,3 +26,8 @@ spec:
             source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VUrKqyiJT81T0vF2DfJz9QEJGRgYGFgZWlgZGOgZKOk4Ood4+vvZ2iolpqQo6fg5+rraKuVlJhsqcZFtqiFOU42UuAABAAD//64yhGWsAAAA
           mode: 420
           path: /etc/udev/rules.d/90-bnxt_en.rules
+        - contents:
+            compression: gzip
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcqsSE9KVdLxdg3yc/UBCRgYGBhYGVpYGRjoGSjpODqHePr72doqJaakKOn4Ofq62irlZSYbKnGRaaYhTjONlLgAAQAA//8YCjzsqAAAAA==
+          mode: 420
+          path: /etc/udev/rules.d/90-ixgbe.rules

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
@@ -18,3 +18,7 @@ storage:
       contents:
         local: bnxt_en.rules
       mode: 0644
+    - path: /etc/udev/rules.d/90-ixgbe.rules
+      contents:
+        local: ixgbe.rules
+      mode: 0644

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/ixgbe.rules
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/ixgbe.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="net",DRIVERS=="ixgbe",KERNELS=="0000:18:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="ixgbe",KERNELS=="0000:18:00.1",ACTION=="add",NAME="nic2"


### PR DESCRIPTION
This adds udev rules for 5/7 recently added V100 nodes that have ixgbe NICs (`wrk-10[2,3,6,7,8]`). This should fix the networking issue on these hosts that's preventing them from properly configuring the storage tagged-VLAN device.