### PR TITLE
snmp-exporter remove app.kubernetes.io/instance label

### DIFF
--- a/snmp-exporter/base/deployment-prometheus-snmp-exporter.yaml
+++ b/snmp-exporter/base/deployment-prometheus-snmp-exporter.yaml
@@ -10,14 +10,12 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus-snmp-exporter
-      app.kubernetes.io/instance: prometheus-snmp-exporter
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -31,7 +29,6 @@ spec:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: prometheus-snmp-exporter
         app.kubernetes.io/name: prometheus-snmp-exporter
-        app.kubernetes.io/instance: prometheus-snmp-exporter
         app.kubernetes.io/version: "v0.27.0"
       annotations: {}
     spec:

--- a/snmp-exporter/base/role-prometheus-snmp-exporter.yaml
+++ b/snmp-exporter/base/role-prometheus-snmp-exporter.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
 rules:
   - apiGroups: [""]

--- a/snmp-exporter/base/rolebinding-prometheus-snmp-exporter.yaml
+++ b/snmp-exporter/base/rolebinding-prometheus-snmp-exporter.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
 subjects:
   - kind: ServiceAccount

--- a/snmp-exporter/base/service-prometheus-snmp-exporter.yaml
+++ b/snmp-exporter/base/service-prometheus-snmp-exporter.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
 spec:
   type: ClusterIP
@@ -20,4 +19,3 @@ spec:
       protocol: TCP
   selector:
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter

--- a/snmp-exporter/base/serviceaccount-prometheus-snmp-exporter.yaml
+++ b/snmp-exporter/base/serviceaccount-prometheus-snmp-exporter.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
   name: prometheus-snmp-exporter

--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
     prometheus: "kube-prometheus"
 spec:
@@ -25,7 +24,6 @@ spec:
         - layer2
         - layer3
         - cisco_device
-        - cisco_fc_fe
       auth: [public_v2]
       target:
       - 10.82.3.41
@@ -53,7 +51,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus-snmp-exporter
-      app.kubernetes.io/instance: prometheus-snmp-exporter
 ---
 # Source: prometheus-snmp-exporter/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -66,7 +63,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
     prometheus: "kube-prometheus"
 spec:
@@ -81,7 +77,6 @@ spec:
         - layer2
         - layer3
         - cisco_device
-        - cisco_fc_fe
       auth: [public_v2]
       target:
       - 10.82.3.42
@@ -109,7 +104,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus-snmp-exporter
-      app.kubernetes.io/instance: prometheus-snmp-exporter
 ---
 # Source: prometheus-snmp-exporter/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -122,7 +116,6 @@ metadata:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
-    app.kubernetes.io/instance: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
     prometheus: "kube-prometheus"
 spec:
@@ -136,7 +129,6 @@ spec:
         - system
         - layer2
         - layer3
-        - dell
         - dell_network
       auth: [public_v2]
       target:
@@ -165,4 +157,3 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: prometheus-snmp-exporter
-      app.kubernetes.io/instance: prometheus-snmp-exporter


### PR DESCRIPTION
ArgoCD changes the app.kubernetes.io/instance: prometheus-snmp-exporter
label at sync time, so we will remove this label. Also, the dell and
cisco_fc_fe modules are unknown modules so we will remove those too.

```bash
sh-4.4# curl 'http://10.128.3.93:9116/snmp?auth=public_v2&module=system&module=layer2&module=layer3&module=cisco_devce&module=cisco_fc_fe&target=10.82.3.41'
Unknown module 'cisco_fc_fe'

sh-4.4# curl 'http://10.128.3.93:9116/snmp?auth=public_v2&module=system&module=layer2&module=layer3&module=cisco_devce&module=cisco_fc_fe&target=10.82.3.41'
Unknown module 'cisco_fc_fe'
```