### PR TITLE
fix: correct minio external secret changes

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/externalsecret.yaml
@@ -22,9 +22,6 @@ spec:
             insecure: false
             access_key: "{{ .access_key }}"
             secret_key: "{{ .secret_key }}"
-            http_config:
-              tls_config:
-                ca_file: "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
   data:
   - secretKey: bucket
     remoteRef:


### PR DESCRIPTION
fix: correct minio external secret changes

new secrets for minio were added manually, http tls config removed
this PR reflects these manual changes in GitOps