### PR TITLE
ocp-prod: add udev rules for lenovo H100 nics

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018yUNu6FmIvXvYAAAAD//1CIi59gAQAA
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018yUNu6FmEt99yYb08a9iQTMJde9RgTMNSY3PRAw10SJCxAAAP//qtQhOcACAAA=
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
         - contents:

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
@@ -2,3 +2,7 @@ SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.0",ACTION=="add",NAME
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.1",ACTION=="add",NAME="nic2"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.0",ACTION=="add",NAME="nic1"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.1",ACTION=="add",NAME="nic2"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:c3:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:a3:00.0",ACTION=="add",NAME="nic2"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:23:00.0",ACTION=="add",NAME="nic3"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:03:00.0",ACTION=="add",NAME="nic4"


### PR DESCRIPTION
This installs the udev rules needed for the 4x Lenovo H100 nodes on the `nerc-ocp-prod` cluster. This will be merged during the 05/13 maintenance.