### PR TITLE
fix base console plugins

### DIFF
--- a/cluster-scope/base/operator.openshift.io/consoles/cluster/console.yaml
+++ b/cluster-scope/base/operator.openshift.io/consoles/cluster/console.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   plugins:
     - odf-console
-    - acm
-    - mce
     - logging-view-plugin
   customization:
     customLogoFile:

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -93,3 +93,17 @@ patches:
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.nerc-ocp-infra.rc.fas.harvard.edu
+- target:
+    kind: Console
+    name: cluster
+  patch: |
+    - op: add
+      path: /spec/plugins/-
+      value: acm
+- target:
+    kind: Console
+    name: cluster
+  patch: |
+    - op: add
+      path: /spec/plugins/-
+      value: mce

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -138,6 +138,5 @@ patches:
     name: cluster
   patch: |
     - op: add
-      path: /spec
-      value:
-        managementState: Managed
+      path: /spec/managementState
+      value: Managed


### PR DESCRIPTION
The ACM and MCE plugins being in base is causing lots of warnings/errors in the console operator pod logs on `nerc-ocp-prod` due to the plugins not being installed on that cluster. Currently these plugins are only installed on the `nerc-ocp-infra` cluster.

This patch does the following:

- Removes ACM and MCE plugins from the base console manifest.
- ocp-infra: patches the console manifest to add ACM and MCE plugins.
- ocp-test: fixes console managementState patch from clobbering all of console.spec


