### PR TITLE
Add rhods-notebooks secret store

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - openshift-logging
 - group-sync-operator
 - ece440spring2024-619f12
+- rhods-notebooks

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/rhods-notebooks/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/rhods-notebooks/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rhods-notebooks
+components:
+  - ../../../../components/nerc-secret-store

--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-prod.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-prod.yaml
@@ -17,6 +17,7 @@ auth:
     - openshift-logging
     - openshift-ingress-operator
     - ece440spring2024-619f12
+    - rhods-notebooks
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
In order to deploy the assign-class-label webhook, we require a secret for the webhook cert