### PR TITLE
Adding minio with dex auth to nerc-ocp-test cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/minio/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/minio/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/minio/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/minio/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+spec: {}

--- a/cluster-scope/bundles/minio/kustomization.yaml
+++ b/cluster-scope/bundles/minio/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: minio
+resources:
+- ../../base/core/namespaces/minio

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - ../../bundles/openshift-pipelines-operator
 - ../../bundles/virt
 - ../../bundles/autopilot
+- ../../bundles/minio
 
 components:
   - ../../components/nerc-oauth-github

--- a/minio/base/console-route.yaml
+++ b/minio/base/console-route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: minio-console
+spec:
+  port:
+    targetPort: console
+  to:
+    kind: "Service"
+    name: minio
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/minio/base/deployment.yaml
+++ b/minio/base/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: minio
+        envFrom:
+        - secretRef:
+            name: minio-admin-credentials
+        - configMapRef:
+            name: minio-config
+            optional: true
+        image: docker.io/minio/minio:RELEASE.2024-11-07T00-52-20Z
+        ports:
+        - containerPort: 9000
+          name: object-storage
+        - containerPort: 8080
+          name: console
+        args:
+        - server
+        - --console-address
+        - ":8080"
+        - /data
+        volumeMounts:
+        - name: minio-data
+          mountPath: /data
+        livenessProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 1
+          httpGet:
+            scheme: HTTP
+            path: /minio/health/live
+            port: 9000
+      volumes:
+      - name: minio-data
+        persistentVolumeClaim:
+          claimName: minio-data

--- a/minio/base/externalsecret-minio-admin-credentials.yaml
+++ b/minio/base/externalsecret-minio-admin-credentials.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-admin-credentials
+  namespace: minio
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: minio-admin-credentials
+  dataFrom:
+    - extract:
+        key: $ENV/$CLUSTER/minio/minio-config

--- a/minio/base/kustomization.yaml
+++ b/minio/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: minio
+commonLabels:
+  app: minio
+
+resources:
+- externalsecret-minio-admin-credentials.yaml
+- deployment.yaml
+- pvc.yaml
+- service.yaml
+- console-route.yaml
+- object-storage-route.yaml

--- a/minio/base/object-storage-route.yaml
+++ b/minio/base/object-storage-route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: minio
+spec:
+  port:
+    targetPort: object-storage
+  to:
+    kind: "Service"
+    name: minio
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/minio/base/pvc.yaml
+++ b/minio/base/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  storageClassName: ocs-external-storagecluster-ceph-rbd
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/minio/base/service.yaml
+++ b/minio/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+  - name: object-storage
+    port: 9000
+    targetPort: object-storage
+  - name: console
+    port: 8080
+    targetPort: console

--- a/minio/overlays/nerc-ocp-test/externalsecrets/patch-minio-admin-credentials.yaml
+++ b/minio/overlays/nerc-ocp-test/externalsecrets/patch-minio-admin-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-admin-credentials
+  namespace: minio
+spec:
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-test/minio/minio-admin-credentials

--- a/minio/overlays/nerc-ocp-test/files/minio-config.env
+++ b/minio/overlays/nerc-ocp-test/files/minio-config.env
@@ -1,0 +1,11 @@
+# Documentation: https://min.io/docs/minio/linux/reference/minio-server/settings/iam/openid.html
+
+MINIO_IDENTITY_OPENID_CONFIG_URL=https://dex-dex.apps.ocp-test.nerc.mghpcc.org/.well-known/openid-configuration
+MINIO_IDENTITY_OPENID_CLIENT_ID=minio
+MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC=on
+
+# This tells minio to look up policy names in the "groups" claim (so e.g. if
+# someone in the "nerc-ops" group logs in, minio will look for a "nerc-ops"
+# policy to apply). A person cannot log in if there is no policy matches any of
+# the claim values.
+MINIO_IDENTITY_OPENID_CLAIM_NAME=groups

--- a/minio/overlays/nerc-ocp-test/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+
+configMapGenerator:
+- name: minio-config
+  namespace: minio
+  envs:
+  - files/minio-config.env
+
+patches:
+  - path: externalsecrets/patch-minio-admin-credentials.yaml


### PR DESCRIPTION
Adding support for object stores in the test cluster with authentication
and policy based authorization by OpenShift groups.
