### PR TITLE
ocp-prod: bump image registry PVC to 750Gi

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -138,3 +138,10 @@ patches:
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.shift.nerc.mghpcc.org
+- target:
+    kind: PersistentVolumeClaim
+    name: image-registry-storage
+  patch: |
+    - op: replace
+      path: /spec/resources/requests/storage
+      value: 750Gi


### PR DESCRIPTION
closes nerc-project/operations#816