### PR TITLE
Configure a A100 node for for PCI passthrough

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: ""
-            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%0A
+            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%2C10de%3A144e%0A
           mode: 420
           overwrite: true
           path: /etc/modprobe.d/vfio.conf

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
@@ -11,7 +11,7 @@ storage:
     overwrite: true
     contents:
       inline: |
-        options vfio-pci ids=10de:1db6
+        options vfio-pci ids=10de:1db6,10de:144e
   - path: /etc/modules-load.d/vfio-pci.conf
     mode: 0644
     overwrite: true

--- a/virt/overlays/nerc-ocp-test/hyperconverged.yaml
+++ b/virt/overlays/nerc-ocp-test/hyperconverged.yaml
@@ -8,3 +8,5 @@ spec:
     pciHostDevices:
     - pciDeviceSelector: "10DE:1DB6"
       resourceName: "nvidia.com/GV100GL_Tesla_V100"
+    - pciDeviceSelector: "10DE:144E"
+      resourceName: "nvidia.com/A100_SXM4_40GB"


### PR DESCRIPTION
This allows us to test gpu passthrough with multiple GPUs in the test cluster.

This will let me test a single VM with multiple GPUs and multiple VMs each with a single GPU each on the same host.