### PR TITLE
ocp-prod: upgrade RHOAI operator to stable 2.19

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -157,3 +157,13 @@ patches:
     - op: replace
       path: /spec/channel
       value: stable-6.2
+- target:
+    kind: Subscription
+    name: rhods-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-2.19
+    - op: replace
+      path: /spec/startingCSV
+      value: rhods-operator.2.19.0


### PR DESCRIPTION
See https://github.com/nerc-project/operations/issues/1104