### PR TITLE
Refactor snmp generator configuration

### DIFF
--- a/snmp-exporter/base/files/generator.yml
+++ b/snmp-exporter/base/files/generator.yml
@@ -7,40 +7,39 @@ auths:
 modules:
   system:
     walk:
-      - sysUpTime
       - SNMPv2-MIB::system
+      - SNMPv2-MIB::snmp
     overrides:
       sysName:
         type: DisplayString
-  snmpv2_mib:
-    walk: [snmp]
-  network_mib:
-    walk: [tcp, udp]
-  if_mib:
-    walk: [interfaces, ifXTable]
+  layer3:
+    walk:
+      - TCP-MIB::tcp
+      - UDP-MIB::udp
+      - IP-MIB::ipv4InterfaceTable
+  layer2:
+    walk:
+      - IF-MIB::ifTable
+      - IF-MIB::ifXTable
     lookups:
-      - source_indexes: [ifIndex]
+      - source_indexes:
+          - ifIndex
         lookup: ifAlias
-      - source_indexes: [ifIndex]
-        # Uis OID to avoid conflict with PaloAlto PAN-COMMON-MIB.
-        lookup: 1.3.6.1.2.1.2.2.1.2   # ifDescr
-      - source_indexes: [ifIndex]
-        # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
-        lookup: 1.3.6.1.2.1.31.1.1.1.1  # ifName
+      - source_indexes:
+          - ifIndex
+        lookup: IF-MIB::ifDescr
+      - source_indexes:
+          - ifIndex
+        lookup: IF-MIB::ifName
     overrides:
       ifAlias:
-        ignore: true  # Lookup metric
+        ignore: true
       ifDescr:
-        ignore: true  # Lookup metric
+        ignore: true
       ifName:
-        ignore: true  # Lookup metric
+        ignore: true
       ifType:
         type: EnumAsInfo
-
-  # Default IP-MIB with ipv4InterfaceTable for example.
-  ip_mib:
-    walk: [ipv4InterfaceTable]
-
   cisco_device:
     walk:
       - CISCO-PROCESS-MIB::cpmProcessTimeCreated
@@ -51,17 +50,23 @@ modules:
       - CISCO-MEMORY-POOL-MIB::ciscoMemoryPoolType
       - CISCO-MEMORY-POOL-MIB::ciscoMemoryPoolName
     lookups:
-      - source_indexes: [entPhysicalIndex]
+      - source_indexes:
+          - entPhysicalIndex
         lookup: CISCO-ENTITY-SENSOR-MIB::entSensorScale
-      - source_indexes: [entPhysicalIndex]
+      - source_indexes:
+          - entPhysicalIndex
         lookup: CISCO-ENTITY-SENSOR-MIB::entSensorType
-      - source_indexes: [entPhysicalIndex]
+      - source_indexes:
+          - entPhysicalIndex
         lookup: ENTITY-MIB::entPhysicalName
-      - source_indexes: [ciscoMemoryPoolType]
+      - source_indexes:
+          - ciscoMemoryPoolType
         lookup: ciscoMemoryPoolName
-      - source_indexes: [cempMemPoolIndex]
+      - source_indexes:
+          - cempMemPoolIndex
         lookup: cempMemPoolType
-      - source_indexes: [cempMemPoolIndex]
+      - source_indexes:
+          - cempMemPoolIndex
         lookup: cempMemPoolName
     overrides:
       entSensorScale:
@@ -84,7 +89,6 @@ modules:
         ignore: true
       cempMemPoolName:
         type: DisplayString
-
   cisco_fc_fe:
     walk:
       - CISCO-FC-FE-MIB::fcIfInvalidCrcs
@@ -96,21 +100,16 @@ modules:
       - CISCO-FC-FE-MIB::fcIfTxWaitCount
       - CISCO-FC-FE-MIB::fcIfCurrRxBbCredit
       - CISCO-FC-FE-MIB::fcIfCurrTxBbCredit
-
-  # Dell OpenManage MIBs
   dell:
     walk:
-      - 1.3.6.1.4.1.674.10892.5.2   # statusGroup
-      - 1.3.6.1.4.1.674.10892.5.4   # systemDetailsGroup
-      - 1.3.6.1.4.1.674.10892.5.5   # storageDetailsGroup
-
-  # Dell network (Force10)
+      - 1.3.6.1.4.1.674.10892.5.2
+      - 1.3.6.1.4.1.674.10892.5.4
+      - 1.3.6.1.4.1.674.10892.5.5
   dell_network:
     walk:
       - DELL-NETWORKING-CHASSIS-MIB::dellNetCpuUtilTable
       - DELL-NETWORKING-CHASSIS-MIB::dellNetPowerSupplyTable
       - DELL-NETWORKING-CHASSIS-MIB::dellNetSwModuleTable
-      # DELL-NETWORKING-CHASSIS-MIB::dellNetFlashStorageTable
     overrides:
       dellNetPowerSupplyIndex:
         ignore: true

--- a/snmp-exporter/base/files/generator.yml
+++ b/snmp-exporter/base/files/generator.yml
@@ -100,11 +100,6 @@ modules:
       - CISCO-FC-FE-MIB::fcIfTxWaitCount
       - CISCO-FC-FE-MIB::fcIfCurrRxBbCredit
       - CISCO-FC-FE-MIB::fcIfCurrTxBbCredit
-  dell:
-    walk:
-      - 1.3.6.1.4.1.674.10892.5.2
-      - 1.3.6.1.4.1.674.10892.5.4
-      - 1.3.6.1.4.1.674.10892.5.5
   dell_network:
     walk:
       - DELL-NETWORKING-CHASSIS-MIB::dellNetCpuUtilTable

--- a/snmp-exporter/base/files/generator.yml
+++ b/snmp-exporter/base/files/generator.yml
@@ -9,9 +9,6 @@ modules:
     walk:
       - SNMPv2-MIB::system
       - SNMPv2-MIB::snmp
-    overrides:
-      sysName:
-        type: DisplayString
   layer3:
     walk:
       - TCP-MIB::tcp

--- a/snmp-exporter/base/kustomization.yaml
+++ b/snmp-exporter/base/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: snmp-exporter
+commonLabels:
+  app: snmp-exporter
+
 resources:
   - deployment-prometheus-snmp-exporter.yaml
   - role-prometheus-snmp-exporter.yaml

--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
@@ -22,10 +22,8 @@ spec:
     params:
       module:
         - system
-        - snmpv2_mib
-        - network_mib
-        - if_mib
-        - ip_mib
+        - layer2
+        - layer3
         - cisco_device
         - cisco_fc_fe
       auth: [public_v2]
@@ -80,10 +78,8 @@ spec:
     params:
       module:
         - system
-        - snmpv2_mib
-        - network_mib
-        - if_mib
-        - ip_mib
+        - layer2
+        - layer3
         - cisco_device
         - cisco_fc_fe
       auth: [public_v2]
@@ -138,10 +134,8 @@ spec:
     params:
       module:
         - system
-        - snmpv2_mib
-        - network_mib
-        - if_mib
-        - ip_mib
+        - layer2
+        - layer3
         - dell
         - dell_network
       auth: [public_v2]


### PR DESCRIPTION
- Remove unused `dell` module

  These oids are part of the IDRAC-MIB [1] and aren't going to be available
  on Dell switches.

  [1]: https://github.com/librenms/librenms/blob/master/mibs/dell/IDRAC-MIB

- Use fully qualified names for oids and rename modules

  - Fully qualify OID names to avoid conflicts
  - Use names rather than raw OIDs
  - Restructure modules to logically group metrics

