### PR TITLE
Upgrading odf operator to 4.15 in obs cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.14
+    channel: stable-4.15


### PR DESCRIPTION
This will fix the upgrade issue: ClusterServiceVersions blocking cluster
upgrade: openshift-storage/odf-operator.v4.14.11-rhodf is incompatible
with OpenShift minor versions greater than 4.15

Fixes https://github.com/nerc-project/operations/issues/785