### PR TITLE
odf: enable ceph tools by default

### DIFF
--- a/cluster-scope/base/odf.openshift.io/storageclusters/ocs-external-storagecluster/storagecluster.yaml
+++ b/cluster-scope/base/odf.openshift.io/storageclusters/ocs-external-storagecluster/storagecluster.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   externalStorage:
     enable: true
+  enableCephTools: true


### PR DESCRIPTION
This enables the ceph tools pod deployment in the openshift-storage by default given that it's useful for debugging issues and inspecting the current state of ceph.