### PR TITLE
feat: adding mco_* to metrics allowlist

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -7,7 +7,6 @@ data:
   metrics_list.yaml: |
     names:
       - kube_persistentvolumeclaim_resource_requests_storage_bytes
-      - kube_pod_spec_volumes_persistentvolumeclaims_info
       - kube_persistentvolumeclaim_info
       - kube_storageclass_info
       - kubelet_volume_stats_used_bytes
@@ -49,3 +48,4 @@ data:
       - __name__=~"(argocd_.*)"
       - __name__=~"(kube_node_.*)"
       - __name__=~"(kube_pod_.*)"
+      - __name__=~"(mco_.*)"


### PR DESCRIPTION
# feat: adding moc_* to metrics allowlist

- `(mco_.*)` added to capture most needed currently `mco_degraded_machine_count`
- removed `kube_pod_spec_volumes_persistentvolumeclaims_info`, already captured by `(kube_pod_.*)`