### PR TITLE
Removing specific version as confilct with the actual Grafana Operator

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -29,7 +29,6 @@ spec:
         'Deny'
       role_attribute_strict: true
       client_id: grafana
-  version: 11.3.0
   dashboardLabelSelector:
   - matchExpressions:
     - key: app


### PR DESCRIPTION
We will implement it back to version: 11.3.0 once Grafana Operator will be updated to v5