### PR TITLE
ocp-prod: upgrade cluster version to 4.16.41

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.15
+  channel: stable-4.16
   desiredUpdate:
-    version: 4.15.51
+    version: 4.16.41
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982


### PR DESCRIPTION
This is the second of three steps in the upgrade path to 4.17.31:

- 4.15.51
- 4.16.41
- 4.17.31

See https://github.com/nerc-project/operations/issues/1146