### PR TITLE
Adding support for dex in the test cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - ../common
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/core/namespaces/openshift-gitops
+- ../../base/core/namespaces/dex
 - externalsecrets
 - secretstores
 - issuers

--- a/dex/overlays/nerc-ocp-test/configmaps/files/config.yaml
+++ b/dex/overlays/nerc-ocp-test/configmaps/files/config.yaml
@@ -1,0 +1,46 @@
+issuer: https://dex-dex.apps.ocp-test.nerc.mghpcc.org
+
+storage:
+  type: memory
+
+web:
+  http: "0.0.0.0:5556"
+
+grpc:
+  addr: "0.0.0.0:5557"
+
+telemetry:
+  http: "0.0.0.0:5558"
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: grafana
+    name: Grafana
+    redirectURIs:
+      - https://grafana.apps.ocp-test.nerc.mghpcc.org/login/generic_oauth
+    secretEnv: GRAFANA_SECRET
+  - id: minio
+    name: MinIO
+    redirectURIs:
+      - https://minio-console-minio.apps.ocp-test.nerc.mghpcc.org/oauth_callback
+      - https://minio-minio.apps.ocp-test.nerc.mghpcc.org/oauth_callback
+    secretEnv: MINIO_IDENTITY_OPENID_CLIENT_SECRET
+  - id: ai-telemetry
+    name: AI Telemetry
+    redirectURIs:
+      - https://keycloak.apps.obs.nerc.mghpcc.org/realms/NERC/broker/OpenShift/endpoint
+    secretEnv: AI_TELEMETRY_AUTH_SECRET
+
+connectors:
+  - type: openshift
+    id: openshift
+    name: OpenShift
+    config:
+      issuer: https://kubernetes.default.svc
+      clientID: system:serviceaccount:dex:dex
+      clientSecret: $OPENSHIFT_CLIENT_SECRET
+      redirectURI: https://dex-dex.apps.ocp-test.nerc.mghpcc.org/callback
+      groups:
+        - system:authenticated

--- a/dex/overlays/nerc-ocp-test/configmaps/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-test/configmaps/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  kustomize.config.k8s.io/behavior: merge
+
+configMapGenerator:
+  - files:
+      - files/config.yaml
+    name: dex

--- a/dex/overlays/nerc-ocp-test/externalsecrets/dex-clients_patch.yaml
+++ b/dex/overlays/nerc-ocp-test/externalsecrets/dex-clients_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-clients
+spec:
+  dataFrom:
+    - extract:
+        key: nerc-ocp-test/dex/dex-clients

--- a/dex/overlays/nerc-ocp-test/kustomization.yaml
+++ b/dex/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+resources:
+  - ../../base
+  - configmaps
+patches:
+  - path: externalsecrets/dex-clients_patch.yaml

--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
@@ -20,6 +20,7 @@ auth:
     - koku-metrics-operator
     - curator-system
     - csi-wekafsplugin
+    - dex
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
Adding dex OpenID Connect integration into the test cluster, for clients
who need OpenShift user authentication. This includes grafana, minio,
and ai-telemetry as clients we are testing.
