### PR TITLE
This removes the A100 node from GPU PCI passthrough

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/100-worker-vfiopci.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: ""
-            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%2C10de%3A20b0%0A
+            source: data:,options%20vfio-pci%20ids%3D10de%3A1db6%0A
           mode: 420
           overwrite: true
           path: /etc/modprobe.d/vfio.conf

--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/pci-passthrough/src/100-worker-vfiopci.bu
@@ -11,7 +11,7 @@ storage:
     overwrite: true
     contents:
       inline: |
-        options vfio-pci ids=10de:1db6,10de:20b0
+        options vfio-pci ids=10de:1db6
   - path: /etc/modules-load.d/vfio-pci.conf
     mode: 0644
     overwrite: true

--- a/virt/overlays/nerc-ocp-test/hyperconverged.yaml
+++ b/virt/overlays/nerc-ocp-test/hyperconverged.yaml
@@ -8,5 +8,3 @@ spec:
     pciHostDevices:
     - pciDeviceSelector: "10DE:1DB6"
       resourceName: "nvidia.com/GV100GL_Tesla_V100"
-    - pciDeviceSelector: "10DE:20B0"
-      resourceName: "nvidia.com/A100_SXM4_40GB"


### PR DESCRIPTION
This leaves us with the V100 available for VM passthrough. 

I have unlabelled wrk-4 so the nvidia pods can run on it `oc label node wrk-4 nvidia.com/gpu.deploy.operands-`

