### PR TITLE
ocp-test: patch console object to include managementState

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -126,3 +126,11 @@ patches:
     - op: add
       path: /spec/plugins/-
       value: kubevirt-plugin
+- target:
+    kind: Console
+    name: cluster
+  patch: |
+    - op: add
+      path: /spec
+      value:
+        managementState: Managed


### PR DESCRIPTION
Closes issue: https://github.com/nerc-project/operations/issues/912 The console object "cluster" was giving error due to a missing managementState. Since we have a cutom console config we need to add a patch which includes this line with the value Managed, so the managementState does not fall off the console resource in the future.