### PR TITLE
nerc-ocp-test: add gatekeeper-operator bundle to cluster overlay

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gatekeeper-operator-product
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: gatekeeper-operator-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
+++ b/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: gatekeeper
+resources:
+  - ../../base/operators.coreos.com/subscriptions/gatekeeper-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - feature/odf
 - feature/rhoai
 - ../../bundles/clusterissuer-http01
+- ../../bundles/gatekeeper-operator
 - ../../bundles/hostpath-provisioner
 - ../../bundles/node-feature-discovery
 - ../../bundles/patch-operator


### PR DESCRIPTION
This PR adds an operator bundle for gatekeeper operator to the cluster scope resources, and installs the operator on the nerc-ocp-test cluster.