### PR TITLE
Adding 1Ti MinIO object storage to nerc-ocp-test

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/danni-ilab/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/danni-ilab/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: danni-ilab
+components:
+  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - curator-system
 - dex
 - minio
+- danni-ilab

--- a/minio/overlays/nerc-ocp-test/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-test/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- projects
 
 configMapGenerator:
 - name: minio-config
@@ -11,3 +12,4 @@ configMapGenerator:
 
 patches:
   - path: externalsecrets/patch-minio-admin-credentials.yaml
+  - path: persistentvolumeclaims/patch-pvc.yaml

--- a/minio/overlays/nerc-ocp-test/persistentvolumeclaims/patch-pvc.yaml
+++ b/minio/overlays/nerc-ocp-test/persistentvolumeclaims/patch-pvc.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  resources:
+    requests:
+      storage: 1Ti

--- a/minio/overlays/nerc-ocp-test/projects/danni-ilab.yaml
+++ b/minio/overlays/nerc-ocp-test/projects/danni-ilab.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-bucket
+  namespace: danni-ilab
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: nerc-secret-store
+    kind: SecretStore
+  target:
+    name: minio-bucket
+  dataFrom:
+    - extract:
+        key: nerc/nerc-ocp-test/minio/projects/danni-ilab

--- a/minio/overlays/nerc-ocp-test/projects/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-test/projects/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- danni-ilab.yaml

--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-test.yaml
@@ -22,6 +22,7 @@ auth:
     - csi-wekafsplugin
     - dex
     - minio
+    - danni-ilab
     name: secret-reader
     policies:
     - nerc-common-reader


### PR DESCRIPTION
There are other projects using the test cluster that could use 300Gi
object storage. We will increase the size of the MinIO PVC from 10Gi to
1Ti.
