### PR TITLE
Add ai-telemetry-sa client for access to all metrics

### DIFF
--- a/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakauthorizations/nerc/keycloakauthorization.yaml
@@ -114,6 +114,15 @@ spec:
                   clients:
                     - ai-telemetry
 
+            - id: client-ai-telemetry-sa
+              name: client-ai-telemetry-sa
+              logic: POSITIVE
+              decisionStrategy: UNANIMOUS
+              type:
+                client:
+                  clients:
+                    - ai-telemetry-sa
+
             - id: client-ai4cloudops
               name: client-ai4cloudops
               logic: POSITIVE
@@ -163,6 +172,13 @@ spec:
               resource: cluster
             - name: group-ai-telemetry-namespace-all
               policy: group-ai-telemetry
+              resource: namespace
+
+            - name: client-ai-telemetry-sa-cluster-all
+              policy: client-ai-telemetry-sa
+              resource: cluster
+            - name: client-ai-telemetry-sa-namespace-all
+              policy: client-ai-telemetry-sa
               resource: namespace
 
             - name: group-nerc-ai4cloudops-namespace-all

--- a/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/keycloakrealmimports/nerc/keycloakrealmimport.yaml
@@ -307,6 +307,20 @@ spec:
             name: ai-telemetry
             protocol: openid-connect
             protocolMapper: oidc-audience-mapper
+      - id: ai-telemetry-sa
+        name: ai-telemetry-sa
+        description: A client scope for the ai-telemetry-sa client
+        protocol: openid-connect
+        protocolMappers:
+          - config:
+              access.token.claim: 'true'
+              id.token.claim: 'false'
+              included.client.audience: 'ai-telemetry-sa'
+            consentRequired: false
+            id: ai-telemetry-sa
+            name: ai-telemetry-sa
+            protocol: openid-connect
+            protocolMapper: oidc-audience-mapper
     defaultDefaultClientScopes:
       - nerc
     clients:
@@ -338,6 +352,19 @@ spec:
           - openid
           - profile
           - ai-telemetry
+        authorizationSettings:
+          decisionStrategy: AFFIRMATIVE
+      - id: ai-telemetry-sa
+        clientId: ai-telemetry-sa
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        authorizationServicesEnabled: true
+        frontchannelLogout: true
+        protocol: openid-connect
+        defaultClientScopes:
+          - openid
+          - profile
+          - ai-telemetry-sa
         authorizationSettings:
           decisionStrategy: AFFIRMATIVE
       - id: ai4cloudops


### PR DESCRIPTION
**Add ai-telemetry-sa client for access to all metrics**
Adding an ai-telemetry-sa service account client which has access to import all AI related metrics on all clusters for AI telemetry, separate from the main ai-telemetry client for all users.