### PR TITLE
csi-driver-nfs + nfs-server manifests for RWX storage

### DIFF
--- a/csi-driver-nfs/base/core/daemonsets/csi-driver-node.yaml
+++ b/csi-driver-nfs/base/core/daemonsets/csi-driver-node.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-nfs-node
+  namespace: csi-driver-nfs
+spec:
+  selector:
+    matchLabels:
+      app: csi-nfs-node
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-node
+    spec:
+      containers:
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --probe-timeout=3s
+        - --http-endpoint=localhost:29653
+        - --v=2
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.13.1
+        name: liveness-probe
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        env:
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/csi-nfsplugin/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1
+        livenessProbe:
+          exec:
+            command:
+            - /csi-node-driver-registrar
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --mode=kubelet-registration-probe
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
+        name: node-driver-registrar
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /registration
+          name: registration-dir
+      - args:
+        - -v=5
+        - --nodeid=$(NODE_ID)
+        - --endpoint=$(CSI_ENDPOINT)
+        env:
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        image: registry.k8s.io/sig-storage/nfsplugin:v4.9.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: localhost
+            path: /healthz
+            port: 29653
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: nfs
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+            drop:
+            - ALL
+          privileged: true
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: csi-nfs-node-sa
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi-nfsplugin
+          type: DirectoryOrCreate
+        name: socket-dir
+      - hostPath:
+          path: /var/lib/kubelet/pods
+          type: Directory
+        name: pods-mount-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+        name: registration-dir
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/csi-driver-nfs/base/core/daemonsets/kustomization.yaml
+++ b/csi-driver-nfs/base/core/daemonsets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: csi-driver-nfs
+resources:
+  - csi-driver-node.yaml

--- a/csi-driver-nfs/base/core/deployments/csi-nfs-controller.yaml
+++ b/csi-driver-nfs/base/core/deployments/csi-nfs-controller.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-nfs-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-nfs-controller
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-controller
+    spec:
+      containers:
+      - args:
+        - -v=2
+        - --csi-address=$(ADDRESS)
+        - --leader-election
+        - --leader-election-namespace=csi-driver-nfs
+        - --extra-create-metadata=true
+        - --feature-gates=HonorPVReclaimPolicy=true
+        - --timeout=1200s
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.0.2
+        name: csi-provisioner
+        resources:
+          limits:
+            memory: 400Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --v=2
+        - --csi-address=$(ADDRESS)
+        - --leader-election-namespace=csi-driver-nfs
+        - --leader-election
+        - --timeout=1200s
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
+        imagePullPolicy: IfNotPresent
+        name: csi-snapshotter
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - --csi-address=/csi/csi.sock
+        - --probe-timeout=3s
+        - --http-endpoint=localhost:29652
+        - --v=2
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.13.1
+        name: liveness-probe
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - -v=5
+        - --nodeid=$(NODE_ID)
+        - --endpoint=$(CSI_ENDPOINT)
+        env:
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        image: registry.k8s.io/sig-storage/nfsplugin:v4.9.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            host: localhost
+            path: /healthz
+            port: 29652
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+        name: nfs
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+            drop:
+            - ALL
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+          name: pods-mount-dir
+        - mountPath: /csi
+          name: socket-dir
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: csi-nfs-controller-sa
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/controlplane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/pods
+          type: Directory
+        name: pods-mount-dir
+      - emptyDir: {}
+        name: socket-dir

--- a/csi-driver-nfs/base/core/deployments/kustomization.yaml
+++ b/csi-driver-nfs/base/core/deployments/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: csi-driver-nfs
+resources:
+  - csi-nfs-controller.yaml

--- a/csi-driver-nfs/base/core/namespaces/kustomization.yaml
+++ b/csi-driver-nfs/base/core/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/csi-driver-nfs/base/core/namespaces/namespace.yaml
+++ b/csi-driver-nfs/base/core/namespaces/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-driver-nfs
+spec: {}

--- a/csi-driver-nfs/base/core/serviceaccounts/csi-nfs-controller-sa.yaml
+++ b/csi-driver-nfs/base/core/serviceaccounts/csi-nfs-controller-sa.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-controller-sa

--- a/csi-driver-nfs/base/core/serviceaccounts/csi-nfs-node-sa.yaml
+++ b/csi-driver-nfs/base/core/serviceaccounts/csi-nfs-node-sa.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-node-sa

--- a/csi-driver-nfs/base/core/serviceaccounts/kustomization.yaml
+++ b/csi-driver-nfs/base/core/serviceaccounts/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: csi-driver-nfs
+resources:
+  - csi-nfs-controller-sa.yaml
+  - csi-nfs-node-sa.yaml

--- a/csi-driver-nfs/base/kustomization.yaml
+++ b/csi-driver-nfs/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: csi-driver-nfs
+resources:
+  - core/namespaces
+  - rbac.authorization.k8s.io/clusterroles
+  - rbac.authorization.k8s.io/clusterrolebindings
+  - rbac.authorization.k8s.io/rolebindings
+  - core/serviceaccounts
+  - core/daemonsets
+  - core/deployments
+  - storage.k8s.io/csidrivers
+  - storage.k8s.io/storageclasses

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterrolebindings/clusterrolebinding.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterrolebindings/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfs-csi-provisioner-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfs-external-provisioner-role
+subjects:
+- kind: ServiceAccount
+  name: csi-nfs-controller-sa
+  namespace: csi-driver-nfs

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterrolebindings/kustomization.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterrolebindings/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrolebinding.yaml

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterroles/clusterrole.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterroles/clusterrole.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfs-external-provisioner-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterroles/kustomization.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/clusterroles/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/rolebindings/csi-driver-nfs-sa-privileged.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/rolebindings/csi-driver-nfs-sa-privileged.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-driver-nfs-sa-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  namespace: csi-driver-nfs
+  name: csi-nfs-controller-sa
+- kind: ServiceAccount
+  namespace: csi-driver-nfs
+  name: csi-nfs-node-sa

--- a/csi-driver-nfs/base/rbac.authorization.k8s.io/rolebindings/kustomization.yaml
+++ b/csi-driver-nfs/base/rbac.authorization.k8s.io/rolebindings/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: csi-driver-nfs
+resources:
+  - csi-driver-nfs-sa-privileged.yaml

--- a/csi-driver-nfs/base/storage.k8s.io/csidrivers/kustomization.yaml
+++ b/csi-driver-nfs/base/storage.k8s.io/csidrivers/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs-csi-k8s-io.yaml

--- a/csi-driver-nfs/base/storage.k8s.io/csidrivers/nfs-csi-k8s-io.yaml
+++ b/csi-driver-nfs/base/storage.k8s.io/csidrivers/nfs-csi-k8s-io.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: nfs.csi.k8s.io
+spec:
+  attachRequired: false
+  fsGroupPolicy: File
+  volumeLifecycleModes:
+  - Persistent

--- a/csi-driver-nfs/base/storage.k8s.io/storageclasses/kustomization.yaml
+++ b/csi-driver-nfs/base/storage.k8s.io/storageclasses/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - storageclass.yaml

--- a/csi-driver-nfs/base/storage.k8s.io/storageclasses/storageclass.yaml
+++ b/csi-driver-nfs/base/storage.k8s.io/storageclasses/storageclass.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-csi
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs-server.nfs.svc.cluster.local
+  share: /
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - nfsvers=4.1

--- a/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base

--- a/nfs/base/core/deployments/kustomization.yaml
+++ b/nfs/base/core/deployments/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs
+resources:
+  - nfs-server.yaml

--- a/nfs/base/core/deployments/nfs-server.yaml
+++ b/nfs/base/core/deployments/nfs-server.yaml
@@ -1,0 +1,41 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-server
+  template:
+    metadata:
+      name: nfs-server
+      labels:
+        app: nfs-server
+    spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
+      containers:
+        - name: nfs-server
+          image: itsthenetwork/nfs-server-alpine:latest
+          env:
+            - name: SHARED_DIRECTORY
+              value: "/exports"
+          volumeMounts:
+            - mountPath: /exports
+              name: nfs-server-root
+          securityContext:
+            privileged: true
+          ports:
+            - name: tcp-2049
+              containerPort: 2049
+              protocol: TCP
+            - name: udp-111
+              containerPort: 111
+              protocol: UDP
+      serviceAccountName: nfs-server-sa
+      volumes:
+        - name: nfs-server-root
+          persistentVolumeClaim:
+            claimName: nfs-server-root

--- a/nfs/base/core/namespaces/kustomization.yaml
+++ b/nfs/base/core/namespaces/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/nfs/base/core/namespaces/namespace.yaml
+++ b/nfs/base/core/namespaces/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs
+spec: {}

--- a/nfs/base/core/persistentvolumeclaims/kustomization.yaml
+++ b/nfs/base/core/persistentvolumeclaims/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs
+resources:
+  - nfs-server-root.yaml

--- a/nfs/base/core/persistentvolumeclaims/nfs-server-root.yaml
+++ b/nfs/base/core/persistentvolumeclaims/nfs-server-root.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-server-root
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi

--- a/nfs/base/core/serviceaccounts/kustomization.yaml
+++ b/nfs/base/core/serviceaccounts/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs
+resources:
+  - nfs-server-sa.yaml

--- a/nfs/base/core/serviceaccounts/nfs-server-sa.yaml
+++ b/nfs/base/core/serviceaccounts/nfs-server-sa.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-server-sa

--- a/nfs/base/core/services/kustomization.yaml
+++ b/nfs/base/core/services/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs
+resources:
+  - service.yaml

--- a/nfs/base/core/services/service.yaml
+++ b/nfs/base/core/services/service.yaml
@@ -1,0 +1,18 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-server
+  labels:
+    app: nfs-server
+spec:
+  type: ClusterIP  # use "LoadBalancer" to get a public ip
+  selector:
+    app: nfs-server
+  ports:
+    - name: tcp-2049
+      port: 2049
+      protocol: TCP
+    - name: udp-111
+      port: 111
+      protocol: UDP

--- a/nfs/base/kustomization.yaml
+++ b/nfs/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nfs
+resources:
+  - core/namespaces
+  - core/serviceaccounts
+  - rbac.authorization.k8s.io/rolebindings
+  - core/persistentvolumeclaims
+  - core/deployments
+  - core/services

--- a/nfs/base/rbac.authorization.k8s.io/rolebindings/kustomization.yaml
+++ b/nfs/base/rbac.authorization.k8s.io/rolebindings/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nfs
+resources:
+  - nfs-server-sa-anyuid.yaml
+  - nfs-server-sa-privileged.yaml

--- a/nfs/base/rbac.authorization.k8s.io/rolebindings/nfs-server-sa-anyuid.yaml
+++ b/nfs/base/rbac.authorization.k8s.io/rolebindings/nfs-server-sa-anyuid.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfs-server-sa-anyuid
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  namespace: nfs
+  name: nfs-server-sa

--- a/nfs/base/rbac.authorization.k8s.io/rolebindings/nfs-server-sa-privileged.yaml
+++ b/nfs/base/rbac.authorization.k8s.io/rolebindings/nfs-server-sa-privileged.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfs-server-sa-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  namespace: nfs
+  name: nfs-server-sa

--- a/nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+- ../../base


### PR DESCRIPTION
Alternate solution for https://github.com/nerc-project/operations/issues/737 using csi-driver-nfs (https://github.com/openshift/csi-driver-nfs)

This approach appears to be more maintained upstream than the deployment used in https://github.com/OCP-on-NERC/nerc-ocp-config/pull/538

Related nerc-ocp-apps PR: https://github.com/OCP-on-NERC/nerc-ocp-apps/pull/55