### PR TITLE
ocp-test: allow secretstore in csi-wekafsplugin ns

### DIFF
--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
@@ -19,6 +19,7 @@ auth:
     - openshift-logging
     - koku-metrics-operator
     - curator-system
+    - csi-wekafsplugin
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
This is needed in order to fetch weka secrets from vault. See #603