### PR TITLE
IN DRAFT Add minio operator to infra and obs cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/minio-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/minio-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/minio-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/minio-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/minio-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/minio-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/minio-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/minio-operator/operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: minio-operator
+  namespace: minio-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: minio-operator
+  namespace: minio-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: minio-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/minio/kustomization.yaml
+++ b/cluster-scope/bundles/minio/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: minio
+resources:
+- ../../base/core/namespaces/minio-operator
+- ../../base/operators.coreos.com/operatorgroups/minio-operator
+- ../../base/operators.coreos.com/subscriptions/minio-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ../../bundles/patch-operator
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/multicluster-engine-operator
+- ../../bundles/minio
 - ../../bundles/grafana
 - ../../base/core/namespaces/dex
 - ../../base/core/namespaces/nerc-ocp-prod

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../../bundles/clusterissuer-http01
 - ../../bundles/nerc-certificate-clusterissuers
 - ../../bundles/external-secrets-clustersecretstore
+- ../../bundles/minio
 - ../../bundles/grafana
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/keycloak


### PR DESCRIPTION
The NooBaa operator is failing to provide stable object storage for logs
and metrics. We will migrate logs and ACM metrics storage to MinIO.
This requires MinIO to be installed on the infra and obs clusters.
