### PR TITLE
ocp-test: Add H100 acceleratorProfile

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/h100-acceleratorprofile.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/h100-acceleratorprofile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: nvidia-h100-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA H100 GPU
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-H100-SXM5-80GB

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/acceleratorprofiles/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - a100-acceleratorprofile.yaml
   - v100-acceleratorprofile.yaml
+  - h100-acceleratorprofile.yaml


### PR DESCRIPTION
The toleration in the acceleratorProfile in this commit inject tolerations into RHOAI workloads, adding a H100 selection in the RHOAI dashboard.

NOTE: AcceleratorProfiles do not taint the nodes, they only locate gpus and inject tolerations to workloads.