### PR TITLE
Upgrading keycloak in obs cluster to v26

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/rhbk-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rhbk-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rhbk-operator
   namespace: keycloak
 spec:
-  channel: stable-v24
+  channel: stable-v26
   installPlanApproval: Automatic
   name: rhbk-operator
   source: redhat-operators


### PR DESCRIPTION
This will bring in the latest fixes for fine-grain access control for AI
Telemetry and the Prometheus Keycloak Proxy.
