### PR TITLE
Add oauth-proxy imagestream

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/oauth-proxy.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/imagestreams/oauth-proxy.yaml
@@ -1,0 +1,17 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: oauth-proxy
+  namespace: redhat-ods-applications
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: 'registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Source

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - odhdashboardconfigs/odh-dashboard-config.yaml
 - imagestreams/ucsls-f24-imagestream.yaml
+- imagestreams/oauth-proxy.yaml


### PR DESCRIPTION
This image is used by RHOAI to provide authentication. RHOAI is currently pulling this image externally but we would like to store it and pull from the internal image repo.