### PR TITLE
nerc-ocp-test: add unique acceleratorProfiles for A100 vs V100 GPUs

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/a100-acceleratorprofile.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/a100-acceleratorprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: nvidia-a100-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA A100 GPU
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - a100-acceleratorprofile.yaml
+  - v100-acceleratorprofile.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/v100-acceleratorprofile.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/v100-acceleratorprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: nvidia-v100-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA V100 GPU
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - datascienceclusters
   - odhdashboardconfigs
   - imagestreams/ucsls-f24-imagestream.yaml
+  - acceleratorprofiles
 
 patches:
   - path: subscriptions/subscription-patch.yaml


### PR DESCRIPTION
Addresses: https://github.com/nerc-project/operations/issues/767

Prior to this commit, there was no way to distinguish between different GPU node types in RHOAI The current acceleratorProfile simply looks for any node with the label nvidia.com/gpu, whether that schedules the workload in A100 or V100 is up to chance

The tolerations in the acceleratorProfiles in this commit inject tolerations into RHOAI workloads based on the the choice of NVIDIA GPU from the RHOAI dashboard.

NOTE: AcceleratorProfiles do not taint the nodes, they only locate gpus and inject tolerations to workloads.