### PR TITLE
ocp-infra: add nagios monitoring bundle

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/multicluster-engine-operator
 - ../../bundles/grafana
+- ../../bundles/nagios-monitoring
 - ../../base/core/namespaces/dex
 - ../../base/core/namespaces/nerc-ocp-prod
 - ../../base/core/namespaces/nerc-ocp-obs


### PR DESCRIPTION
This adds the nagios-monitoring bundle to the `nerc-ocp-infra` cluster in order to monitor the cluster from nagios.