### PR TITLE
Correct service unit names in machineconfig resources

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-controller.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-controller.yaml
@@ -10,7 +10,7 @@ spec:
       version: 3.2.0
     systemd:
       units:
-        - name: block-public-ssh
+        - name: block-public-ssh.service
           enabled: true
           contents: |
             [Unit]

--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/machineconfig-worker.yaml
@@ -10,7 +10,7 @@ spec:
       version: 3.2.0
     systemd:
       units:
-        - name: block-public-ssh
+        - name: block-public-ssh.service
           enabled: true
           contents: |
             [Unit]


### PR DESCRIPTION
This adds the required extension to the unit names created in #557.
