### PR TITLE
nerc-ocp-test: Remove redundant env var from clusterpolicy

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -14,5 +14,3 @@ spec:
     env:
       - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
         value: 'false'
-      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
-        value: "true"


### PR DESCRIPTION
The environment variable is already included in the base clusterpolicy resource. See https://github.com/OCP-on-NERC/nerc-ocp-config/pull/586