### PR TITLE
Upgrade rhoai operator in nerc-ocp-test cluster to v2.13.1

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -56,6 +56,7 @@ generatorOptions:
 
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
+- path: subscriptions/rhoai-operator-patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth

--- a/cluster-scope/overlays/nerc-ocp-test/subscriptions/rhoai-operator-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/subscriptions/rhoai-operator-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-operator
+  namespace: redhat-ods-operator
+spec:
+  startingCSV: rhods-operator.2.13.1


### PR DESCRIPTION
Closes: https://github.com/nerc-project/operations/issues/806