### PR TITLE
Fixing SecretStore reference for dex and minio on test

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/dex/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/dex/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - openshift-logging
 - group-sync-operator
 - curator-system
+- dex
+- minio

--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/minio/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/minio/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: minio
+components:
+  - ../../../../components/nerc-secret-store

--- a/dex/base/externalsecrets/dex-clients.yaml
+++ b/dex/base/externalsecrets/dex-clients.yaml
@@ -4,8 +4,8 @@ metadata:
   name: dex-clients
 spec:
   secretStoreRef:
-    name: nerc-cluster-secrets
-    kind: ClusterSecretStore
+    name: nerc-secret-store
+    kind: SecretStore
   refreshInterval: "1h"
   target:
     name: dex-clients

--- a/minio/base/externalsecret-minio-admin-credentials.yaml
+++ b/minio/base/externalsecret-minio-admin-credentials.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   refreshInterval: "1h"
   secretStoreRef:
-    name: nerc-cluster-secrets
-    kind: ClusterSecretStore
+    name: nerc-secret-store
+    kind: SecretStore
   target:
     name: minio-admin-credentials
   dataFrom:

--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
@@ -21,6 +21,7 @@ auth:
     - curator-system
     - csi-wekafsplugin
     - dex
+    - minio
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
There isn't a ClusterSecretStore in the nerc-ocp-test cluster, so we
will use namespace SecretStores instead for dex and minio.
