### PR TITLE
prod: add GPU tolerations to the ODF daemonset

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/configmaps/rook-ceph-operator-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/configmaps/rook-ceph-operator-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  CSI_ENABLE_CSIADDONS: "true"
+  CSI_LOG_LEVEL: "5"
+  CSI_PLUGIN_TOLERATIONS: |2-
+
+    - key: node.ocs.openshift.io/storage
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+  CSI_PROVISIONER_TOLERATIONS: |2-
+
+    - key: node.ocs.openshift.io/storage
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+  ROOK_CSI_ENABLE_CEPHFS: "false"
+kind: ConfigMap
+metadata:
+  name: rook-ceph-operator-config
+  namespace: openshift-storage

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/configmaps/rook-ceph-operator-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/configmaps/rook-ceph-operator-config.yaml
@@ -8,11 +8,27 @@ data:
       operator: Equal
       value: "true"
       effect: NoSchedule
+    - key: nvidia.com/gpu.product
+      operator: Equal
+      value: "Tesla-V100-PCIE-32GB"
+      effect: NoSchedule
+    - key: nvidia.com/gpu.product
+      operator: Equal
+      value: "NVIDIA-A100-SXM4-40GB"
+      effect: NoSchedule
   CSI_PROVISIONER_TOLERATIONS: |2-
 
     - key: node.ocs.openshift.io/storage
       operator: Equal
       value: "true"
+      effect: NoSchedule
+    - key: nvidia.com/gpu.product
+      operator: Equal
+      value: "Tesla-V100-PCIE-32GB"
+      effect: NoSchedule
+    - key: nvidia.com/gpu.product
+      operator: Equal
+      value: "NVIDIA-A100-SXM4-40GB"
       effect: NoSchedule
   ROOK_CSI_ENABLE_CEPHFS: "false"
 kind: ConfigMap

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ../../../../bundles/odf-external
   - externalsecrets/rook-ceph-external-cluster-details.yaml
   - redhatcop.redhat.io/odf-node-patcher.yaml
+  - configmaps/rook-ceph-operator-config.yaml
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml


### PR DESCRIPTION
closes nerc-project/operations#903

Same fix on ocp-test solved the issue (#644)

The first commit in this PR adds the configmap that's currently active in production. Second commit adds the fix.