### PR TITLE
ai telemetry permissions

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
@@ -26,6 +26,12 @@ spec:
             - id: namespace-rhods-notebooks
               name: rhods-notebooks
               displayName: rhods-notebooks namespace
+            - id: namespace-kruizeoptimization-143c8e
+              name: kruizeoptimization-143c8e
+              displayName: kruizeoptimization-143c8e namespace
+            - id: namespace-kruizeoptimization-5ad5bc
+              name: kruizeoptimization-5ad5bc
+              displayName: kruizeoptimization-5ad5bc namespace
 
             - id: cluster-all
               name: all clusters

--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -47,6 +47,8 @@ spec:
         name: nerc-ai4cloudops
       - id: nerc-kruizeoptimization
         name: nerc-kruizeoptimization
+      - id: ai-telemetry
+        name: ai-telemetry
     users:
       - id: computate
         username: computate


### PR DESCRIPTION
Adding missing namespace policies and ai-telemetry group for successful import with the Keycloak Permissions Operator. 