### PR TITLE
ocp-prod: upgrade to latest 4.15.51

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.15
   desiredUpdate:
-    version: 4.15.23
+    version: 4.15.51
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982


### PR DESCRIPTION
This is the first of three steps in the upgrade path to 4.17.31:

- 4.15.51
- 4.16.41
- 4.17.31

See https://github.com/nerc-project/operations/issues/1146