### PR TITLE
Grant nerc-test-people reader access to nerc-test-cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - nodenetworkconfigurationpolicies
 - feature/odf
 - feature/rhoai
+- rbac
 - ../../bundles/clusterissuer-http01
 - ../../bundles/gatekeeper-operator
 - ../../bundles/hostpath-provisioner
@@ -73,6 +74,7 @@ patches:
             - ocp-on-nerc/nerc-ops
             - ocp-on-nerc/nerc-logs-metrics
             - ocp-on-nerc/nerc-rhods
+            - ocp-on-nerc/nerc-test-people
 - target:
     kind: ExternalSecret
     name: github-client-secret

--- a/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nerc-test-people.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-people.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-people.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-test-people-readers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: nerc-test-people


### PR DESCRIPTION
Update the oauth configuration to permit access by the nerc-test-people
group, and grant this group cluster-reader access.
