### PR TITLE
Re-enable notebook controller in RHOAI

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -48,7 +48,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: false
+    enabled: true
     notebookNamespace: rhods-notebooks
     pvcSize: 20Gi
   notebookSizes:


### PR DESCRIPTION
We use the notebook controller for courses running in prod in order to provide isolation between student notebooks.