### PR TITLE
fix: align GitOps repo with working alert config

### DIFF
--- a/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   custom_rules.yaml: |
     groups:
+
       - name: openshift-storage
         rules:
 
@@ -289,115 +290,112 @@ data:
 
       - name: IBM autopilot
         rules:
-        - name: Alerts on GPU related issues
-          rules:
-          - alert: LowPCIeBandwidth
-            annotations:
-              description: |
-                GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has a PCIE bandwidth of {{ $value }} {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: GPU with a PCIe bandwidth of 4 or less
-            expr: |
-              sum (autopilot_health_checks{health="pciebw"}<=4) by (node, deviceid, value) > 0
-            for: 1m
-            labels:
-              severity: warning
-              alert: autopilot
-          - alert: DCGMLevel1Errors
-            annotations:
-              description: |
-                GPUs on node {{ $labels.node }} have DCGM Level 1 failures '{{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: GPUs have DCGM failures
-            expr: |
-              sum (autopilot_health_checks{health="dcgm"}==1) by (node)
-            for: 1m
-            labels:
-              severity: warning
-              alert: autopilot
-          - alert: GPUPowerSlowdownEnabled
-            annotations:
-              description: |
-                GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has power slowdown enabled
-              summary: A GPU has power slowdown enabled {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-            expr: |
-              sum (autopilot_health_checks{health="power-slowdown"}==1) by (node, deviceid)
-            for: 1m
-            labels:
-              severity: warning
-              alert: autopilot
-          - alert: RemappedRowsActive
-            annotations:
-              description: |
-                GPU device {{ $labels.deviceid}} on node {{ $labels.node }} with incorrect remapped rows in memory {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: A GPU device has incorrect remapped rows
-            expr: |
-              sum (autopilot_health_checks{health="remapped"}==1) by (node, deviceid)
-            for: 1m
-            labels:
-              severity: warning
-              alert: autopilot
-          - alert: DCGMLevel3Errors
-            annotations:
-              description: |
-                A node reported errors after running DCGM level 3 - check health of nodes {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: Node {{ $labels.node }} has GPU errors
-            expr: |
-              kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
-            for: 1m
-            labels:
-              severity: critical
-              alert: autopilot
-        - name: Alerts on network related issues
-          rules:
-            - alert: PingFailures
-              annotations:
-                description: |
-                  IP {{ $labels.deviceid }} on node {{ $labels.node }} is unreachable {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-                summary: Node has unreachable IPs
-              expr: |
-                sum (autopilot_health_checks{health="ping"}==1) by (deviceid)
-              for: 10m
-              labels:
-                severity: critical
-                alert: autopilot
-        - name: Alerts on PVC related issues
-          rules:
-          - alert: PVCAlert
-            annotations:
-              description: |
-                PVC creation by Autopilot on node {{ $labels.node }} failed {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: PVC cannot be created
-            expr: |
-              sum (autopilot_health_checks{health="pvc"}==1) by (node)
-            for: 1m
-            labels:
-              severity: critical
-              alert: autopilot
-        - name: Generic alert on periodic check failure
-          rules:
-          - alert: GPUNodeHealth
-            annotations:
-              description: |
-                Node {{ $labels.node }} reported errors after running Autopilot's periodic health checks {{ with $console_url := "console_url" | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url) }}{{ end }}{{ end }}.
-              summary: Node {{ $labels.node }} has errors
-            expr: |
-              kube_node_labels{label_autopilot_ibm_com_gpuhealth=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_gpuhealth!~""}
-            for: 1m
-            labels:
-              severity: warning
-              alert: autopilot
-        - name: Alerts on Autopilot pods not ready
-          rules:
-          - alert: AutopilotPodsFailing
-            annotations:
-              description: Autopilot pod on node {{ $labels.node }} are failing {{ with $console_url := "console_url" | query }}{{ if ne
-                  (len (label "url" (first $console_url ) ) ) 0}} on cluster {{ label "url" (first $console_url
-                  ) }}{{ end }}{{ end }}.
-              summary: Autopilot pod on node {{ $labels.node }} is failing
-            expr: count(kube_pod_info{} and on(pod) (kube_pod_container_status_waiting{namespace=~"autopilot.*"} > 0)) by (namespace)
-            for: 5m
-            labels:
-              severity: critical
-              alert: autopilot
+        - alert: LowPCIeBandwidth
+          annotations:
+            description: |
+              GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has a PCIE bandwidth of {{ $value }}.
+            summary: GPU with a PCIe bandwidth of 4 or less
+          expr: |
+            sum (autopilot_health_checks{health="pciebw"}<=4) by (node, deviceid, value) > 0
+          for: 1m
+          labels:
+            severity: warning
+            alert: autopilot
+
+        - alert: DCGMLevel1Errors
+          annotations:
+            description: |
+              GPUs on node {{ $labels.node }} have DCGM Level 1 failures.
+            summary: GPUs have DCGM failures
+          expr: |
+            sum (autopilot_health_checks{health="dcgm"}==1) by (node)
+          for: 1m
+          labels:
+            severity: warning
+            alert: autopilot
+
+        - alert: GPUPowerSlowdownEnabled
+          annotations:
+            description: |
+              GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has power slowdown enabled.
+            summary: A GPU has power slowdown enabled.
+          expr: |
+            sum (autopilot_health_checks{health="power-slowdown"}==1) by (node, deviceid)
+          for: 1m
+          labels:
+            severity: warning
+            alert: autopilot
+
+        - alert: RemappedRowsActive
+          annotations:
+            description: |
+              GPU device {{ $labels.deviceid }} on node {{ $labels.node }} has incorrect remapped rows in memory.
+            summary: A GPU device has incorrect remapped rows.
+          expr: |
+            sum (autopilot_health_checks{health="remapped"}==1) by (node, deviceid)
+          for: 1m
+          labels:
+            severity: warning
+            alert: autopilot
+
+        - alert: DCGMLevel3Errors
+          annotations:
+            description: |
+              A node reported errors after running DCGM level 3 - check health of nodes.
+            summary: Node {{ $labels.node }} has GPU errors.
+          expr: |
+            kube_node_labels{label_autopilot_ibm_com_dcgm_level_3=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_dcgm_level_3!~""}
+          for: 1m
+          labels:
+            severity: critical
+            alert: autopilot
+
+        - alert: PingFailures
+          annotations:
+            description: |
+              IP {{ $labels.deviceid }} on node {{ $labels.node }} is unreachable.
+            summary: Node has unreachable IPs.
+          expr: |
+            sum (autopilot_health_checks{health="ping"}==1) by (deviceid)
+          for: 10m
+          labels:
+            severity: critical
+            alert: autopilot
+
+        - alert: PVCAlert
+          annotations:
+            description: |
+              PVC creation by Autopilot on node {{ $labels.node }} failed.
+            summary: PVC cannot be created.
+          expr: |
+            sum (autopilot_health_checks{health="pvc"}==1) by (node)
+          for: 1m
+          labels:
+            severity: critical
+            alert: autopilot
+
+        - alert: GPUNodeHealth
+          annotations:
+            description: |
+              Node {{ $labels.node }} reported errors after running Autopilot's periodic health checks.
+            summary: Node {{ $labels.node }} has errors.
+          expr: |
+            kube_node_labels{label_autopilot_ibm_com_gpuhealth=~".*ERR.*"} and kube_node_labels{label_autopilot_ibm_com_gpuhealth!~""}
+          for: 1m
+          labels:
+            severity: warning
+            alert: autopilot
+
+        - alert: AutopilotPodsFailing
+          annotations:
+            description: |
+              Autopilot pod on node {{ $labels.node }} is failing.
+            summary: Autopilot pod on node {{ $labels.node }} is failing.
+          expr: count(kube_pod_info{} and on(pod) (kube_pod_container_status_waiting{namespace=~"autopilot.*"} > 0)) by (namespace)
+          for: 5m
+          labels:
+            severity: critical
+            alert: autopilot
 
 # Prometheus generates a metric called up that indicates whether a scrape was successful.
 # A value of “1” is scrape indicates success, “0” failure.


### PR DESCRIPTION
fix: align GitOps repo with working alert config from infra cluster

Rebuilt the Slack alerting config step-by-step in the infra cluster to debug Autopilot-related issues. After a few weeks of stable operation, syncing the working config back to the GitOps repo to ensure reproducibility before the next maintenance restart.