### PR TITLE
Add ACM metrics 2ti object bucket claim & storage

### DIFF
--- a/cluster-scope/base/objectbucket.io/objectbucketclaims/acm-metrics-2ti/kustomization.yaml
+++ b/cluster-scope/base/objectbucket.io/objectbucketclaims/acm-metrics-2ti/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - objectbucketclaim.yaml

--- a/cluster-scope/base/objectbucket.io/objectbucketclaims/acm-metrics-2ti/objectbucketclaim.yaml
+++ b/cluster-scope/base/objectbucket.io/objectbucketclaims/acm-metrics-2ti/objectbucketclaim.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: acm-metrics-2ti
+  namespace: open-cluster-management-observability
+spec:
+  generateBucketName: acm-metrics-2ti
+  storageClassName: acm-metrics-2ti-bucket-storage

--- a/cluster-scope/bundles/acm-observability/kustomization.yaml
+++ b/cluster-scope/bundles/acm-observability/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base/core/namespaces/open-cluster-management-observability
   - ../../base/objectbucket.io/objectbucketclaims/observability
   - ../../base/objectbucket.io/objectbucketclaims/acm-metrics
+  - ../../base/objectbucket.io/objectbucketclaims/acm-metrics-2ti
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/backingstore.yaml
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: acm-metrics-2ti-backing-store
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 1
+    resources:
+      requests:
+        storage: 2Ti
+    storageClass: ocs-external-storagecluster-ceph-rbd
+  type: pv-pool

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/bucketclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/bucketclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: acm-metrics-2ti-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - acm-metrics-2ti-backing-store

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: noobaa
+resources:
+- backingstore.yaml
+- bucketclass.yaml
+- storageclass.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/storageclass.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/storageclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    description: Provides Object Bucket Claims (OBCs) for ACM metrics
+  name: acm-metrics-2ti-bucket-storage
+parameters:
+  bucketclass: acm-metrics-2ti-bucket-class
+provisioner: openshift-storage.noobaa.io/obc
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -32,7 +32,7 @@ resources:
 - persistentvolumeclaims
 - nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
 - acm-metrics-storage
-
+- acm-metrics-2ti-storage
 components:
   - ../../components/nerc-oauth-github
 


### PR DESCRIPTION
Add ACM metrics 2ti object bucket claim & storage

fixes partly https://github.com/nerc-project/operations/issues/745

This PR tackles part of the issue by adding acm-metrics-2ti and updating existing observability and storage settings. The changes try to solve or reproduce the errors in #745.
But this is only the first step, see #745.