### PR TITLE
nerc-secret-store in clusterissuer-dns01 externsecret

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: SecretStore
-    name: nerc-secret-store
+    name: nerc-cluster-secrets
   target:
     name: aws-route53-credentials
     # Prevent generated Secret from inheriting the labels from this


### PR DESCRIPTION
Minor fix to #550 to use the clustersecretstore by default vs a namespaced secretstore