### PR TITLE
Add elsaticSearch (ECK) operator bundle and install on ocp-prod

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-eck-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: elasticsearch-eck-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
+++ b/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: elasticsearch-eck-operator
+resources:
+- ../../base/operators.coreos.com/subscriptions/elasticsearch-eck-operator

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
 - ../../bundles/koku-metrics-operator
 - ../../bundles/autopilot
 - ../../bundles/mongodb-operator
+- ../../bundles/elasticsearch-eck-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin


### PR DESCRIPTION
The favor team needs access to the general purpose elasticsearch operator
    
Closes: https://github.com/nerc-project/operations/issues/991
    
This operator differs from the OCP elasticSearch operator currently installed in prod.
This version is not specific or coupled to OCP but instead k8s