### PR TITLE
nerc-ocp-prod: Add RHOAI GPU AcceleratorProfiles

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/a100-acceleratorprofile.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/a100-acceleratorprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: nvidia-a100-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA A100 GPU
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - a100-acceleratorprofile.yaml
+  - v100-acceleratorprofile.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/v100-acceleratorprofile.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/v100-acceleratorprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: nvidia-v100-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA V100 GPU
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - odhdashboardconfigs/odh-dashboard-config.yaml
 - imagestreams/ucsls-f24-imagestream.yaml
 - imagestreams/oauth-proxy.yaml
+- acceleratorprofiles


### PR DESCRIPTION
Adds unique acceleratorProfiles for each GPU type in production cluster. These profiles will show up under accelerators in the RHOAI workbench wizard.

Part of: https://github.com/nerc-project/operations/issues/849
Closes: https://github.com/nerc-project/operations/issues/847