### PR TITLE
add nagios-monitoring bundle

### DIFF
--- a/cluster-scope/base/core/namespaces/nagios/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nagios/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/nagios/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/nagios/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nagios
+spec: {}

--- a/cluster-scope/base/core/secrets/nagios-monitor/kustomization.yaml
+++ b/cluster-scope/base/core/secrets/nagios-monitor/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nagios
+resources:
+  - secret.yaml

--- a/cluster-scope/base/core/secrets/nagios-monitor/secret.yaml
+++ b/cluster-scope/base/core/secrets/nagios-monitor/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nagios-monitor
+  annotations:
+    kubernetes.io/service-account.name: nagios-monitor
+type: kubernetes.io/service-account-token

--- a/cluster-scope/base/core/serviceaccounts/nagios-monitor/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/nagios-monitor/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nagios
+resources:
+  - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/nagios-monitor/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/nagios-monitor/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nagios-monitor

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nagios:monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nagios:monitoring
+subjects:
+- kind: ServiceAccount
+  name: nagios-monitor
+  namespace: nagios

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring/clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nagios:monitoring
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - "nmstate.io"
+    - "config.openshift.io"
+    - "machineconfiguration.openshift.io"
+  resources:
+    - "*"
+  verbs:
+    - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
+++ b/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nagios-monitoring
+resources:
+- ../../base/core/namespaces/nagios
+- ../../base/core/serviceaccounts/nagios-monitor
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring
+- ../../base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring
+- ../../base/core/secrets/nagios-monitor

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -37,6 +37,7 @@ resources:
 - ../../bundles/minio
 - ../../bundles/mongodb-operator
 - ../../bundles/xdmod-reader
+- ../../bundles/nagios-monitoring
 
 components:
   - ../../components/nerc-oauth-github


### PR DESCRIPTION
This bundle includes a service account, service token secret, clusterrole, and clusterrolebinding needed for nagios monitoring scripts to talk to OCP clusters and monitor machineconfigpools, cluster operators, node states, etc.

Also adds the bundle to the nerc-ocp-test cluster for testing.