### PR TITLE
nerc-ocp-prod: Fix None acceleratorProfile in RHOAI

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  toolkit:
+    env:
+      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
+        value: 'false'

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
   - ../../base
+patches:
+  - path: clusterpolicy/clusterpolicy_patch.yaml


### PR DESCRIPTION
Addresses: https://github.com/nerc-project/operations/issues/685

In https://github.com/OCP-on-NERC/nerc-ocp-config/pull/566 we tested this clusterpolicy config change with success. This PR will bring the change to the prod RHOAI installation.

Marking as a draft for now, since this will require some of the operator pods to reconfigure we should tactically merge this during the Jan maintenance period