### PR TITLE
disable automatic NVIDIA driver upgrades

### DIFF
--- a/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
+++ b/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
@@ -38,7 +38,7 @@ spec:
     repoConfig:
       configMapName: ""
     upgradePolicy:
-      autoUpgrade: true
+      autoUpgrade: false
       drain:
         deleteEmptyDir: false
         enable: false


### PR DESCRIPTION
Automatic upgrades of the NVIDIA driver are dangerous in production given that they often happen unattended and are likely to cause issues on at least a subset of nodes. In the best case, user workloads are impacted at unpredictable times.

This patch disables automatic upgrades by default. Systems that want automatic upgrades should patch the GPU cluster policy in an overlay.