### PR TITLE
ocp-test: update nfd image to v4.17

### DIFF
--- a/nfd-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nfd-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -2,3 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+patches:
+  - target:
+      kind: NodeFeatureDiscovery
+      name: nfd-instance
+    patch: |
+      - op: replace
+        path: /spec/operand/image
+        value: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17


### PR DESCRIPTION
After upgrading OpenShift to v4.17 and the latest version of the operator, the NFD resource requires a newer image. See:

See https://access.redhat.com/solutions/7118049