### PR TITLE
ocp-test: upgrade RHOAI to 2.16.0

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: redhat-ods-operator
 spec:
   channel: stable
-  startingCSV: rhods-operator.2.8.2
+  startingCSV: rhods-operator.2.16.0


### PR DESCRIPTION
Post cluster upgrade to 4.17 in ocp-test, we need to upgrade RHOAI to reflect a supported configuration and try new features. 

