### PR TITLE
Enable notebook spawner for rhods-notebooks namespace

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -48,7 +48,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: false
+    enabled: true
     notebookNamespace: rhods-notebooks
     pvcSize: 20Gi
   notebookSizes:


### PR DESCRIPTION
I will be testing new gatekeeper policies for the ope classes so I will need the notebook spawner enabled in the test cluster. 