### PR TITLE
ocp-prod: add nagios monitoring bundle

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
 - ../../bundles/autopilot
 - ../../bundles/mongodb-operator
 - ../../bundles/elasticsearch-eck-operator
+- ../../bundles/nagios-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin


### PR DESCRIPTION
This adds the nagios-monitoring bundle to the `nerc-ocp-prod `cluster so that it can be monitored via nagios.