### PR TITLE
Upgrading Grafana resources for Grafana 11.3

### DIFF
--- a/autopilot/observability/grafanadashboards/autopilot.yaml
+++ b/autopilot/observability/grafanadashboards/autopilot.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: autopilot
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: grafana
 spec:
-  customFolderName: IBM autopilot
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: IBM autopilot
   json: |
     {
       "annotations": {

--- a/grafana/base/clusterrolebindings/grafana-serviceaccount-cluster-monitoring-view.yaml
+++ b/grafana/base/clusterrolebindings/grafana-serviceaccount-cluster-monitoring-view.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grafana-serviceaccount-cluster-monitoring-view
+  name: grafana-sa-cluster-monitoring-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-monitoring-view
 subjects:
 - kind: ServiceAccount
-  name: grafana-serviceaccount
+  name: grafana-sa
   namespace: grafana

--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/ope-metrics.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/ope-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: ope-metrics
@@ -6,7 +6,10 @@ metadata:
   labels:
     app: grafana
 spec:
-  customFolderName: OPE
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: OPE
   json: |
     {
       "annotations": {

--- a/grafana/overlays/nerc-ocp-obs/grafanadatasources/observability-metrics.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadatasources/observability-metrics.yaml
@@ -1,26 +1,49 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   name: observability-metrics
   namespace: grafana
   labels:
     app.kubernetes.io/instance: grafana-obs
 spec:
-  name: observability-metrics
-  datasources:
-    - name: observability-metrics
-      access: proxy
-      editable: false
-      isDefault: true
-      jsonData:
-        httpHeaderName1: Authorization
-        timeInterval: 5s
-        tlsAuth: true
-        tlsAuthWithCACert: true
-      secureJsonData:
-        httpHeaderValue1: "Bearer ${GF_AUTH_TOKEN}"
-        tlsCACert: "${GF_TLSCACERT}"
-        tlsClientCert: "${GF_TLSCLIENTCERT}"
-        tlsClientKey: "${GF_TLSCLIENTKEY}"
-      type: prometheus
-      url: 'https://observatorium-api-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/api/metrics/v1/default'
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: "oauth-client-secret"
+          key: "GF_AUTH_TOKEN"
+    - targetPath: "secureJsonData.tlsCACert"
+      valueFrom:
+        secretKeyRef:
+          name: "oauth-client-secret"
+          key: "GF_TLSCACERT"
+    - targetPath: "secureJsonData.tlsClientCert"
+      valueFrom:
+        secretKeyRef:
+          name: "oauth-client-secret"
+          key: "GF_TLSCLIENTCERT"
+    - targetPath: "secureJsonData.tlsClientKey"
+      valueFrom:
+        secretKeyRef:
+          name: "oauth-client-secret"
+          key: "GF_TLSCLIENTKEY"
+  datasource:
+    name: observability-metrics
+    access: proxy
+    editable: false
+    isDefault: true
+    jsonData:
+      httpHeaderName1: Authorization
+      timeInterval: 5s
+      tlsAuth: true
+      tlsAuthWithCACert: true
+    secureJsonData:
+      httpHeaderValue1: "Bearer ${GF_AUTH_TOKEN}"
+      tlsCACert: "${GF_TLSCACERT}"
+      tlsClientCert: "${GF_TLSCLIENTCERT}"
+      tlsClientKey: "${GF_TLSCLIENTKEY}"
+    type: prometheus
+    url: 'https://observatorium-api-open-cluster-management-observability.apps.nerc-ocp-infra.rc.fas.harvard.edu/api/metrics/v1/default'

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -1,37 +1,46 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: grafana
   namespace: grafana
+  labels:
+    dashboards: grafana
+    folders: grafana
 spec:
-  deployment:
-    envFrom:
-      - secretRef:
-          name: oauth-client-secret
-      - secretRef:
-          name: grafana-serviceaccount-token
-      - configMapRef:
-          name: openshift-service-ca.crt
   config:
     server:
-      root_url: https://grafana.apps.obs.nerc.mghpcc.org
+      root_url: 'https://grafana.apps.obs.nerc.mghpcc.org'
+    auth:
+      disable_login_form: 'false'
     auth.generic_oauth:
-      enabled: true
-      scopes: openid email groups profile
-      email_attribute_path: name
-      api_url: https://dex-dex.apps.obs.nerc.mghpcc.org/userinfo
-      auth_url: https://dex-dex.apps.obs.nerc.mghpcc.org/auth
-      token_url: https://dex-dex.apps.obs.nerc.mghpcc.org/token
+      enabled: 'true'
+      client_secret: '${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}'
+      token_url: 'https://dex-dex.apps.obs.nerc.mghpcc.org/token'
+      api_url: 'https://dex-dex.apps.obs.nerc.mghpcc.org/userinfo'
+      name: OAuth
+      email_attribute_path: email
+      client_id: grafana
       role_attribute_path: >-
         contains(groups[*], 'cluster-admins') && 'Admin' ||
         contains(groups[*], 'nerc-ops')  && 'Admin' ||
         contains(groups[*], 'nerc-logs-metrics')  && 'Admin' ||
         'Deny'
-      role_attribute_strict: true
-      client_id: grafana
-  dashboardLabelSelector:
-  - matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - grafana
+      auth_url: 'https://dex-dex.apps.obs.nerc.mghpcc.org/auth'
+      scopes: openid email groups profile
+    log:
+      mode: console
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: 'grafana/grafana:11.3.0'
+              name: grafana
+              envFrom:
+                - secretRef:
+                    name: oauth-client-secret
+                - secretRef:
+                    name: grafana-sa-token
+                - configMapRef:
+                    name: openshift-service-ca.crt
+  version: 11.3.0

--- a/grafana/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/kustomization.yaml
@@ -13,9 +13,9 @@ patches:
   - path: patches/grafana-route.yaml
 
 secretGenerator:
-  - name: grafana-serviceaccount-token
+  - name: grafana-sa-token
     type: kubernetes.io/service-account-token
     options:
       disableNameSuffixHash: true
       annotations:
-        kubernetes.io/service-account.name: grafana-serviceaccount
+        kubernetes.io/service-account.name: grafana-sa


### PR DESCRIPTION
The latest 11.3 version of Grafana introduces a new apiVersion
grafana.integreatly.org/v1beta1, as well as some CRD schema changes to
Grafana, GrafanaDatasource, and GrafanaDashboard resources.
