### PR TITLE
ocp-test: Add griot-grits group to allowed github groups in cluster OAuth

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -78,6 +78,7 @@ patches:
             - ocp-on-nerc/nerc-logs-metrics
             - ocp-on-nerc/nerc-rhods
             - ocp-on-nerc/nerc-test-people
+            - ocp-on-nerc/griot-grits
 - target:
     kind: ExternalSecret
     name: github-client-secret


### PR DESCRIPTION
The griot-grits team was unable to log into ocp-test cluster using github method. This PR allows their team to login 