### PR TITLE
feat: switch to acm-metrics-2ti object storage

### DIFF
--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/multiclusterobservability.yaml
@@ -16,8 +16,8 @@ spec:
     storageClass: gp2
     storeStorageSize: 10Gi
     metricObjectStorage:
-      key: acm-metrics.yaml
-      name: acm-metrics-object-storage
+      key: acm-metrics-2ti.yaml
+      name: acm-metrics-2ti-object-storage
   advanced:
     rbacQueryProxy:
       replicas: 2


### PR DESCRIPTION
### waiting for
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/544 to be merged

# feat: switch to acm-metrics-2ti object storage

partly fixing https://github.com/nerc-project/operations/issues/745

Update the configuration for ACM metrics object storage to use
- the acm-metrics-2ti.yaml file
- and the acm-metrics-2ti-object-storage name.

This new storage is for testing our problems with nooba, scaling storage pools, and ODF operator.
https://github.com/nerc-project/operations/issues/688
To reproduce the error or solve it.

Signed-off-by: ​/Thor(sten)?/ Schwesig <89909507+schwesig@users.noreply.github.com>