### PR TITLE
clusterissuer: add aws-route53-credentials externalsecret

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-route53-credentials
+  namespace: openshift-operators
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: nerc-secret-store
+  target:
+    name: aws-route53-credentials
+    # Prevent generated Secret from inheriting the labels from this
+    # ExternalSecret. OpenShift will create a copy of the Secret, and the
+    # labels will causse it to show up as out-of-sync in ArgoCD. See
+    # https://github.com/OCP-on-NERC/operations/issues/42 for additional
+    # details.
+    template:
+      metadata:
+        labels: {}
+  dataFrom:
+    - extract:
+        key: REPLACE_IN_OVERLAY

--- a/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - aws-route53-credentials.yaml

--- a/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
@@ -4,5 +4,6 @@ commonLabels:
   nerc.mghpcc.org/bundle: nerc-certificate-clusterissuer
 
 resources:
+- ../../base/external-secrets.io/externalsecrets/clusterissuer-dns01
 - ../../cert-manager.io/clusterissuers/letsencrypt-production-dns01
 - ../../cert-manager.io/clusterissuers/letsencrypt-staging-dns01


### PR DESCRIPTION
This was missing from the `nerc-certificate-clusterissuers` bundle so the manually created aws-route53-credentials secret that we created on the nerc-ocp-obs cluster during bootstrapping wasn't being synced with vault.

See: https://github.com/nerc-project/operations/issues/750