### PR TITLE
Fix incorrect PCIe IDs of A100

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: ""
-            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%2C10de%3A144e%0A
+            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%2C10de%3A20b0%0A
           mode: 420
           overwrite: true
           path: /etc/modprobe.d/vfio.conf

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
@@ -11,7 +11,7 @@ storage:
     overwrite: true
     contents:
       inline: |
-        options vfio-pci ids=10de:1db6,10de:144e
+        options vfio-pci ids=10de:1db6,10de:20b0
   - path: /etc/modules-load.d/vfio-pci.conf
     mode: 0644
     overwrite: true

--- a/virt/overlays/nerc-ocp-test/hyperconverged.yaml
+++ b/virt/overlays/nerc-ocp-test/hyperconverged.yaml
@@ -8,5 +8,5 @@ spec:
     pciHostDevices:
     - pciDeviceSelector: "10DE:1DB6"
       resourceName: "nvidia.com/GV100GL_Tesla_V100"
-    - pciDeviceSelector: "10DE:144E"
+    - pciDeviceSelector: "10DE:20B0"
       resourceName: "nvidia.com/A100_SXM4_40GB"


### PR DESCRIPTION
this PR corrects it.

```
sh-5.1# lspci -nnv | grep -i nvidia
31:00.0 3D controller [0302]: NVIDIA Corporation GA100 [A100 SXM4 40GB] [10de:20b0] (rev a1)
	Subsystem: NVIDIA Corporation Device [10de:144e]
```