### PR TITLE
Explicitly create service account token for eso-vault-auth-token

### DIFF
--- a/cluster-scope/base/core/secrets/eso-vault-auth-token/kustomization.yaml
+++ b/cluster-scope/base/core/secrets/eso-vault-auth-token/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+    - secret.yaml

--- a/cluster-scope/base/core/secrets/eso-vault-auth-token/secret.yaml
+++ b/cluster-scope/base/core/secrets/eso-vault-auth-token/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eso-vault-auth-token
+  annotations:
+    kubernetes.io/service-account.name: eso-vault-auth
+type: kubernetes.io/service-account-token

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview
 - ../../base/operators.coreos.com/operatorgroups/external-secrets
+- ../../base/core/secrets/eso-vault-auth-token/


### PR DESCRIPTION
With newer versions of kubernetes/openshift, it is necessary to explicitly
request a long-lived token for service accounts [1].

[1]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
