### PR TITLE
ocp-prod: upgrade nvidia gpu operator to v25.3

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -167,3 +167,10 @@ patches:
     - op: replace
       path: /spec/startingCSV
       value: rhods-operator.2.19.0
+- target:
+    kind: Subscription
+    name: gpu-operator-certified
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: v25.3


### PR DESCRIPTION
This updates to the latest stable version of the operator.