### PR TITLE
obs: fix loki bearer token externalsecret

### DIFF
--- a/logging/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-obs/kustomization.yaml
@@ -3,3 +3,12 @@ kind: Kustomization
 
 resources:
 - ../../base
+
+patches:
+- target:
+    kind: ExternalSecret
+    name: openshift-logging-lokistack-gateway-bearer-token
+  patch: |
+    - op: replace
+      path: /spec/dataFrom/0/extract/key
+      value: nerc/nerc-ocp-obs/lokistack-gateway-bearer-token


### PR DESCRIPTION
The vault key referenced in the externalsecret in logging/base is a template by default that needs to be patched in each overlay.

Currently this secret is failing on the obs cluster given that the key string still contains template variables.


```
$ oc get externalsecrets -n openshift-logging | grep -i error
externalsecret.external-secrets.io/openshift-logging-lokistack-gateway-bearer-token   nerc-cluster-secrets   15s                SecretSyncedError   False

$ oc describe -n openshift-logging externalsecret.external-secrets.io/openshift-logging-lokistack-gateway-bearer-token
<redacted>
Events:
  Type     Reason        Age                      From              Message
  ----     ------        ----                     ----              -------
  Warning  UpdateFailed  4m26s (x717 over 7d22h)  external-secrets  cannot read secret data from Vault: Error making API request.

URL: GET https://vault-ui-vault.apps.nerc-ocp-infra.rc.fas.harvard.edu/v1/nerc/data/$ENV/$CLUSTER/lokistack-gateway-bearer-token
Code: 403. Errors:

* 1 error occurred:
  * permission denied
```
