### PR TITLE
gpu: move toolkit env patches to base

### DIFF
--- a/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
+++ b/nvidia-gpu-operator/base/gpu-cluster-policy.yaml
@@ -82,6 +82,8 @@ spec:
     env:
     - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
       value: "true"
+    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
+      value: 'false'
   validator:
     plugin:
       env:

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -1,9 +1,0 @@
-apiVersion: nvidia.com/v1
-kind: ClusterPolicy
-metadata:
-  name: gpu-cluster-policy
-spec:
-  toolkit:
-    env:
-      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
-        value: 'false'

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -3,5 +3,3 @@ kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
   - ../../base
-patches:
-  - path: clusterpolicy/clusterpolicy_patch.yaml

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -9,8 +9,3 @@ spec:
     config:
       default: all-disabled
       name: test-mig-parted-config
-  toolkit:
-    enabled: true
-    env:
-      - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
-        value: 'false'


### PR DESCRIPTION
Both overlays (ocp-test and ocp-prod) in the nvidia-gpu-operator app are applying the same toolkit env patch. Moved this update to base.