### PR TITLE
add nfs-rwx manifests and bundle

### DIFF
--- a/cluster-scope/base/core/deployments/nfs-rwx/deployment.yaml
+++ b/cluster-scope/base/core/deployments/nfs-rwx/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-client-provisioner
+  labels:
+    app: nfs-client-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
+  template:
+    metadata:
+      labels:
+        app: nfs-client-provisioner
+    spec:
+      serviceAccountName: nfs-client-provisioner
+      containers:
+        - name: nfs-client-provisioner
+          image: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            - name: PROVISIONER_NAME
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
+            - name: NFS_SERVER
+              value: 'nfs-server.nfs-rwx.svc.cluster.local'
+            - name: NFS_PATH
+              value: /
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: nfs-server.nfs-rwx.svc.cluster.local
+            path: /

--- a/cluster-scope/base/core/deployments/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/core/deployments/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+- deployment.yaml

--- a/cluster-scope/base/core/namespaces/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/nfs-rwx/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/nfs-rwx/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-rwx
+spec: {}

--- a/cluster-scope/base/core/serviceaccounts/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+  - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/nfs-rwx/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/nfs-rwx/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-client-provisioner

--- a/cluster-scope/base/core/services/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/core/services/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+- service.yaml

--- a/cluster-scope/base/core/services/nfs-rwx/service.yaml
+++ b/cluster-scope/base/core/services/nfs-rwx/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nfs-server
+  name: nfs-server
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    app: nfs-server

--- a/cluster-scope/base/core/statefulsets/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/core/statefulsets/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+- statefulset.yaml

--- a/cluster-scope/base/core/statefulsets/nfs-rwx/statefulset.yaml
+++ b/cluster-scope/base/core/statefulsets/nfs-rwx/statefulset.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: nfs-server
+  name: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-server
+      statefulset: nfs-server
+  template:
+    metadata:
+      labels:
+        app: nfs-server
+        statefulset: nfs-server
+    spec:
+      serviceAccountName: nfs-server
+      containers:
+      - name: nfs-server
+        command:
+        - /usr/local/bin/run_nfs.sh
+        - -G
+        - "0"
+        image: ghcr.io/nerc-project/nerc-nfs-server:main
+        ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /exports
+            name: nfs-server
+  volumeClaimTemplates:
+  - metadata:
+      name: nfs-server
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 6Gi

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-rwx/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-rwx/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: run-nfs-client-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfs-client-provisioner-runner
+subjects:
+- kind: ServiceAccount
+  name: nfs-client-provisioner
+  namespace: nfs-rwx

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-rwx/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-rwx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nfs-rwx/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nfs-rwx/clusterrole.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfs-client-provisioner-runner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nfs-rwx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+  - rolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/nfs-rwx/rolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/nfs-rwx/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-locking-nfs-client-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-locking-nfs-client-provisioner
+subjects:
+- kind: ServiceAccount
+  name: nfs-client-provisioner
+  namespace: nfs-rwx
+

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/nfs-rwx/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs-rwx
+resources:
+  - leader-locking-nfs-client-provisioner.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/nfs-rwx/leader-locking-nfs-client-provisioner.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/nfs-rwx/leader-locking-nfs-client-provisioner.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-locking-nfs-client-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-rwx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-rwx/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-rwx/securitycontextconstraints.yaml
@@ -1,0 +1,17 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: nfs-admin
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - nfs
+  - secret
+users:
+  - system:serviceaccount:nfs-rwx:nfs-client-provisioner

--- a/cluster-scope/base/storage.k8s.io/storageclasses/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/nfs-rwx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/nfs-rwx/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/nfs-rwx/storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: managed-nfs-storage
+provisioner: k8s-sigs.io/nfs-subdir-external-provisioner
+parameters:
+  archiveOnDelete: "false"

--- a/cluster-scope/bundles/nfs-rwx/kustomization.yaml
+++ b/cluster-scope/bundles/nfs-rwx/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nfs-rwx
+resources:
+- ../../base/core/namespaces/nfs-rwx
+- ../../base/core/deployments/nfs-rwx
+- ../../base/core/serviceaccounts/nfs-rwx
+- ../../base/core/services/nfs-rwx
+- ../../base/core/statefulsets/nfs-rwx
+- ../../base/rbac.authorization.k8s.io/roles/nfs-rwx
+- ../../base/rbac.authorization.k8s.io/clusterroles/nfs-rwx
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-rwx
+- ../../base/rbac.authorization.k8s.io/rolebindings/nfs-rwx
+- ../../base/security.openshift.io/securitycontextconstraints/nfs-rwx
+- ../../base/storage.k8s.io/storageclasses/nfs-rwx

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
 - ../../bundles/openshift-opentelemetry-operator
 - ../../bundles/openshift-pipelines-operator
 - ../../bundles/virt
+- ../../bundles/nfs-rwx
 
 components:
   - ../../components/nerc-oauth-github


### PR DESCRIPTION
This implements an NFS server deployment on OpenShift and provisioner in order to provide RWX volumes. 

From: https://github.com/kwkoo/openshift-nfs-server

See: https://github.com/nerc-project/operations/issues/737