### PR TITLE
ocp-prod: upgrade ODF operator to 4.17

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -149,4 +149,4 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: stable-4.16
+      value: stable-4.17


### PR DESCRIPTION
This is needed after upgrading the ocp-prod cluster to 4.17