### PR TITLE
ocp-prod: ack API removals in 4.16.41

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -73,6 +73,7 @@ configMapGenerator:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
     - ack-4.13-kube-1.27-api-removals-in-4.14=true
+    - ack-4.15-kube-1.29-api-removals-in-4.16=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
Confirmed we're not using any of these API versions currently on ocp-prod:

https://access.redhat.com/articles/7031404