### PR TITLE
Disable public ssh access to nerc-ocp-beta-test

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- configure-sysctl-ip-forward/
-- udev-rules/
-- block-public-ssh/
+- machineconfig-controller.yaml
+- machineconfig-worker.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-controller.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-controller.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: block-public-ssh-controller
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - name: block-public-ssh
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Block ssh from anywhere but private network
+            Requires=sshd.service
+            Before=sshd.service
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/sbin/iptables -I INPUT -p tcp --dport 22 ! -s 192.168.50.0/24 -j DROP
+
+            [Install]
+            WantedBy=multi-user.target

--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-worker.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: block-public-ssh-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - name: block-public-ssh
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Block ssh from anywhere but private network
+            Requires=sshd.service
+            Before=sshd.service
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/sbin/iptables -I INPUT -p tcp --dport 22 ! -s 192.168.50.0/24 -j DROP
+
+            [Install]
+            WantedBy=multi-user.target


### PR DESCRIPTION
This mitigates CVEs 48795 and 6387 by preventing public ssh access to this
cluster through the ingress or api addresses.
