### PR TITLE
fix: acm-metrics-2ti setting new storage class

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/backingstore.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/acm-metrics-2ti-storage/backingstore.yaml
@@ -9,5 +9,5 @@ spec:
     resources:
       requests:
         storage: 2Ti
-    storageClass: ocs-external-storagecluster-ceph-rbd
+    storageClass: acm-metrics-2ti-bucket-storage
   type: pv-pool


### PR DESCRIPTION
fix: acm-metrics-2ti setting new storage class

acm-metrics-2ti still had old storage class