### PR TITLE
fix kind in clusterissuer-dns01 externalsecret

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/aws-route53-credentials.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
 spec:
   secretStoreRef:
-    kind: SecretStore
+    kind: ClusterSecretStore
     name: nerc-cluster-secrets
   target:
     name: aws-route53-credentials


### PR DESCRIPTION
Minor fix to #554 to update kind to ClusterSecretStore in the secreStoreRef. (I need more coffee 😛 )