### PR TITLE
Add vlan 935 interfaces on obs cluster to access SNMP on MOC switches

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - vlan-2177-nese.yaml
+- vlan-935-moc-swmon.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-935-moc-swmon.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/vlan-935-moc-swmon.yaml
@@ -1,0 +1,20 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vlan-935-moc-swmon
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+    - name: bond0.935
+      type: vlan
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: true
+        auto-routes: true
+      vlan:
+        base-iface: bond0
+        id: 935
+      mtu: 9000


### PR DESCRIPTION
This adds vlan 935 tagged interfaces to obs cluster nodes in order to to access and monitor MOC switches.