### PR TITLE
Cleanup zookeeper deployment on obs cluster for ai-telemetry

### DIFF
--- a/ai-telemetry/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/ai-telemetry/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: zookeeper
 resources:
 - ../../base

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/keycloak
 - ../../bundles/prom-keycloak-proxy
+- ../../bundles/zookeeper
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/core/namespaces/dex
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac


### PR DESCRIPTION
This is for the ai-telemetry project to include a Zookeeper cluster
manager for Solr search engine and ai-telemetry event bus messages.
