### PR TITLE
ocp-test: add udev rules for a100 mlx5 nics

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWxkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018SSNu6FmIvXvYAAAAD//9CsdZdgAQAA
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWxkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018SSNu6FmEt995qZ0sa9EHPxuhcQAAD///2wC9YQAgAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
         - contents:

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/mlx5_core.rules
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/mlx5_core.rules
@@ -2,3 +2,5 @@ SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:07:00.0",ACTION=="add",NAME
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:07:00.1",ACTION=="add",NAME="nic2"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:49:00.0",ACTION=="add",NAME="nic1"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:49:00.1",ACTION=="add",NAME="nic2"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.1",ACTION=="add",NAME="nic2"


### PR DESCRIPTION
This adds udev rules for the Mellanox nics connected to the A100 host added via ESI (wrk-4) in the nerc-admins project (MOC-R8PAC23U27). These rules were manually put in place and verified working.