### PR TITLE
Upgrade Grafana operator and instance

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/grafana-operator/grafana-operator.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/grafana-operator/grafana-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-operator
   namespace: grafana
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -29,6 +29,7 @@ spec:
         'Deny'
       role_attribute_strict: true
       client_id: grafana
+  version: 11.3.0
   dashboardLabelSelector:
   - matchExpressions:
     - key: app


### PR DESCRIPTION
- Upgarde Grafana operator from channel 4 to 5
- Forced the grafana instance to run with version 11.3.0 to enable granual access to dashboards