### PR TITLE
Manage NVIDIA Driver Upgrades via GPU Operator clusterPolicy Resource

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  driver:
+    image: driver
+    repository: nvcr.io/nvidia
+    version: 550.127.05

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
   - ../../base
+patches:
+  - path: clusterpolicy/clusterpolicy_patch.yaml

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -3,6 +3,10 @@ kind: ClusterPolicy
 metadata:
   name: gpu-cluster-policy
 spec:
+  driver:
+    image: driver
+    repository: nvcr.io/nvidia
+    version: 550.127.05
   mig:
     strategy: single
   migManager:


### PR DESCRIPTION
This PR changes how we track nvidia driver upgrades in nerc-ocp-test and nerc-ocp-prod. Since manual operator upgrades are disabled, we will need to change the driver version and toggle the upgrade policy to automatic to implement the upgrades. 