### PR TITLE
ocp-test cluster upgrade from 4.16.32 -> 4.17.14

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.16
+  channel: stable-4.17
   clusterID: 2b3d6e03-1bfe-4d1e-bf32-3e2df96fc2bd
   desiredUpdate:
-    version: 4.16.32
+    version: 4.17.17

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
   name: odf-operator
 spec:
-  channel: stable-4.16
+  channel: stable-4.17


### PR DESCRIPTION
The first commit bumps the ocp-test cluster from 4.16 -> 4.17 and the second commit adjusts the odf operator in response.

Preparations for this upgrade took place in: https://github.com/nerc-project/operations/issues/912