### PR TITLE
Remove ai-telemetry client permissions to metrics

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
@@ -164,12 +164,6 @@ spec:
             - name: group-ai-telemetry-namespace-all
               policy: group-ai-telemetry
               resource: namespace
-            - name: client-ai-telemetry-namespace-all
-              policy: client-ai-telemetry
-              resource: namespace
-            - name: client-ai-telemetry-cluster-all
-              policy: client-ai-telemetry
-              resource: cluster
 
             - name: group-nerc-ai4cloudops-namespace-all
               policy: group-nerc-ai4cloudops


### PR DESCRIPTION
We should remove the ai-telemetry client permissions to metrics all
clusters and all namespaces. This will allow groups of users to be
granted access to metrics with different permissions instead of all
users having access as we build the new ai-telemetry application.
