### PR TITLE
Adding ai-telemetry client to prom-keycloak-proxy

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
@@ -90,6 +90,24 @@ spec:
                   groups:
                     - id: nerc-ops
 
+            - id: group-ai-telemetry
+              name: group-ai-telemetry
+              logic: POSITIVE
+              decisionStrategy: UNANIMOUS
+              type:
+                group:
+                  groups:
+                    - id: ai-telemetry
+
+            - id: client-ai-telemetry
+              name: client-ai-telemetry
+              logic: POSITIVE
+              decisionStrategy: UNANIMOUS
+              type:
+                client:
+                  clients:
+                    - ai-telemetry
+
             - id: client-ai4cloudops
               name: client-ai4cloudops
               logic: POSITIVE
@@ -133,6 +151,19 @@ spec:
             - name: group-nerc-ops-namespace-all
               policy: group-nerc-ops
               resource: namespace
+
+            - name: group-ai-telemetry-cluster-all
+              policy: group-ai-telemetry
+              resource: cluster
+            - name: group-ai-telemetry-namespace-all
+              policy: group-ai-telemetry
+              resource: namespace
+            - name: client-ai-telemetry-namespace-all
+              policy: client-ai-telemetry
+              resource: namespace
+            - name: client-ai-telemetry-cluster-all
+              policy: client-ai-telemetry
+              resource: cluster
 
             - name: group-nerc-ai4cloudops-namespace-all
               policy: group-nerc-ai4cloudops

--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -75,6 +75,14 @@ spec:
         username: syedmohdqasim
         groups:
           - nerc-ai4cloudops
+      - id: dheerajodha
+        username: dheerajodha
+        groups:
+          - nerc-logs-metrics
+      - id: rh-csaggin
+        username: rh-csaggin
+        groups:
+          - nerc-logs-metrics
     roles:
       realm:
         - id: cluster-prod-view-all
@@ -283,6 +291,20 @@ spec:
             name: realm roles
             protocol: openid-connect
             protocolMapper: oidc-usermodel-realm-role-mapper
+      - id: ai-telemetry
+        name: ai-telemetry
+        description: A client scope for the ai-telemetry client
+        protocol: openid-connect
+        protocolMappers:
+          - config:
+              access.token.claim: 'true'
+              id.token.claim: 'false'
+              included.client.audience: 'ai-telemetry'
+            consentRequired: false
+            id: ai-telemetry
+            name: ai-telemetry
+            protocol: openid-connect
+            protocolMapper: oidc-audience-mapper
     defaultDefaultClientScopes:
       - nerc
     clients:
@@ -298,6 +320,22 @@ spec:
           - openid
           - profile
           - nerc
+        authorizationSettings:
+          decisionStrategy: AFFIRMATIVE
+      - id: ai-telemetry
+        clientId: ai-telemetry
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        authorizationServicesEnabled: true
+        frontchannelLogout: true
+        protocol: openid-connect
+        redirectUris:
+          - https://ai-telemetry.apps.obs.nerc.mghpcc.org/callback
+          - https://ai-telemetry.apps.obs.nerc.mghpcc.org/logout
+        defaultClientScopes:
+          - openid
+          - profile
+          - ai-telemetry
         authorizationSettings:
           decisionStrategy: AFFIRMATIVE
       - id: ai4cloudops


### PR DESCRIPTION
We need a new ai-telemetry client which has access to metrics on all
clusters and all namespaces to report on GPU usage metrics.
