### PR TITLE
ocp-prod: update nfd image to v4.17

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   instance: ""
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17
     imagePullPolicy: Always
     servicePort: 0
   topologyUpdater: false

--- a/nfd-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nfd-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -2,11 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-patches:
-  - target:
-      kind: NodeFeatureDiscovery
-      name: nfd-instance
-    patch: |
-      - op: replace
-        path: /spec/operand/image
-        value: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17


### PR DESCRIPTION
After upgrading OpenShift to v4.17 and the latest version of the operator, the NFD resource requires a newer image. This updates the image in the base manifest given that both ocp-test and ocp-prod overlays are on OpenShift v4.17

See: https://access.redhat.com/solutions/7118049