### PR TITLE
feat: add ExtSecret for acm-metrics-2Ti objstore

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
@@ -1,0 +1,44 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: open-cluster-management-observability-acm-metrics-2ti-object-storage
+  namespace: open-cluster-management-observability
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: acm-metrics-2ti-object-storage
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        acm-metrics.yaml: |
+          type: s3
+          config:
+            bucket: "{{ .bucket }}"
+            endpoint: "{{ .endpoint }}"
+            insecure: false
+            access_key: "{{ .access_key }}"
+            secret_key: "{{ .secret_key }}"
+            http_config:
+              tls_config:
+                ca_file: "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+  data:
+  - secretKey: bucket
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics-2ti/object-storage    # the path-details will be replaced in the overlay patch
+      property: bucket
+  - secretKey: endpoint
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: endpoint
+  - secretKey: access_key
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: access_key
+  - secretKey: secret_key
+    remoteRef:
+      key: $ENV/$CLUSTER/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: secret_key

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/kustomized: "true"
+
+resources:
+  - externalsecret.yaml

--- a/cluster-scope/bundles/acm-observability/kustomization.yaml
+++ b/cluster-scope/bundles/acm-observability/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base/objectbucket.io/objectbucketclaims/acm-metrics
   - ../../base/objectbucket.io/objectbucketclaims/acm-metrics-2ti
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-object-storage
+  - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret
   - ../../base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: open-cluster-management-observability-acm-metrics-2ti-object-storage
+  namespace: open-cluster-management-observability
+spec:
+  data:
+  - secretKey: bucket
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: bucket
+  - secretKey: endpoint
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: endpoint
+  - secretKey: access_key
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: access_key
+  - secretKey: secret_key
+    remoteRef:
+      key: nerc/nerc-ocp-infra/open-cluster-management-observability/acm-metrics-2ti/object-storage
+      property: secret_key

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -59,6 +59,7 @@ patches:
 - path: machineconfigs/hostpath-provisioner-selinux_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-acm-metrics-object-storage_patch.yaml
+- path: externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage_patch.yaml
 - path: externalsecrets/open-cluster-management-observability-thanos-object-storage_patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1


### PR DESCRIPTION
# feat: add ExtSecret for acm-metrics-2Ti objstore

partly fixing https://github.com/nerc-project/operations/issues/745

- New ExternalSecret for ACM metrics 2Ti object storage in `open-cluster-management-observability` namespace.
- Updated the ACM observability bundle to include the new resource in the kustomization.
- Patch for the infra overlay to map the bucket, endpoint, access_key, and secret_key for ACM metrics 2Ti object storage.
- Manually, outside of github: added bucket, endpoint, access_key, and secret_key to vault infra.

This new storage is for testing our problems with nooba, scaling storage pools, and ODF operator. 
https://github.com/nerc-project/operations/issues/688
To reproduce the error or solve it.