### PR TITLE
fix: renaming the external secret yaml to match 2ti

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       type: Opaque
       engineVersion: v2
       data:
-        acm-metrics.yaml: |
+        acm-metrics-2ti.yaml: |
           type: s3
           config:
             bucket: "{{ .bucket }}"


### PR DESCRIPTION
fix: renaming the external secret yaml to match 2ti

partly fixing https://github.com/nerc-project/operations/issues/751