### PR TITLE
nerc-ocp-test: patch gpu clusterPolicy to fix NONE acceleratorProfile

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -9,3 +9,8 @@ spec:
     config:
       default: all-disabled
       name: test-mig-parted-config
+  toolkit:
+    enabled: true
+    env:
+      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
+        value: 'false'


### PR DESCRIPTION
Closes: https://github.com/nerc-project/operations/issues/685 This change adjusts the behavior within RHOAI w.r.t acceleratorProfile NONE, from expose all NVIDIA devices to none