### PR TITLE
ocp-test: add support for local users via htpasswd

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/externalsecret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: oauth-htpasswd
+  namespace: openshift-config
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: nerc-secret-store
+  target:
+    name: oauth-htpasswd
+    # Prevent generated Secret from inheriting the labels from this
+    # ExternalSecret. OpenShift will create a copy of the Secret, and the
+    # labels will causse it to show up as out-of-sync in ArgoCD. See
+    # https://github.com/OCP-on-NERC/operations/issues/42 for additional
+    # details.
+    template:
+      metadata:
+        labels: {}
+  data:
+    - secretKey: htpasswd
+      remoteRef:
+        key: REPLACE_IN_OVERLAY
+        property: htpasswd

--- a/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - externalsecret.yaml

--- a/cluster-scope/components/nerc-oauth-htpasswd/kustomization.yaml
+++ b/cluster-scope/components/nerc-oauth-htpasswd/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ../../base/external-secrets.io/externalsecrets/oauth-htpasswd
+
+patches:
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+          - name: local-login-htpasswd
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: oauth-htpasswd

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
 
 components:
   - ../../components/nerc-oauth-github
+  - ../../components/nerc-oauth-htpasswd
 
   # this must come last in order to apply
   # to all resources.
@@ -75,6 +76,13 @@ patches:
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-test/openshift-config/github-client-secret
+- target:
+    kind: ExternalSecret
+    name: oauth-htpasswd
+  patch: |
+    - op: replace
+      path: /spec/data/0/remoteRef/key
+      value: nerc/nerc-ocp-test/openshift-config/oauth-htpasswd
 
 - target:
     kind: SecretStore


### PR DESCRIPTION
This adds an htpasswd component that includes a patch to the OAuth resource and an externalsecret for the htpasswd file contents. This will enable us to create local user accounts for testing as non-admins or other use cases (e.g. monitoring via nagios for example)