### PR TITLE
Adding support for IBM autopilot GPU metrics, alerts, dashboards

### DIFF
--- a/autopilot/base/clusterrolebindings/autopilot.yaml
+++ b/autopilot/base/clusterrolebindings/autopilot.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autopilot
+  namespace: autopilot
+subjects:
+- kind: ServiceAccount
+  name: autopilot
+  namespace: autopilot
+roleRef:
+  kind: ClusterRole
+  name: autopilot
+  apiGroup: rbac.authorization.k8s.io

--- a/autopilot/base/clusterrolebindings/kustomization.yaml
+++ b/autopilot/base/clusterrolebindings/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot.yaml
+- prometheus-k8s-autopilot.yaml

--- a/autopilot/base/clusterrolebindings/prometheus-k8s-autopilot.yaml
+++ b/autopilot/base/clusterrolebindings/prometheus-k8s-autopilot.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-autopilot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s-autopilot
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/autopilot/base/clusterroles/autopilot.yaml
+++ b/autopilot/base/clusterroles/autopilot.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: autopilot
+  namespace: autopilot
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "create"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list", "get", "patch", "watch"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["list", "get"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["list", "get", "create", "delete"]

--- a/autopilot/base/clusterroles/kustomization.yaml
+++ b/autopilot/base/clusterroles/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot.yaml
+- prometheus-k8s-autopilot.yaml

--- a/autopilot/base/clusterroles/prometheus-k8s-autopilot.yaml
+++ b/autopilot/base/clusterroles/prometheus-k8s-autopilot.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s-autopilot
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/autopilot/base/daemonsets/autopilot.yaml
+++ b/autopilot/base/daemonsets/autopilot.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: autopilot
+  name: autopilot
+  namespace: autopilot
+spec:
+  selector:
+    matchLabels:
+      app: autopilot
+  template:
+    metadata:
+      annotations:
+        null
+      labels:
+        app: autopilot
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: 'true'
+      serviceAccountName: autopilot
+      initContainers:
+        - args:
+          - |
+            until [ -f /usr/bin/nvidia-smi ]; do echo waiting for nvidia device plug-in to be setup; sleep 5 && exit -1; done
+          command:
+          - sh
+          - -c
+          image: quay.io/autopilot/autopilot:v1.9.0
+          imagePullPolicy: Always
+          name: device-plugin-validation
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+      containers:
+        - image: quay.io/autopilot/autopilot:v1.9.0
+          command:
+          - sh
+          - -c
+          - |
+            iperf3 -s -p 6310 -D
+            /usr/local/bin/autopilot --port 3333 --loglevel=2 --bw 4 --w 1 --invasive-check-timer 4
+          imagePullPolicy: Always
+          name: autopilot
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+          env:
+            - name: PERIODIC_CHECKS
+              value: pciebw,remapped,dcgm,ping,gpupower
+            - name: PVC_TEST_STORAGE_CLASS
+              value:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: "POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 3333
+              name: healthcheck
+            - containerPort: 8081
+              name: http
+            - containerPort: 8080
+              name: readinessprobe
+          readinessProbe:
+            httpGet:
+              path: /readinessprobe
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 120
+            timeoutSeconds: 10
+          livenessProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 120
+            timeoutSeconds: 15
+            exec:
+              command:
+                - nvidia-smi
+          resources:
+            limits:
+              nvidia.com/gpu: 0
+            requests:
+              nvidia.com/gpu: 0
+          volumeMounts: []
+      volumes: []

--- a/autopilot/base/daemonsets/kustomization.yaml
+++ b/autopilot/base/daemonsets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot.yaml

--- a/autopilot/base/kustomization.yaml
+++ b/autopilot/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccounts
+- clusterroles
+- clusterrolebindings
+- services
+- daemonsets
+- servicemonitors
+commonLabels:
+  app.kubernetes.io/name: autopilot
+  app.kubernetes.io/component: autopilot
+  app.kubernetes.io/part-of: autopilot

--- a/autopilot/base/serviceaccounts/autopilot.yaml
+++ b/autopilot/base/serviceaccounts/autopilot.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: autopilot
+  namespace: autopilot

--- a/autopilot/base/serviceaccounts/kustomization.yaml
+++ b/autopilot/base/serviceaccounts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot.yaml

--- a/autopilot/base/servicemonitors/autopilot-metrics-monitor.yaml
+++ b/autopilot/base/servicemonitors/autopilot-metrics-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: autopilot
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/component: metrics
+  name: autopilot-metrics-monitor
+  namespace: autopilot
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+      scheme: http
+  selector:
+    matchLabels:
+      app: autopilot

--- a/autopilot/base/servicemonitors/kustomization.yaml
+++ b/autopilot/base/servicemonitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot-metrics-monitor.yaml

--- a/autopilot/base/services/autopilot-healthchecks.yaml
+++ b/autopilot/base/services/autopilot-healthchecks.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autopilot
+  name: autopilot-healthchecks
+  namespace: autopilot
+  annotations:
+    null
+spec:
+  ports:
+    - port: 3333
+      protocol: TCP
+      name: healthcheck
+  selector:
+    app: autopilot

--- a/autopilot/base/services/autopilot-metrics-service.yaml
+++ b/autopilot/base/services/autopilot-metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autopilot
+  name: autopilot-metrics-service
+  namespace: autopilot
+spec:
+  ports:
+  - name: http
+    port: 8081
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: autopilot

--- a/autopilot/base/services/autopilot.yaml
+++ b/autopilot/base/services/autopilot.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autopilot
+  name: autopilot-readinessprobe
+  namespace: autopilot
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: readinessprobe
+  selector:
+    app: autopilot

--- a/autopilot/base/services/kustomization.yaml
+++ b/autopilot/base/services/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- autopilot-metrics-service.yaml
+- autopilot-healthchecks.yaml
+- autopilot.yaml

--- a/autopilot/observability/grafanadashboards/autopilot.yaml
+++ b/autopilot/observability/grafanadashboards/autopilot.yaml
@@ -1,0 +1,806 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: autopilot
+  namespace: grafana
+  labels:
+    app: grafana
+spec:
+  customFolderName: IBM autopilot
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 1,
+      "iteration": 1689354875983,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": "observability-metrics",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 22,
+          "panels": [],
+          "title": "Single Node Stats",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 20,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "autopilot_health_checks{cluster=\"$cluster\",node=\"$node\",health=\"$health\",deviceid=\"$deviceid\"}",
+              "interval": "",
+              "legendFormat": "{{ health }} for device {{ deviceid }} on {{ node }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Single Node Metrics",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "collapsed": false,
+          "datasource": "observability-metrics",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 24,
+          "panels": [],
+          "title": "All Nodes",
+          "type": "row"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "observability-metrics",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 3,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "autopilot_health_checks{health=\"pciebw\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "GPU {{ deviceid }} - {{ node }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "autopilot_health_checks{health=\"pciebw\"cluster=\"$cluster\",,node=\"$node\"}",
+              "hide": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "GPU {{ deviceid }} - {{ node }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PCIe Bandwidths (Gauge)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": "observability-metrics",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "autopilot_health_checks{health=\"pciebw\"} < 4",
+              "interval": "",
+              "legendFormat": "GPU {{deviceid}} - {{node}}",
+              "refId": "A"
+            }
+          ],
+          "title": "GPUs with low PCIeBW (less than 4 GB/s)",
+          "type": "stat"
+        },
+        {
+          "datasource": "observability-metrics",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 1
+                  },
+                  {
+                    "color": "green",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "string"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 4,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "autopilot_health_report_total{health=\"netdevice\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "NIC {{ deviceid }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "group (avg(autopilot_health_report_total{health=\"netdevice\"})) by (node))",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "{{ node }} ",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(autopilot_health_checks{health=\"net-reach\"})by(node) < 2",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{ node }}",
+              "refId": "C"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Faulty Secondary NIC by Node",
+          "type": "gauge"
+        },
+        {
+          "datasource": "observability-metrics",
+          "description": "Checks remapped rows on GPUs. If no remapped rows, then value is 0. 1 otherwise.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 8,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.17",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(autopilot_health_checks{health=\"remapped\"})by(node)>0",
+              "hide": false,
+              "interval": "",
+              "legendFormat": " {{ node }}",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Faulty Remapped Rows by Node",
+          "type": "gauge"
+        },
+        {
+          "collapsed": true,
+          "datasource": "observability-metrics",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 26,
+          "panels": [
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "observability-metrics",
+              "description": "",
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 11,
+                "x": 0,
+                "y": 27
+              },
+              "hiddenSeries": false,
+              "id": 12,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.17",
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "exemplar": true,
+                  "expr": "sum_over_time(scrape_series_added{job=\"autopilot-metrics-service\"}[1h]) ",
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Approximate number of new series in this scrape",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "observability-metrics",
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "fill": 1,
+              "fillGradient": 0,
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 27
+              },
+              "hiddenSeries": false,
+              "id": 10,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "options": {
+                "alertThreshold": true
+              },
+              "percentage": false,
+              "pluginVersion": "7.5.17",
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "spaceLength": 10,
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "exemplar": true,
+                  "expr": "topk(10, sum without(instance)(sum_over_time(scrape_series_added[1h])))",
+                  "hide": true,
+                  "interval": "",
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "exemplar": true,
+                  "expr": "sum_over_time(scrape_samples_scraped{job=\"autopilot-metrics-service\"}[1h])",
+                  "hide": false,
+                  "interval": "",
+                  "legendFormat": "{{pod}}",
+                  "refId": "C"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Number of samples exposed",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            }
+          ],
+          "title": "Timeseries Stats",
+          "type": "row"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 27,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": "",
+            "datasource": "observability-metrics",
+            "definition": "label_values(autopilot_health_checks, cluster)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": "Cluster",
+            "multi": true,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "query": "label_values(autopilot_health_checks, cluster)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": "",
+            "datasource": "observability-metrics",
+            "definition": "label_values(autopilot_health_checks, node)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": "Node",
+            "multi": true,
+            "name": "node",
+            "options": [],
+            "query": {
+              "query": "label_values(autopilot_health_checks, node)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "/wrk-*/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": "",
+            "current": {
+              "selected": false,
+              "text": "pciebw",
+              "value": "pciebw"
+            },
+            "datasource": "observability-metrics",
+            "definition": "label_values(autopilot_health_checks, health)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Health Check",
+            "multi": false,
+            "name": "health",
+            "options": [],
+            "query": {
+              "query": "label_values(autopilot_health_checks, health)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": "",
+            "datasource": "observability-metrics",
+            "definition": "label_values(autopilot_health_checks, deviceid)",
+            "description": "GPU (0-7)",
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": "Device ID",
+            "multi": true,
+            "name": "deviceid",
+            "options": [],
+            "query": {
+              "query": "label_values(autopilot_health_checks, deviceid)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Autopilot",
+      "uid": "Ny3de_UVz",
+      "version": 8
+    }

--- a/autopilot/observability/grafanadashboards/kustomization.yaml
+++ b/autopilot/observability/grafanadashboards/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - autopilot.yaml

--- a/autopilot/observability/kustomization.yaml
+++ b/autopilot/observability/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - grafanadashboards
+commonLabels:
+  app.kubernetes.io/name: autopilot
+  app.kubernetes.io/component: autopilot
+  app.kubernetes.io/part-of: autopilot

--- a/autopilot/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: grafana
+
+resources:
+- ../../observability

--- a/autopilot/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: autopilot
+
+resources:
+- ../../base

--- a/autopilot/overlays/nerc-ocp-test/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: autopilot
+
+resources:
+- ../../base

--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -27,6 +27,9 @@ data:
       - kube_pod_status_ready_time
       - kube_pod_status_unschedulable
       - loki_distributor_bytes_received_total
+      - autopilot_health_checks
+      - autopilot_health_report_total
+      - scrape_series_added
     matches:
       - __name__=~"(ipmi_.*)"
       - __name__=~"(ceph_.*)"

--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -287,6 +287,118 @@ data:
             description: |
               info: kube_pod_owner: {{ $value }} pod owners
 
+      - name: IBM autopilot
+        rules:
+        - name: Alerts on GPU related issues
+          rules:
+          - alert: LowPCIeBandwidth
+            annotations:
+              description: |
+                GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has a PCIE bandwidth of {{ $value }} {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: GPU with a PCIe bandwidth of 4 or less
+            expr: |
+              sum (autopilot_health_checks{health="pciebw"}<=4) by (node, deviceid, value) > 0
+            for: 1m
+            labels:
+              severity: warning
+              alert: autopilot
+          - alert: DCGMLevel1Errors
+            annotations:
+              description: |
+                GPUs on node {{ $labels.node }} have DCGM Level 1 failures '{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: GPUs have DCGM failures
+            expr: |
+              sum (autopilot_health_checks{health="dcgm"}==1) by (node)
+            for: 1m
+            labels:
+              severity: warning
+              alert: autopilot
+          - alert: GPUPowerSlowdownEnabled
+            annotations:
+              description: |
+                GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has power slowdown enabled
+              summary: A GPU has power slowdown enabled {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+            expr: |
+              sum (autopilot_health_checks{health="power-slowdown"}==1) by (node, deviceid)
+            for: 1m
+            labels:
+              severity: warning
+              alert: autopilot
+          - alert: RemappedRowsActive
+            annotations:
+              description: |
+                GPU device {{ $labels.deviceid}} on node {{ $labels.node }} with incorrect remapped rows in memory {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: A GPU device has incorrect remapped rows
+            expr: |
+              sum (autopilot_health_checks{health="remapped"}==1) by (node, deviceid)
+            for: 1m
+            labels:
+              severity: warning
+              alert: autopilot
+          - alert: DCGMLevel3Errors
+            annotations:
+              description: |
+                A node reported errors after running DCGM level 3 - check health of nodes {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: Node {{ $labels.node }} has GPU errors
+            expr: |
+              kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
+            for: 1m
+            labels:
+              severity: critical
+              alert: autopilot
+        - name: Alerts on network related issues
+          rules:
+            - alert: PingFailures
+              annotations:
+                description: |
+                  IP {{ $labels.deviceid }} on node {{ $labels.node }} is unreachable {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+                summary: Node has unreachable IPs
+              expr: |
+                sum (autopilot_health_checks{health="ping"}==1) by (deviceid)
+              for: 10m
+              labels:
+                severity: critical
+                alert: autopilot
+        - name: Alerts on PVC related issues
+          rules:
+          - alert: PVCAlert
+            annotations:
+              description: |
+                PVC creation by Autopilot on node {{ $labels.node }} failed {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: PVC cannot be created
+            expr: |
+              sum (autopilot_health_checks{health="pvc"}==1) by (node)
+            for: 1m
+            labels:
+              severity: critical
+              alert: autopilot
+        - name: Generic alert on periodic check failure
+          rules:
+          - alert: GPUNodeHealth
+            annotations:
+              description: |
+                Node {{ $labels.node }} reported errors after running Autopilot's periodic health checks {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
+              summary: Node {{ $labels.node }} has errors
+            expr: |
+              kube_node_labels{label_autopilot_ibm_com_gpuhealth=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_gpuhealth!~""}
+            for: 1m
+            labels:
+              severity: warning
+              alert: autopilot
+        - name: Alerts on Autopilot pods not ready
+          rules:
+          - alert: AutopilotPodsFailing
+            annotations:
+              description: Autopilot pod on node {{ $labels.node }} are failing {{ with $console_url := "console_url" | query }}{{ if ne
+                  (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url
+                  ) }}{{ end }}{{ end }}.
+              summary: Autopilot pod on node {{ $labels.node }} is failing
+            expr: count(kube_pod_info{} and on(pod) (kube_pod_container_status_waiting{namespace=~"autopilot.*"} > 0)) by (namespace)
+            for: 5m
+            labels:
+              severity: critical
+              alert: autopilot
+
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.
 # The up metric is useful for debugging and alerting for targets that are down or having issues.

--- a/cluster-scope/base/core/namespaces/autopilot/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/autopilot/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/autopilot/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/autopilot/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autopilot
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+spec: {}

--- a/cluster-scope/bundles/autopilot/kustomization.yaml
+++ b/cluster-scope/bundles/autopilot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: autopilot
+resources:
+- ../../base/core/namespaces/autopilot

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -29,3 +29,9 @@ spec:
         'Deny'
       role_attribute_strict: true
       client_id: grafana
+  dashboardLabelSelector:
+  - matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - grafana

--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -51,8 +51,7 @@ spec:
         pci:
           deviceClassWhitelist:
           - "0200"
-          - "0300"
-          - "0302"
+          - "03"
+          - "12"
           deviceLabelFields:
           - "vendor"
-          - "class"


### PR DESCRIPTION
We wish to use the IBM Autopilot application. A Kubernetes-native daemon
that continuously monitors and evaluates GPUs, network and storage
health, designed to detect and report infrastructure-level issues during
the lifetime of AI workloads. We will deploy autopilot to the test and
prod cluster, and the grafana dashboard to the obs cluster.

Closes nerc-project/operations#769