### PR TITLE
Extend nerc-allow-sys-admin scc to permit arbitrary fsGroup

### DIFF
--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/securitycontextconstraints.yaml
@@ -11,10 +11,11 @@ allowedCapabilities:
   - SYS_ADMIN
   - SETUID
   - SETGID
+  - CHOWN
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
-  type: MustRunAs
+  type: RunAsAny
 kind: SecurityContextConstraints
 metadata:
   name: nerc-allow-sys-admin


### PR DESCRIPTION
We're using this scc to avoid grant "privileged: true" to a container,
which means that the project-robbie folks keep discovering additional
capabilities they need in order for things to work.

This commits modifies the `nerc-allow-sys-admin` scc to permit setting
pod.spec.securityContext.fsGroup to an arbitrary value (which means you
don't need to be able to chown things).

We also add CAP_CHOWN to the capability set, in case the use of fsGroup by
itself is insufficiently flexible.