### PR TITLE
Add ServiceMesh-Operator & Authorino-Operator to Prod

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: authorino-operator
+  namespace: openshift-operators
+spec:
+  channel: tech-preview-v1
+  installPlanApproval: Manual
+  name: authorino-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Manual
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/authorino-operator/kustomization.yaml
+++ b/cluster-scope/bundles/authorino-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: authorino-operator
+resources:
+- ../../base/operators.coreos.com/subscriptions/authorino-operator

--- a/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
+++ b/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: servicemesh-operator
+resources:
+- ../../base/operators.coreos.com/subscriptions/servicemesh-operator

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ../../bundles/solr-helm-repo
 - ../../bundles/ansible-automation-platform-operator
 - ../../bundles/openshift-serverless-operator
+- ../../bundles/servicemesh-operator
 - ../../bundles/amq-broker-rhel8-operator
 - ../../bundles/crunchy-postgres-operator
 - ../../bundles/amq-streams-operator

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - ../../bundles/solr-helm-repo
 - ../../bundles/ansible-automation-platform-operator
 - ../../bundles/openshift-serverless-operator
+- ../../bundles/authorino-operator
 - ../../bundles/servicemesh-operator
 - ../../bundles/amq-broker-rhel8-operator
 - ../../bundles/crunchy-postgres-operator


### PR DESCRIPTION
The servicemesh operator is required by RHOAI in order to enable single-model serving capabilities. It is also required by KServe in order to do model deployments using servingruntimes that use KServe. Authorino provides authentication for model endpoints.


Closes: https://github.com/nerc-project/operations/issues/1051