### PR TITLE
The NVIDIA GPU Operator requires GPU tolerations

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -9,3 +9,13 @@ spec:
     config:
       default: all-disabled
       name: test-mig-parted-config
+  daemonsets:
+    tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB


### PR DESCRIPTION
The NVIDIA DaemonSets are unable to run their pods without specifying
the tolerations given to the GPU nodes in the AcceleratorProfiles.

Fixes https://github.com/nerc-project/operations/issues/913