### PR TITLE
prod: add tolerations to clusterpolicy daemonset

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  daemonsets:
+    tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
   - ../../base
+patches:
+  - path: clusterpolicy/clusterpolicy_patch.yaml


### PR DESCRIPTION
The NVIDIA DaemonSets are unable to run their pods without specifying the tolerations given to the GPU nodes in the AcceleratorProfiles.

See #647 and nerc-project/operations#913