### PR TITLE
ocp-prod: Add mongoDB operator bundle to cluster overlay

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/mongodb-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/mongodb-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongodb-operator
   namespace: openshift-operators
 spec:
-  Channel: alpha
+  channel: alpha
   installPlanApproval: Automatic
   name: mongodb-operator
   source: community-operators

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - ../../bundles/curator
 - ../../bundles/koku-metrics-operator
 - ../../bundles/autopilot
+- ../../bundles/mongodb-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin


### PR DESCRIPTION
This PR fixes a typo in the mongoDB subscription resource which was causing issues in argoCD, in the first commit

The second commit adds the operator to the nerc-ocp-prod cluster. 

Merging this PR would close: [https://github.com/nerc-project/operations/issues/917](https://github.com/nerc-project/operations/issues/917)

Marking as a draft until we have NERC sign-off for adding the new operator.