### PR TITLE
ocp-prod: update logging operator to stable 6.2

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -150,3 +150,10 @@ patches:
     - op: replace
       path: /spec/channel
       value: stable-4.17
+- target:
+    kind: Subscription
+    name: cluster-logging
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-6.2


### PR DESCRIPTION
This is required after upgrading ocp-prod cluster to 4.17