### PR TITLE
Fix to NVIDIA GPU driver devices as volume mounts

### DIFF
--- a/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
+++ b/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
@@ -23,6 +23,9 @@ spec:
       default: ""
       name: ""
     enabled: true
+    env:
+    - name: DEVICE_LIST_STRATEGY
+      value: volume-mounts
   driver:
     certConfig:
       name: ""
@@ -76,6 +79,9 @@ spec:
   toolkit:
     enabled: true
     installDir: /usr/local/nvidia
+    env:
+    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
+      value: "true"
   validator:
     plugin:
       env:

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -14,3 +14,5 @@ spec:
     env:
       - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
         value: 'false'
+      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
+        value: "true"


### PR DESCRIPTION
A suggested fix from NVIDIA for the drivers that were going missing on
the GPU nodes in the prod, test, and test-2 clusters. This fixes a bug with unprivileged access to device plugin. 

These fixes to the GPU Cluster Policy have resolved the GPU driver issues on the test cluster. 

Fixes nerc-project/operations#768

**Important note: This PR requires removing the GPU Cluster Policy and uninstalling the nvidia-gpu-operator and reinstalling GPU Operator and GPU Cluster Policy.**

**In draft until the code freeze is over**