### PR TITLE
Add llm_performance_* to metrics allowlist

### DIFF
--- a/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -49,3 +49,4 @@ data:
       - __name__=~"(kube_node_.*)"
       - __name__=~"(kube_pod_.*)"
       - __name__=~"(mco_.*)"
+      - __name__=~"(llm_performance_.*)"


### PR DESCRIPTION
This PR will allow prometheus to gather the metrics from the llm-load-test-exporter application, which gathers performance metrics for ai models running in a cluster: https://github.com/IsaiahStapleton/llm-load-test-exporter. 
