### PR TITLE
Add Ibm scale operator and deployment resources

### DIFF
--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/approvalrequests.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/approvalrequests.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,251 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: approvalrequests.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - scalejobs
+    - scaleapprovals
+    kind: ApprovalRequest
+    listKind: ApprovalRequestList
+    plural: approvalrequests
+    shortNames:
+    - approvalreq
+    singular: approvalrequest
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.requestObjectRef.kind
+      name: Type
+      type: string
+    - jsonPath: .spec.requestObjectRef.name
+      name: RequestObject
+      type: string
+    - jsonPath: .spec.approve
+      name: Approve
+      type: string
+    - jsonPath: .spec.description
+      name: Description
+      priority: 10
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Schedule Time
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Last Successful Time
+      type: date
+    - jsonPath: .status.scheduled.id
+      name: Running
+      type: string
+    - jsonPath: .status.completed.reason
+      name: Completed
+      type: string
+    - jsonPath: .status.completed.message
+      name: Completed Message
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApprovalRequest is the Schema for the jobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApprovalRequestSpec defines the desired state of ApprovalRequest
+            properties:
+              approve:
+                description: approve is the approval mechanism that tells this job
+                  to take action to approve or reject the request
+                enum:
+                - approved
+                - rejected
+                type: string
+              description:
+                description: description provides more information about the approvalrequest
+                type: string
+              maxRetryFailed:
+                default: infinity
+                description: |-
+                  maxRetryFailed is the maximum number of retry attempts on consecutive failures.
+                  If set to "0", no retries are performed. If set to "infinity", the job will retry failed runs until success.
+                  The default is "infinity".
+                type: string
+              requestObjectRef:
+                description: RequestObjectRef is the object reference which needs
+                  approval
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of resource being referenced
+                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              run:
+                description: |-
+                  run can be: "suspend" or "once". "once" is default.
+                  "suspend" pauses scheduling of subsequent jobs, it does not apply to Running jobs.
+                  "once" will run the job successfully once according to schedule or one time at all if "cron" is not specified.
+                enum:
+                - suspend
+                - once
+                type: string
+              schedule:
+                description: schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+            required:
+            - requestObjectRef
+            type: object
+          status:
+            properties:
+              completed:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                required:
+                - message
+                - reason
+                type: object
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailedRuns:
+                description: consecutiveFailedRuns is the number of consecutive failed
+                  job runs
+                type: integer
+              lastApprove:
+                description: lastApprove is the previous value of the approve field
+                  in the spec before it was changed
+                type: string
+              lastScheduleTime:
+                description: lastScheduleTime is the last time the job was scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: lastSuccessfulTime is the last time the job completed
+                  successfully.
+                format: date-time
+                type: string
+              scheduled:
+                properties:
+                  id:
+                    description: id may be an identifier corresponding to the job.
+                    type: string
+                required:
+                - id
+                type: object
+            required:
+            - consecutiveFailedRuns
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/asyncreplications.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/asyncreplications.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,251 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: asyncreplications.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: AsyncReplication
+    listKind: AsyncReplicationList
+    plural: asyncreplications
+    shortNames:
+    - asyncrepl
+    singular: asyncreplication
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targetRole
+      name: Role
+      type: string
+    - jsonPath: .spec.replication
+      name: Replication
+      type: string
+    - jsonPath: .spec.recoveryPointObjective
+      name: RPO
+      priority: 10
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Healthy")].reason
+      name: Healthy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AsyncReplication is the Schema for the AsyncReplication API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of AsyncReplication
+            properties:
+              consistencyGroup:
+                description: Specifies the consistency group name that this AsyncReplication
+                  refers to
+                type: string
+              recoveryPointObjective:
+                default: 60
+                description: Specifies the Recovery Point Objective (RPO) for this
+                  AsyncReplication, the unit of time is Minute
+                minimum: 60
+                type: integer
+              remote:
+                description: Specifies the remote region that the regional DR targets
+                  to
+                properties:
+                  clusterNamespace:
+                    default: ibm-spectrum-scale
+                    description: Specifies the Scale Cluster namespace in the region
+                    type: string
+                  filesystem:
+                    description: Specifies the Scale Filesystem name in the region
+                    type: string
+                  site:
+                    description: Specifies the site name, which is same with ClusterInterconnect
+                      CR name
+                    type: string
+                required:
+                - filesystem
+                - site
+                type: object
+              replication:
+                default: active
+                description: Specifies if the replication should be active or if replication
+                  should be stopped
+                enum:
+                - active
+                - stopped
+                type: string
+              targetRole:
+                default: primary
+                description: |-
+                  Specifies the target role of the region that this AsyncReplication CR resides in.
+                  The role can be below value.
+                    primary: the local site is primary.
+                    secondary: the local site is secondary.
+                    forcedPrimary: the local site is forced failed over from secondary to primary.
+                    local: the replication has been deleted, but the approvalrequest is rejected, the data is still retained.
+                enum:
+                - primary
+                - secondary
+                - forcedPrimary
+                - local
+                type: string
+            required:
+            - consistencyGroup
+            - remote
+            - targetRole
+            type: object
+          status:
+            description: status defines the observed state of AsyncReplication
+            properties:
+              completedActions:
+                description: Indicates the completed actions during the fileset DR
+                  setup, failover and failback
+                items:
+                  type: string
+                type: array
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentAction:
+                description: Indicates the current action during the fileset DR setup,
+                  failover and failback
+                type: string
+              currentRole:
+                description: Indicates the current role of the region that this AsyncReplication
+                  CR resides in
+                type: string
+              exportPath:
+                description: Indicates the export path for the fileset on secondary
+                  region
+                type: string
+              forcedMode:
+                description: Indicates whether it's in forced mode, force mode will
+                  ignore the dirty data and do a forced role reversal
+                type: boolean
+              phase:
+                default: Unconfigured
+                description: Indicates the current phase during Regional DR management
+                enum:
+                - Unconfigured
+                - PrimaryReady
+                - SecondaryReady
+                - Configured
+                - Unconfiguring
+                type: string
+              primaryID:
+                description: Indicates the primaryID of the primary fileset
+                type: string
+              remoteConsistencyGroup:
+                description: Indicates the remote Consistency Group
+                type: string
+              replication:
+                description: |-
+                  Indicates if replication is currently active or stopped.
+                  This field corresponds to spec.replication and is meaningful only when spec.targetRole is primary.
+                type: string
+            required:
+            - currentRole
+            - exportPath
+            - forcedMode
+            - primaryID
+            - remoteConsistencyGroup
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/cachevolumeoperations.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/cachevolumeoperations.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,186 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: cachevolumeoperations.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: CacheVolumeOperation
+    listKind: CacheVolumeOperationList
+    plural: cachevolumeoperations
+    shortNames:
+    - cvo
+    singular: cachevolumeoperation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.action
+      name: Action
+      type: string
+    - jsonPath: .spec.cacheVolume
+      name: CacheVolume
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="OperationCompleted")].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="OperationCompleted")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CacheVolumeOperation is the Schema for the cachevolumeoperations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              action:
+                description: action specifies the operation to perform (Download or
+                  Evict)
+                enum:
+                - Download
+                - Evict
+                type: string
+              cacheVolume:
+                description: cacheVolume is the name of the associated CacheVolume
+                type: string
+              contentFilter:
+                description: contentFilter specifies the objects for download or eviction
+                  based on the specified operation
+                items:
+                  type: string
+                type: array
+              contentType:
+                default: DataAndMetadata
+                description: contentType specifies the type of content for the operation
+                  (DataAndMetadata, DataOnly, MetadataOnly)
+                enum:
+                - DataAndMetadata
+                - DataOnly
+                - MetadataOnly
+                type: string
+              ttlDuration:
+                default: 24h
+                description: |-
+                  ttlDuration specifies the time duration to wait before automatically deleting the CVO after successful completion.
+                  It can be specified in hours (e.g. 5h) or in days (2h). The default value is 24h.
+                pattern: ^[0-9]+[dh]$
+                type: string
+            required:
+            - action
+            - cacheVolume
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the operation
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failedToQueueCount:
+                description: FailedToQueueCount is the number of invalid files specified
+                  by users which could not be added to the download queue.
+                type: integer
+              retryAttempts:
+                description: RetryAttempts specifies the number of retry attempts
+                  for the operation
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/cachevolumes.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/cachevolumes.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,162 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: cachevolumes.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: CacheVolume
+    listKind: CacheVolumeList
+    plural: cachevolumes
+    shortNames:
+    - cv
+    singular: cachevolume
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.cacheMode
+      name: CacheMode
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Healthy")].status
+      name: HealthStatus
+      type: string
+    - jsonPath: .status.filesystem
+      name: Filesystem
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CacheVolume is the Schema for the cachevolumes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            description: CacheVolumeStatus defines the observed state of CacheVolume
+            properties:
+              bucketEndpoint:
+                description: bucketEndpoint is the endpoint of the the object storage
+                  server where the bucket to be cached is present
+                type: string
+              bucketName:
+                description: bucketName is the name of the bucket to be cached
+                type: string
+              cacheMode:
+                description: cacheMode is the AFM caching mode which defines the read
+                  and write access and also the direction of data sync to and from
+                  the bucket
+                type: string
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              filesystem:
+                description: filesystem is the filesystem in which the cache fileset
+                  is created
+                type: string
+              secretName:
+                description: secretName is the name of a secret which holds the bucket
+                  information for cache fileset
+                type: string
+              secretNamespace:
+                description: secretNamespace is the namespace of a secret which holds
+                  the bucket information for cache fileset
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/callhomes.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/callhomes.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,228 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: callhomes.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Callhome
+    listKind: CallhomeList
+    plural: callhomes
+    singular: callhome
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.mode
+      name: Mode
+      type: string
+    - jsonPath: .spec.companyName
+      name: Company Name
+      type: string
+    - jsonPath: .spec.customerID
+      name: Customer ID
+      priority: 10
+      type: string
+    - jsonPath: .spec.companyEmail
+      name: Company Email
+      type: string
+    - jsonPath: .spec.countryCode
+      name: Country Code
+      priority: 10
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Enabled")].status
+      name: Enabled
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Success")].status
+      name: Connected
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Callhome is the Schema for the callhomes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Callhome
+            properties:
+              companyEmail:
+                description: |-
+                  The address of the system administrator who can be contacted by the IBM Support. Usually this e-mail
+                  address is directed towards a group or task e-mail address. For example, itsupport@mycompanyname.com.
+                type: string
+              companyName:
+                description: |-
+                  The company to which the contact person belongs. This name can consist of any alphanumeric
+                  characters and these non-alphanumeric characters are '-', '_', '.', ' ', ','.
+                type: string
+              countryCode:
+                description: The two-letter upper-case country codes as defined in
+                  ISO 3166-1 alpha-2.
+                type: string
+              customerID:
+                description: |-
+                  The customer ID of the system administrator who can be contacted by the IBM Support. This can
+                  consist of any alphanumeric characters and these non-alphanumeric characters are '-', '_', '.'.
+                type: string
+              license:
+                description: License must be accepted by the end user to enable Callhome.
+                properties:
+                  accept:
+                    description: |-
+                      By accepting this license, you agree to allow IBM and its subsidiaries to store and use your contact information
+                      and your support information anywhere they do business worldwide. For more information, please refer to the
+                      Program license agreement and documentation.
+
+
+                      Set to true to agree the license and enable Callhome. Set to false to disable Callhome.
+                    type: boolean
+                required:
+                - accept
+                type: object
+              proxy:
+                description: If specified, defines a proxy server configuration.
+                properties:
+                  host:
+                    description: The host of proxy server as hostname or IP address.
+                    type: string
+                  port:
+                    description: The port of proxy server.
+                    type: integer
+                  secretName:
+                    description: The secret name of a basic authentication secret,
+                      which contains username and password for proxy server.
+                    type: string
+                required:
+                - host
+                - port
+                type: object
+              type:
+                default: production
+                description: |-
+                  Marks the cluster as a test or a production system.
+                  In case this parameter is not explicitly set, the value is set to production by default.
+                enum:
+                - production
+                - test
+                type: string
+            required:
+            - companyEmail
+            - companyName
+            - countryCode
+            - customerID
+            - license
+            type: object
+          status:
+            description: status defines the observed state of Callhome
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              mode:
+                description: 'mode is the current mode of operation: test, production,
+                  or disabled.'
+                enum:
+                - production
+                - test
+                - disabled
+                type: string
+            required:
+            - mode
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/clusterinterconnects.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/clusterinterconnects.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: clusterinterconnects.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: ClusterInterconnect
+    listKind: ClusterInterconnectList
+    plural: clusterinterconnects
+    singular: clusterinterconnect
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Connected")].reason
+      name: Connected
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInterconnect is the Schema for the ClusterInterconnect
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of ClusterInterconnect
+            properties:
+              identifiesMeAs:
+                description: |-
+                  Since Kubernetes does not know the concept of a cluster name, we need to specify how the other site calls us.
+                  This must match to the Spec.Remote.Site parameter of the AsyncReplication resources on the remote site.
+                type: string
+              kubeApi:
+                description: The URL of the Kubernetes API server of the remote site.
+                type: string
+              kubeConfigSecret:
+                description: A secret name that contains kubeconfig for a remote OpenShift
+                  cluster. The secret must be created in the ibm-spectrum-scale-operator
+                  namespace.
+                type: string
+            type: object
+          status:
+            description: status defines the observed state of ClusterInterconnect
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/clusters.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/clusters.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,1082 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: clusters.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - gpfs
+    singular: cluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.license.license
+      name: Edition
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Cluster
+            properties:
+              csi:
+                description: csi defines the configuration of the Container Storage
+                  Interface (CSI).
+                properties:
+                  sidecar:
+                    description: sidecar specifies configuration options for the CSI
+                      sidecar pods
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: nodeSelector is the label selector for CSI sidecar
+                          pods. Nodes that do not run an IBM Storage Scale core pod
+                          are ignored for scheduling CSI sidecar pods.
+                        type: object
+                    type: object
+                type: object
+              daemon:
+                default:
+                  nsdDevicesConfig:
+                    bypassDiscovery: true
+                description: It tells the operator how to configure the gpfs daemons.
+                properties:
+                  clusterNameOverride:
+                    description: clusterName overrides the default name, which is
+                      that of the Daemon resource itself postpended with any resolved
+                      domain suffix.
+                    maxLength: 115
+                    pattern: ^(?:(?:[a-z0-9](?:[\-a-z0-9]*[a-z0-9])?)\.?)+$
+                    type: string
+                  clusterProfile:
+                    description: |-
+                      IBM Spectrum Scale configuration parameters for the cluster.
+                      Changing these values is unsupported and should
+                      not be changed unless advised by IBM Support
+                    properties:
+                      afmAsyncDelay:
+                        type: string
+                      afmDIO:
+                        type: string
+                      afmHashVersion:
+                        type: string
+                      afmMaxParallelRecoveries:
+                        type: string
+                      afmObjKeyExpiration:
+                        type: string
+                      backgroundSpaceReclaimThreshold:
+                        type: string
+                      cloudEnv:
+                        default: general
+                        enum:
+                        - general
+                        type: string
+                      controlSetxattrImmutableSELinux:
+                        type: string
+                      encryptionKeyCacheExpiration:
+                        type: string
+                      enforceFilesetQuotaOnRoot:
+                        type: string
+                      ignorePrefetchLUNCount:
+                        type: string
+                      ignoreReplicaSpaceOnStat:
+                        default: "yes"
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                      ignoreReplicationForQuota:
+                        default: "yes"
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                      ignoreReplicationOnStatfs:
+                        default: "yes"
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                      initPrefetchBuffers:
+                        type: string
+                      maxBufferDescs:
+                        type: string
+                      maxMBpS:
+                        type: string
+                      maxTcpConnsPerNodeConn:
+                        type: string
+                      maxblocksize:
+                        type: string
+                      nsdMaxWorkerThreads:
+                        type: string
+                      nsdMinWorkerThreads:
+                        type: string
+                      nsdMultiQueue:
+                        type: string
+                      nsdRAIDBlockDeviceMaxSectorsKB:
+                        type: string
+                      nsdRAIDBlockDeviceNrRequests:
+                        type: string
+                      nsdRAIDBlockDeviceQueueDepth:
+                        type: string
+                      nsdRAIDBlockDeviceScheduler:
+                        type: string
+                      nsdRAIDBufferPoolSizePct:
+                        type: string
+                      nsdRAIDDefaultGeneratedFD:
+                        type: string
+                      nsdRAIDDiskCheckVWCE:
+                        type: string
+                      nsdRAIDEventLogToConsole:
+                        type: string
+                      nsdRAIDFlusherFWLogHighWatermarkMB:
+                        type: string
+                      nsdRAIDMasterBufferPoolSize:
+                        type: string
+                      nsdRAIDMaxPdiskQueueDepth:
+                        type: string
+                      nsdRAIDMaxRecoveryRetries:
+                        type: string
+                      nsdRAIDMaxTransientStale2FT:
+                        type: string
+                      nsdRAIDMaxTransientStale3FT:
+                        type: string
+                      nsdRAIDNonStealableBufPct:
+                        type: string
+                      nsdRAIDReadRGDescriptorTimeout:
+                        type: string
+                      nsdRAIDReconstructAggressiveness:
+                        type: string
+                      nsdRAIDSmallThreadRatio:
+                        type: string
+                      nsdRAIDThreadsPerQueue:
+                        type: string
+                      nsdRAIDTracks:
+                        type: string
+                      nsdSmallThreadRatio:
+                        type: string
+                      nspdBufferMemPerQueue:
+                        type: string
+                      nspdQueues:
+                        type: string
+                      nspdThreadsPerQueue:
+                        type: string
+                      numaMemoryInterleave:
+                        type: string
+                      pagepoolMaxPhysMemPct:
+                        type: string
+                      panicOnIOHang:
+                        type: string
+                      pitWorkerThreadsPerNode:
+                        type: string
+                      prefetchPct:
+                        type: string
+                      prefetchThreads:
+                        type: string
+                      prefetchTimeout:
+                        type: string
+                      proactiveReconnect:
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                      qMaxBlockShare:
+                        type: string
+                      qRevokeDisable:
+                        type: string
+                      readReplicaPolicy:
+                        default: local
+                        enum:
+                        - default
+                        - local
+                        - fastest
+                        type: string
+                      seqDiscardThreshold:
+                        type: string
+                      traceGenSubDir:
+                        default: /var/mmfs/tmp/traces
+                        enum:
+                        - /var/mmfs/tmp/traces
+                        type: string
+                      tscCmdAllowRemoteConnections:
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                      tscCmdPortRange:
+                        type: string
+                      verbsPorts:
+                        type: string
+                      verbsRdma:
+                        enum:
+                        - enable
+                        - disable
+                        type: string
+                      verbsRdmaCm:
+                        enum:
+                        - enable
+                        - disable
+                        type: string
+                      verbsRdmaSend:
+                        enum:
+                        - "yes"
+                        - "no"
+                        type: string
+                    type: object
+                  hostAliases:
+                    description: hostAliases that will be added to the internal DNS
+                      that resolves hosts for core pods
+                    items:
+                      properties:
+                        hostname:
+                          description: Hostname for the associated IP address.
+                          type: string
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - hostname
+                      - ip
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      nodeSelector will be applied to daemon core pods. The selectors in this field are ANDed.
+                      This means that only nodes are selected which have all labels of this field.
+                      This field is logically ANDed with any nodeSelectorExpressions also configured.
+                    type: object
+                  nodeSelectorExpressions:
+                    description: nodeSelectorExpressions that will apply to daemon
+                      core pods. This field is logically ANDed with any nodeSelector
+                      also configured.
+                    items:
+                      description: |-
+                        A node selector requirement is a selector that contains values, a key, and an operator
+                        that relates the key and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: |-
+                            Represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                          type: string
+                        values:
+                          description: |-
+                            An array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted as an integer.
+                            This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  nsdDevicesConfig:
+                    default:
+                      bypassDiscovery: true
+                    description: |-
+                      nsdDevicesConfig allows users to specify non-standard device names in order to override or enhance the disk discovery process.
+                      This parameter must only be specified when using a local filesystem with devices that use non-standard device names.
+                    properties:
+                      bypassDiscovery:
+                        default: true
+                        description: |-
+                          bypassDiscovery allows bypass of automatic disk discovery. If set to true, only the set of devices
+                          defined by the localDevicePaths will be used. If set to false, the automatic device discovery will find
+                          devices with standard device names.
+                        enum:
+                        - true
+                        - false
+                        type: boolean
+                      localDevicePaths:
+                        description: localDevicePaths specifies the device names and
+                          device types.
+                        items:
+                          properties:
+                            devicePath:
+                              description: |-
+                                devicePath specifies nsd device names. Allows wildcards.
+                                For example: '/dev/sdd', '/dev/pvc*', ...
+                              type: string
+                            deviceType:
+                              default: generic
+                              description: |-
+                                deviceType specifies the device type.
+                                For example: 'dmm', 'vpath', 'generic', ...
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  roles:
+                    description: |-
+                      roles specify the IBM Spectrum Scale configuration parameters for nodes that apply to a role.
+                      Specifying configuration parameters for roles is optional and does overwrite a set of default parameters.
+                    items:
+                      properties:
+                        limits:
+                          description: The Memory/CPU resource limits that will be
+                            set for Scale core pods.
+                          properties:
+                            cpu:
+                              description: CPU is measured in cpu units (i.e 1, 2,
+                                100m, 2500m)
+                              type: string
+                            memory:
+                              description: |-
+                                Memory is measured in bytes as plain integer or with kubernetes supported suffixes (i.e 128974848, 129e6, 129M, 123Mi).
+                                The value is the maximum amount of memory the Scale core pod is allowed to consume.
+                              type: string
+                          type: object
+                        name:
+                          description: Name of the role. Only afm, storage or client
+                            are allowed.
+                          enum:
+                          - afm
+                          - storage
+                          - client
+                          type: string
+                        profile:
+                          description: |-
+                            IBM Spectrum Scale node-scoped configuration parameters.
+                            Changing these values is unsupported and should
+                            not be changed unless advised by IBM Support
+                          properties:
+                            afmMaxParallelRecoveries:
+                              type: string
+                            backgroundSpaceReclaimThreshold:
+                              type: string
+                            controlSetxattrImmutableSELinux:
+                              type: string
+                            ignorePrefetchLUNCount:
+                              type: string
+                            initPrefetchBuffers:
+                              type: string
+                            maxBufferDescs:
+                              type: string
+                            maxMBpS:
+                              type: string
+                            maxTcpConnsPerNodeConn:
+                              type: string
+                            maxblocksize:
+                              type: string
+                            nsdMaxWorkerThreads:
+                              type: string
+                            nsdMinWorkerThreads:
+                              type: string
+                            nsdMultiQueue:
+                              type: string
+                            nsdRAIDBlockDeviceMaxSectorsKB:
+                              type: string
+                            nsdRAIDBlockDeviceNrRequests:
+                              type: string
+                            nsdRAIDBlockDeviceQueueDepth:
+                              type: string
+                            nsdRAIDBlockDeviceScheduler:
+                              type: string
+                            nsdRAIDBufferPoolSizePct:
+                              type: string
+                            nsdRAIDDefaultGeneratedFD:
+                              type: string
+                            nsdRAIDDiskCheckVWCE:
+                              type: string
+                            nsdRAIDEventLogToConsole:
+                              type: string
+                            nsdRAIDFlusherFWLogHighWatermarkMB:
+                              type: string
+                            nsdRAIDMasterBufferPoolSize:
+                              type: string
+                            nsdRAIDMaxPdiskQueueDepth:
+                              type: string
+                            nsdRAIDMaxRecoveryRetries:
+                              type: string
+                            nsdRAIDMaxTransientStale2FT:
+                              type: string
+                            nsdRAIDMaxTransientStale3FT:
+                              type: string
+                            nsdRAIDNonStealableBufPct:
+                              type: string
+                            nsdRAIDReadRGDescriptorTimeout:
+                              type: string
+                            nsdRAIDReconstructAggressiveness:
+                              type: string
+                            nsdRAIDSmallThreadRatio:
+                              type: string
+                            nsdRAIDThreadsPerQueue:
+                              type: string
+                            nsdRAIDTracks:
+                              type: string
+                            nsdSmallThreadRatio:
+                              type: string
+                            nspdBufferMemPerQueue:
+                              type: string
+                            nspdQueues:
+                              type: string
+                            nspdThreadsPerQueue:
+                              type: string
+                            numaMemoryInterleave:
+                              type: string
+                            pagepoolMaxPhysMemPct:
+                              type: string
+                            panicOnIOHang:
+                              type: string
+                            pitWorkerThreadsPerNode:
+                              type: string
+                            prefetchPct:
+                              type: string
+                            prefetchThreads:
+                              type: string
+                            prefetchTimeout:
+                              type: string
+                            proactiveReconnect:
+                              enum:
+                              - "yes"
+                              - "no"
+                              type: string
+                            seqDiscardThreshold:
+                              type: string
+                            tscCmdPortRange:
+                              type: string
+                            verbsPorts:
+                              type: string
+                            verbsRdma:
+                              enum:
+                              - enable
+                              - disable
+                              type: string
+                            verbsRdmaCm:
+                              enum:
+                              - enable
+                              - disable
+                              type: string
+                            verbsRdmaSend:
+                              enum:
+                              - "yes"
+                              - "no"
+                              type: string
+                          type: object
+                        resources:
+                          description: The Memory/CPU resource requests that will
+                            be set for Scale core pods.
+                          properties:
+                            cpu:
+                              description: CPU is measured in cpu units (i.e 1, 2,
+                                100m, 2500m)
+                              type: string
+                            memory:
+                              description: |-
+                                Memory is measured in bytes as plain integer or with kubernetes supported suffixes (i.e 128974848, 129e6, 129M, 123Mi).
+                                The value is a target and will be requested for Scale core pods.
+                                Resource request limits on containers impact pod scheduling and bin packing.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  tolerations:
+                    description: tolerations that are applied to daemon core pods.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  update:
+                    description: update defines the update behavior of the Scale core
+                      pods. If not specified, all core pods are updated one by one.
+                    properties:
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable defines either an integer number or percentage of core pods
+                          and nodes that can go Unavailable during an update. This only affects core
+                          pods that do not reside in any update pool (see `pools` parameter).
+                          The default value is 1. A value larger than 1 will mean multiple core pods
+                          and nodes going unavailable during the update, which causes that PV storage
+                          of Storage Scale CSI is unavailable and may affect your workload stress on
+                          the remaining nodes. You cannot set this value to 0 to stop updates;
+                          to stop updates, use the 'paused' property instead.
+                        x-kubernetes-int-or-string: true
+                      paused:
+                        default: false
+                        description: |-
+                          paused specifies whether or not updates should be stopped. This only affects
+                          core pods that do not reside in any update pool (see `pools` parameter).
+                        type: boolean
+                      pools:
+                        description: |-
+                          pools describe a set of update pools. An update pool describes the update
+                          behavior of selected core pods, for example how many pods can be updated in
+                          parallel.
+                        items:
+                          properties:
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                maxUnavailable defines either an integer number or percentage of core pods
+                                and nodes in the pool that can go Unavailable during an update.
+                                The default value is 1. A value larger than 1 will mean multiple core pods
+                                and nodes going unavailable during the update, which causes that PV storage
+                                of Storage Scale CSI is unavailable and may affect your workload stress on
+                                the remaining nodes. You cannot set this value to 0 to stop updates;
+                                to stop updates, use the 'paused' property instead.
+                                This parameter must not be specified if the update pool references to an
+                                Openshift MachineConfigPool (means pool name has "mcp/" prefix).
+                              x-kubernetes-int-or-string: true
+                            name:
+                              description: |-
+                                name is the name of the update pool. This pool references to an OpenShift
+                                MachineConfigPool if the name has a "mcp/" prefix (for example "mcp/worker").
+                              type: string
+                            nodeSelector:
+                              description: |-
+                                nodeSelector selects the Kubernetes nodes that host the core pods that belong
+                                to this update pool. Nodes that do not host a core pod are ignored.
+                                This parameter must not be specified if the update pool references to an
+                                Openshift MachineConfigPool (means pool name has "mcp/" prefix).
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            paused:
+                              default: false
+                              description: |-
+                                paused specifies whether or not updates to this update pool should be stopped.
+                                This parameter is ignored if the update pool references to an Openshift
+                                MachineConfigPool (means pool name has "mcp/" prefix).
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              grafanaBridge:
+                description: It tells the operator how to configure Grafana Bridge.
+                properties:
+                  enablePrometheusExporter:
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: nodeSelector specifies the criteria used to determine
+                      which nodes deploy grafana bridge pods.
+                    type: object
+                  tolerations:
+                    description: tolerations is applied to grafana bridge pods
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              gui:
+                default:
+                  enableSessionIPCheck: true
+                description: It tells the operator how to configure the GUIs.
+                properties:
+                  containerResources:
+                    description: |-
+                      containerResources allow to specify memory and CPU requests and limits for containers of GUI pods.
+                      In large clusters with high number of PersistentVolumes the GUI containers require more resources than default values.
+                    items:
+                      properties:
+                        name:
+                          description: name is the container name.
+                          enum:
+                          - liberty
+                          - postgres
+                          type: string
+                        resources:
+                          description: resources defines the resources for this container
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      - resources
+                      type: object
+                    type: array
+                  enableSessionIPCheck:
+                    description: |-
+                      enableSessionIPCheck verifies that all requests to GUI within the same session are send from the same client IP.
+                      Enabling this flag prevents session hijacking. Without IP validation, if an attacker intercepts the session ID,
+                      the attacker can potentially use the session ID from another IP address without being detected.
+                      The client IP check can be disabled in case a load balancer causes that the requests to GUI within same session are send by different IPs.
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: nodeSelector that is applied to GUI pods
+                    type: object
+                  tolerations:
+                    description: tolerations that are applied to GUI pods
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              license:
+                description: The license must be accepted by the end user that provides
+                  a way to specify the IBM Spectrum Scale Edition.
+                properties:
+                  accept:
+                    description: |-
+                      Read the license and specify "true" to accept or "false" to not accept.
+                      https://www.ibm.com/support/customer/csol/terms/?id=L-WWVS-K7K7DR
+                      BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING THESE TERMS ON BEHALF OF LICENSEE, YOU REPRESENT AND WARRANT THAT YOU HAVE FULL AUTHORITY TO BIND LICENSEE TO THESE TERMS. IF YOU DO NOT AGREE TO THESE TERMS,
+                      * DO NOT DOWNLOAD, INSTALL, COPY, ACCESS, CLICK ON AN "ACCEPT" BUTTON, OR USE THE PROGRAM; AND
+                      * PROMPTLY RETURN THE UNUSED MEDIA AND DOCUMENTATION TO THE PARTY FROM WHOM IT WAS OBTAINED FOR A REFUND OF THE AMOUNT PAID. IF THE PROGRAM WAS DOWNLOADED, DESTROY ALL COPIES OF THE PROGRAM.
+                    enum:
+                    - true
+                    type: boolean
+                  license:
+                    description: It specifies the IBM Spectrum Scale edition, "data-access"
+                      or "data-management".
+                    enum:
+                    - data-access
+                    - data-management
+                    - erasure-code
+                    type: string
+                required:
+                - accept
+                - license
+                type: object
+              networkPolicy:
+                description: It tells the operator how to configure NetworkPolicies
+                type: object
+              pmcollector:
+                description: It tells the operator how to configure the pmcollectors.
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: nodeSelector that is applied to pmcollector pods
+                    type: object
+                  storageClass:
+                    description: |-
+                      storageClass is used for creating PVCs for pmcollector pods, if not specified default storage class 'ibm-spectrum-scale-internal' is used.
+                      Modifying this field will delete existing PVCs and create new ones with the updated storage class. This leads to the loss of the historical performance data.
+                    type: string
+                  tolerations:
+                    description: tolerations that are applied to pmcollector pods
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              regionalDR:
+                description: It tells the operator how to configure Regional DR.
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: nodeSelector will be applied to regionaldr pods.
+                    type: object
+                  tolerations:
+                    description: tolerations that are applied to regionaldr pod.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              site:
+                description: |-
+                  Tells the operator how to configure site zone name resolution.
+                  Site zones must be authoritative.
+                properties:
+                  name:
+                    description: name is the site name.
+                    maxLength: 60
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  zone:
+                    description: |-
+                      zone is the domain name that IBM Spectrum Scale DNS records for this site will be managed.
+                      This will be used to resolve node names for IBM Spectrum Scale.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([\-\.a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                - zone
+                type: object
+            required:
+            - license
+            type: object
+          status:
+            description: status defines the observed state of Cluster
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/compressionjobs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/compressionjobs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: compressionjobs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - scalejobs
+    kind: CompressionJob
+    listKind: CompressionJobList
+    plural: compressionjobs
+    shortNames:
+    - compression
+    - compjob
+    singular: compressionjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastScheduleTime
+      name: Last Schedule Time
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Last Successful Time
+      type: date
+    - jsonPath: .status.scheduled.id
+      name: Running
+      type: string
+    - jsonPath: .status.completed.reason
+      name: Completed
+      type: string
+    - jsonPath: .status.completed.message
+      name: Completed Message
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CompressionJob is the Schema for the jobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompressionJobSpec defines the desired state of CompressionJob
+            properties:
+              filesystem:
+                description: filesystem is the name of the filesystem resource to
+                  run compression job on.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              maxRetryFailed:
+                default: infinity
+                description: |-
+                  maxRetryFailed is the maximum number of retry attempts on consecutive failures.
+                  If set to "0", no retries are performed. If set to "infinity", the job will retry failed runs until success.
+                  The default is "infinity".
+                type: string
+              run:
+                description: |-
+                  run can be: "suspend" or "once". "once" is default.
+                  "suspend" pauses scheduling of subsequent jobs, it does not apply to Running jobs.
+                  "once" will run the job successfully once according to schedule or one time at all if "cron" is not specified.
+                enum:
+                - suspend
+                - once
+                type: string
+              schedule:
+                description: schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+            type: object
+          status:
+            properties:
+              completed:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                required:
+                - message
+                - reason
+                type: object
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailedRuns:
+                description: consecutiveFailedRuns is the number of consecutive failed
+                  job runs
+                type: integer
+              lastScheduleTime:
+                description: lastScheduleTime is the last time the job was scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: lastSuccessfulTime is the last time the job completed
+                  successfully.
+                format: date-time
+                type: string
+              scheduled:
+                properties:
+                  id:
+                    description: id may be an identifier corresponding to the job.
+                    type: string
+                required:
+                - id
+                type: object
+            required:
+            - consecutiveFailedRuns
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/consistencygroups.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/consistencygroups.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: consistencygroups.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: ConsistencyGroup
+    listKind: ConsistencyGroupList
+    plural: consistencygroups
+    shortNames:
+    - cg
+    singular: consistencygroup
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.rootFileset.filesystem
+      name: Filesystem
+      priority: 10
+      type: string
+    - jsonPath: .status.rootFileset.fileset
+      name: RootFileset
+      priority: 10
+      type: string
+    - jsonPath: .status.persistentVolumeCount
+      name: PersistentVolumes
+      type: string
+    - jsonPath: .status.metadataReplicatedCount
+      name: MetadataReplicatedCount
+      priority: 10
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ConsistencyGroupUpdated")].status
+      name: ConsistencyGroupUpdated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="MetadataReplicated")].status
+      name: MetadataReplicated
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ConsistencyGroup is the Schema
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              metadataReplicatedCount:
+                description: metadataReplicatedCount is the number of persistent volume
+                  metadata records that are replicated for this consistency group.
+                type: string
+              persistentVolumeCount:
+                description: persistentVolumeCount is the number of persistent volumes
+                  of consistency group.
+                type: string
+              persistentVolumes:
+                description: persistentVolumes lists the persistent volumes of consistency
+                  group.
+                items:
+                  type: string
+                type: array
+              rootFileset:
+                description: rootFileset is the independent fileset that is the root
+                  for all dependent PV filesets of this consistency group.
+                properties:
+                  clusterNamespace:
+                    description: clusterNamespace is the namespace of the cluster
+                      of the root fileset.
+                    type: string
+                  fileset:
+                    description: fileset is the name of the root fileset.
+                    type: string
+                  filesetID:
+                    description: filesetID is the id of the root fileset.
+                    type: string
+                  filesystem:
+                    description: filesystem is the name of the filesystem where the
+                      consistency group root fileset lives in.
+                    type: string
+                  filesystemID:
+                    description: filesystemID is the id of the filesystem where the
+                      consistency group root fileset lives in.
+                    type: string
+                  path:
+                    description: path is the link path of the root fileset.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/csiscaleoperators.csi.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/csiscaleoperators.csi.ibm.com.yaml
@@ -1,0 +1,1401 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: csiscaleoperators.csi.ibm.com
+spec:
+  group: csi.ibm.com
+  names:
+    categories:
+    - scale
+    kind: CSIScaleOperator
+    listKind: CSIScaleOperatorList
+    plural: csiscaleoperators
+    shortNames:
+    - cso
+    singular: csiscaleoperator
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: CSIDriver version.
+      jsonPath: .status.versions[0].version
+      name: Version
+      type: string
+    - description: CSI driver resource creation status.
+      jsonPath: .status.conditions[?(@ "status")].status
+      name: Success
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CSIScaleOperator is the Schema for the csiscaleoperators API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CSIScaleOperatorSpec specifies the desired state of CSI
+            properties:
+              affinity:
+                description: affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods. If it's null, this PodAffinityTerm
+                                matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select which pods will be taken into consideration.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are merged with
+                                `LabelSelector` as `key in (value)` to select the
+                                group of existing pods which pods will be taken into
+                                consideration for the incoming pod's pod (anti) affinity.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. The default value is empty. The same key
+                                is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                Also, MatchLabelKeys cannot be set when LabelSelector
+                                isn't set. This is an alpha field and requires enabling
+                                MatchLabelKeysInPodAffinity feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: MismatchLabelKeys is a set of pod label
+                                keys to select which pods will be taken into consideration.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are merged with
+                                `LabelSelector` as `key notin (value)` to select the
+                                group of existing pods which pods will be taken into
+                                consideration for the incoming pod's pod (anti) affinity.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. The default value is empty. The same key
+                                is forbidden to exist in both MismatchLabelKeys and
+                                LabelSelector. Also, MismatchLabelKeys cannot be set
+                                when LabelSelector isn't set. This is an alpha field
+                                and requires enabling MatchLabelKeysInPodAffinity
+                                feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods. If it's null, this PodAffinityTerm
+                                matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select which pods will be taken into consideration.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are merged with
+                                `LabelSelector` as `key in (value)` to select the
+                                group of existing pods which pods will be taken into
+                                consideration for the incoming pod's pod (anti) affinity.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. The default value is empty. The same key
+                                is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                Also, MatchLabelKeys cannot be set when LabelSelector
+                                isn't set. This is an alpha field and requires enabling
+                                MatchLabelKeysInPodAffinity feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: MismatchLabelKeys is a set of pod label
+                                keys to select which pods will be taken into consideration.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are merged with
+                                `LabelSelector` as `key notin (value)` to select the
+                                group of existing pods which pods will be taken into
+                                consideration for the incoming pod's pod (anti) affinity.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. The default value is empty. The same key
+                                is forbidden to exist in both MismatchLabelKeys and
+                                LabelSelector. Also, MismatchLabelKeys cannot be set
+                                when LabelSelector isn't set. This is an alpha field
+                                and requires enabling MatchLabelKeysInPodAffinity
+                                feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              attacher:
+                description: attacher is the attacher sidecar image for CSI (actually
+                  attaches to the storage).
+                type: string
+              attacherNodeSelector:
+                default:
+                - key: scale
+                  value: "true"
+                description: attacherNodeSelector is the node selector for attacher
+                  sidecar.
+                items:
+                  description: CSINodeSelector defines the fields of Node Selector
+                  properties:
+                    key:
+                      description: Key for node selector
+                      type: string
+                    value:
+                      description: Value for key
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              clusters:
+                description: clusters is a collection of IBM Storage Scale cluster
+                  properties for the CSI driver to mount.
+                items:
+                  description: Defines the fields of a IBM Storage Scale cluster specification
+                  properties:
+                    cacert:
+                      description: cacert is the name of the configMap storing GUI
+                        certificates. Mandatory if secureSslMode is true.
+                      type: string
+                    id:
+                      description: id is the cluster ID of the IBM Storage Scale cluster.
+                      maxLength: 20
+                      type: string
+                    primary:
+                      description: primary is the primary file system for the IBM
+                        Storage Scale cluster.
+                      properties:
+                        inodeLimit:
+                          description: Inode limit for Primary Fileset
+                          type: string
+                        primaryFs:
+                          description: The name of the primary CSIFilesystem
+                          type: string
+                        primaryFset:
+                          description: The name of the primary fileset, created in
+                            primaryFs
+                          type: string
+                        remoteCluster:
+                          description: Remote IBM Storage Scale cluster ID
+                          type: string
+                      type: object
+                    restApi:
+                      description: restApi is a collection of targets for REST calls
+                      items:
+                        description: Defines the fields for REST API server information.
+                        properties:
+                          guiHost:
+                            description: guiHost is the hostname/IP of the IBM Storage
+                              Scale GUI node.
+                            type: string
+                          guiPort:
+                            description: guiPort is the port number of the IBM Storage
+                              Scale GUI node.
+                            type: integer
+                        required:
+                        - guiHost
+                        type: object
+                      type: array
+                    secrets:
+                      description: secret is the name of the basic-auth secret containing
+                        credentials to connect to IBM Storage Scale REST API server.
+                      type: string
+                    secureSslMode:
+                      default: false
+                      description: secureSslMode specifies if a secure SSL connection
+                        to connect to IBM Storage Scale cluster is required.
+                      enum:
+                      - true
+                      - false
+                      type: boolean
+                  required:
+                  - id
+                  - restApi
+                  - secrets
+                  - secureSslMode
+                  type: object
+                type: array
+              consistencyGroupPrefix:
+                description: consistencyGroupPrefix is a prefix of consistency group
+                  of an application. This is expected to be an RFC4122 UUID value
+                  (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values)
+                type: string
+              csipspname:
+                description: PodSecurityPolicy name for CSI driver and sidecar pods.
+                type: string
+              driverRegistrar:
+                description: driverRegistrar is the Sidecar container image for the
+                  IBM Storage Scale CSI plugin pods.
+                type: string
+              imagePullSecrets:
+                description: A passthrough option that distributes an imagePullSecrets
+                  array to the containers generated by the CSI scale operator. Please
+                  refer to official k8s documentation for your environment for more
+                  details.
+                items:
+                  type: string
+                type: array
+              kubeletRootDirPath:
+                description: kubeletRootDirPath is the path for kubelet root directory.
+                type: string
+              livenessprobe:
+                description: livenessprobe is the image for livenessProbe container
+                  (liveness probe is used to know when to restart a container).
+                type: string
+              nodeMapping:
+                description: nodeMapping specifies mapping of K8s node with IBM Storage
+                  Scale node.
+                items:
+                  description: Defines mapping between kubernetes node and IBM Storage
+                    Scale nodes
+                  properties:
+                    k8sNode:
+                      description: k8sNode is the name of the kubernetes node
+                      type: string
+                    spectrumscaleNode:
+                      description: spectrumscaleNode is the name of the IBM Storage
+                        Scale node
+                      type: string
+                  required:
+                  - k8sNode
+                  - spectrumscaleNode
+                  type: object
+                type: array
+              pluginNodeSelector:
+                default:
+                - key: scale
+                  value: "true"
+                description: pluginNodeSelector is the node selector for IBM Storage
+                  Scale CSI plugin.
+                items:
+                  description: CSINodeSelector defines the fields of Node Selector
+                  properties:
+                    key:
+                      description: Key for node selector
+                      type: string
+                    value:
+                      description: Value for key
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              provisioner:
+                description: provisioner is the provisioner sidecar image for CSI
+                  (actually issues provision requests).
+                type: string
+              provisionerNodeSelector:
+                default:
+                - key: scale
+                  value: "true"
+                description: provisionerNodeSelector is the node selector for provisioner
+                  sidecar.
+                items:
+                  description: CSINodeSelector defines the fields of Node Selector
+                  properties:
+                    key:
+                      description: Key for node selector
+                      type: string
+                    value:
+                      description: Value for key
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              resizer:
+                description: resizer is the resizer sidecar image for CSI (issues
+                  volume expansion requests).
+                type: string
+              resizerNodeSelector:
+                default:
+                - key: scale
+                  value: "true"
+                description: resizerNodeSelector is the node selector for resizer
+                  sidecar.
+                items:
+                  description: CSINodeSelector defines the fields of Node Selector
+                  properties:
+                    key:
+                      description: Key for node selector
+                      type: string
+                    value:
+                      description: Value for key
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              snapshotter:
+                description: snapshotter is the snapshotter sidecar image for CSI
+                  (issues volume snapshot requests).
+                type: string
+              snapshotterNodeSelector:
+                default:
+                - key: scale
+                  value: "true"
+                description: snapshotterNodeSelector is the snapshotter node selector
+                  for snapshotter sidecar.
+                items:
+                  description: CSINodeSelector defines the fields of Node Selector
+                  properties:
+                    key:
+                      description: Key for node selector
+                      type: string
+                    value:
+                      description: Value for key
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              spectrumScale:
+                description: spectrumScale is the image name for the IBM Storage Scale
+                  CSI node driver plugin container.
+                type: string
+              tolerations:
+                description: Array of tolerations that will be distributed to CSI
+                  pods. Please refer to official k8s documentation for your environment
+                  for more details.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - clusters
+            type: object
+          status:
+            description: CSIScaleOperatorStatus defines the observed state of CSIScaleOperator
+            properties:
+              conditions:
+                description: conditions contains the details for one aspect of the
+                  current state of this custom resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              versions:
+                description: version is the current CSIDriver version installed by
+                  the operator.
+                items:
+                  properties:
+                    name:
+                      description: name is the name of the particular operand this
+                        version is for.
+                      type: string
+                    version:
+                      description: version of a particular operand that is currently
+                        being managed.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/daemons.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/daemons.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,1047 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: daemons.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Daemon
+    listKind: DaemonList
+    plural: daemons
+    shortNames:
+    - fsd
+    - mmfsd
+    singular: daemon
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - jsonPath: .status.pods.total
+      name: Pods
+      type: string
+    - jsonPath: .status.podsStatus.running
+      name: Running
+      type: string
+    - jsonPath: .status.podsStatus.starting
+      name: Starting
+      priority: 10
+      type: string
+    - jsonPath: .status.podsStatus.terminating
+      name: Terminating
+      priority: 10
+      type: string
+    - jsonPath: .status.quorumPods.total
+      name: Quorum
+      priority: 10
+      type: string
+    - jsonPath: .status.quorumPods.running
+      name: Quorum Running
+      priority: 10
+      type: string
+    - jsonPath: .status.clusterID
+      name: Cluster ID
+      priority: 10
+      type: string
+    - jsonPath: .status.clusterName
+      name: Cluster Name
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Daemon is the Schema for the daemons API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Daemon
+            properties:
+              clusterNameOverride:
+                description: clusterName overrides the default name, which is that
+                  of the Daemon resource itself postpended with any resolved domain
+                  suffix.
+                maxLength: 115
+                pattern: ^(?:(?:[a-z0-9](?:[\-a-z0-9]*[a-z0-9])?)\.?)+$
+                type: string
+              clusterProfile:
+                description: |-
+                  IBM Spectrum Scale configuration parameters for the cluster.
+                  Changing these values is unsupported and should
+                  not be changed unless advised by IBM Support
+                properties:
+                  afmAsyncDelay:
+                    type: string
+                  afmDIO:
+                    type: string
+                  afmHashVersion:
+                    type: string
+                  afmMaxParallelRecoveries:
+                    type: string
+                  afmObjKeyExpiration:
+                    type: string
+                  backgroundSpaceReclaimThreshold:
+                    type: string
+                  cloudEnv:
+                    default: general
+                    enum:
+                    - general
+                    type: string
+                  controlSetxattrImmutableSELinux:
+                    type: string
+                  encryptionKeyCacheExpiration:
+                    type: string
+                  enforceFilesetQuotaOnRoot:
+                    type: string
+                  ignorePrefetchLUNCount:
+                    type: string
+                  ignoreReplicaSpaceOnStat:
+                    default: "yes"
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                  ignoreReplicationForQuota:
+                    default: "yes"
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                  ignoreReplicationOnStatfs:
+                    default: "yes"
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                  initPrefetchBuffers:
+                    type: string
+                  maxBufferDescs:
+                    type: string
+                  maxMBpS:
+                    type: string
+                  maxTcpConnsPerNodeConn:
+                    type: string
+                  maxblocksize:
+                    type: string
+                  nsdMaxWorkerThreads:
+                    type: string
+                  nsdMinWorkerThreads:
+                    type: string
+                  nsdMultiQueue:
+                    type: string
+                  nsdRAIDBlockDeviceMaxSectorsKB:
+                    type: string
+                  nsdRAIDBlockDeviceNrRequests:
+                    type: string
+                  nsdRAIDBlockDeviceQueueDepth:
+                    type: string
+                  nsdRAIDBlockDeviceScheduler:
+                    type: string
+                  nsdRAIDBufferPoolSizePct:
+                    type: string
+                  nsdRAIDDefaultGeneratedFD:
+                    type: string
+                  nsdRAIDDiskCheckVWCE:
+                    type: string
+                  nsdRAIDEventLogToConsole:
+                    type: string
+                  nsdRAIDFlusherFWLogHighWatermarkMB:
+                    type: string
+                  nsdRAIDMasterBufferPoolSize:
+                    type: string
+                  nsdRAIDMaxPdiskQueueDepth:
+                    type: string
+                  nsdRAIDMaxRecoveryRetries:
+                    type: string
+                  nsdRAIDMaxTransientStale2FT:
+                    type: string
+                  nsdRAIDMaxTransientStale3FT:
+                    type: string
+                  nsdRAIDNonStealableBufPct:
+                    type: string
+                  nsdRAIDReadRGDescriptorTimeout:
+                    type: string
+                  nsdRAIDReconstructAggressiveness:
+                    type: string
+                  nsdRAIDSmallThreadRatio:
+                    type: string
+                  nsdRAIDThreadsPerQueue:
+                    type: string
+                  nsdRAIDTracks:
+                    type: string
+                  nsdSmallThreadRatio:
+                    type: string
+                  nspdBufferMemPerQueue:
+                    type: string
+                  nspdQueues:
+                    type: string
+                  nspdThreadsPerQueue:
+                    type: string
+                  numaMemoryInterleave:
+                    type: string
+                  pagepoolMaxPhysMemPct:
+                    type: string
+                  panicOnIOHang:
+                    type: string
+                  pitWorkerThreadsPerNode:
+                    type: string
+                  prefetchPct:
+                    type: string
+                  prefetchThreads:
+                    type: string
+                  prefetchTimeout:
+                    type: string
+                  proactiveReconnect:
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                  qMaxBlockShare:
+                    type: string
+                  qRevokeDisable:
+                    type: string
+                  readReplicaPolicy:
+                    default: local
+                    enum:
+                    - default
+                    - local
+                    - fastest
+                    type: string
+                  seqDiscardThreshold:
+                    type: string
+                  traceGenSubDir:
+                    default: /var/mmfs/tmp/traces
+                    enum:
+                    - /var/mmfs/tmp/traces
+                    type: string
+                  tscCmdAllowRemoteConnections:
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                  tscCmdPortRange:
+                    type: string
+                  verbsPorts:
+                    type: string
+                  verbsRdma:
+                    enum:
+                    - enable
+                    - disable
+                    type: string
+                  verbsRdmaCm:
+                    enum:
+                    - enable
+                    - disable
+                    type: string
+                  verbsRdmaSend:
+                    enum:
+                    - "yes"
+                    - "no"
+                    type: string
+                type: object
+              edition:
+                description: It specifies the IBM Spectrum Scale edition, "data-access"
+                  or "data-management".
+                enum:
+                - data-access
+                - data-management
+                - erasure-code
+                type: string
+              hostAliases:
+                description: hostAliases that will be added to the internal DNS that
+                  resolves hosts for core pods
+                items:
+                  properties:
+                    hostname:
+                      description: Hostname for the associated IP address.
+                      type: string
+                    ip:
+                      description: IP address of the host file entry.
+                      type: string
+                  required:
+                  - hostname
+                  - ip
+                  type: object
+                type: array
+              images:
+                description: |-
+                  Deprecated: use ClusterManagerConfigSpec.Spec.Images instead.
+                  core and init image pair that daemon will use with respect to edition specified by user
+                properties:
+                  core:
+                    type: string
+                  coreInit:
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  nodeSelector will be applied to daemon core pods. The selectors in this field are ANDed.
+                  This means that only nodes are selected which have all labels of this field.
+                  This field is logically ANDed with any nodeSelectorExpressions also configured.
+                type: object
+              nodeSelectorExpressions:
+                description: nodeSelectorExpressions that will apply to daemon core
+                  pods. This field is logically ANDed with any nodeSelector also configured.
+                items:
+                  description: |-
+                    A node selector requirement is a selector that contains values, a key, and an operator
+                    that relates the key and values.
+                  properties:
+                    key:
+                      description: The label key that the selector applies to.
+                      type: string
+                    operator:
+                      description: |-
+                        Represents a key's relationship to a set of values.
+                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                      type: string
+                    values:
+                      description: |-
+                        An array of string values. If the operator is In or NotIn,
+                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                        the values array must be empty. If the operator is Gt or Lt, the values
+                        array must have a single element, which will be interpreted as an integer.
+                        This array is replaced during a strategic merge patch.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              nsdDevicesConfig:
+                default:
+                  bypassDiscovery: true
+                description: |-
+                  nsdDevicesConfig allows users to specify non-standard device names in order to override or enhance the disk discovery process.
+                  This parameter must only be specified when using a local filesystem with devices that use non-standard device names.
+                properties:
+                  bypassDiscovery:
+                    default: true
+                    description: |-
+                      bypassDiscovery allows bypass of automatic disk discovery. If set to true, only the set of devices
+                      defined by the localDevicePaths will be used. If set to false, the automatic device discovery will find
+                      devices with standard device names.
+                    enum:
+                    - true
+                    - false
+                    type: boolean
+                  localDevicePaths:
+                    description: localDevicePaths specifies the device names and device
+                      types.
+                    items:
+                      properties:
+                        devicePath:
+                          description: |-
+                            devicePath specifies nsd device names. Allows wildcards.
+                            For example: '/dev/sdd', '/dev/pvc*', ...
+                          type: string
+                        deviceType:
+                          default: generic
+                          description: |-
+                            deviceType specifies the device type.
+                            For example: 'dmm', 'vpath', 'generic', ...
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              regionalDR:
+                description: regionalDR contains daemon configuration information
+                  for regionaldr
+                type: object
+              roles:
+                description: |-
+                  roles specify the IBM Spectrum Scale configuration parameters for nodes that apply to a role.
+                  Specifying configuration parameters for roles is optional and does overwrite a set of default parameters.
+                items:
+                  properties:
+                    limits:
+                      description: The Memory/CPU resource limits that will be set
+                        for Scale core pods.
+                      properties:
+                        cpu:
+                          description: CPU is measured in cpu units (i.e 1, 2, 100m,
+                            2500m)
+                          type: string
+                        memory:
+                          description: |-
+                            Memory is measured in bytes as plain integer or with kubernetes supported suffixes (i.e 128974848, 129e6, 129M, 123Mi).
+                            The value is the maximum amount of memory the Scale core pod is allowed to consume.
+                          type: string
+                      type: object
+                    name:
+                      description: Name of the role. Only afm, storage or client are
+                        allowed.
+                      enum:
+                      - afm
+                      - storage
+                      - client
+                      type: string
+                    profile:
+                      description: |-
+                        IBM Spectrum Scale node-scoped configuration parameters.
+                        Changing these values is unsupported and should
+                        not be changed unless advised by IBM Support
+                      properties:
+                        afmMaxParallelRecoveries:
+                          type: string
+                        backgroundSpaceReclaimThreshold:
+                          type: string
+                        controlSetxattrImmutableSELinux:
+                          type: string
+                        ignorePrefetchLUNCount:
+                          type: string
+                        initPrefetchBuffers:
+                          type: string
+                        maxBufferDescs:
+                          type: string
+                        maxMBpS:
+                          type: string
+                        maxTcpConnsPerNodeConn:
+                          type: string
+                        maxblocksize:
+                          type: string
+                        nsdMaxWorkerThreads:
+                          type: string
+                        nsdMinWorkerThreads:
+                          type: string
+                        nsdMultiQueue:
+                          type: string
+                        nsdRAIDBlockDeviceMaxSectorsKB:
+                          type: string
+                        nsdRAIDBlockDeviceNrRequests:
+                          type: string
+                        nsdRAIDBlockDeviceQueueDepth:
+                          type: string
+                        nsdRAIDBlockDeviceScheduler:
+                          type: string
+                        nsdRAIDBufferPoolSizePct:
+                          type: string
+                        nsdRAIDDefaultGeneratedFD:
+                          type: string
+                        nsdRAIDDiskCheckVWCE:
+                          type: string
+                        nsdRAIDEventLogToConsole:
+                          type: string
+                        nsdRAIDFlusherFWLogHighWatermarkMB:
+                          type: string
+                        nsdRAIDMasterBufferPoolSize:
+                          type: string
+                        nsdRAIDMaxPdiskQueueDepth:
+                          type: string
+                        nsdRAIDMaxRecoveryRetries:
+                          type: string
+                        nsdRAIDMaxTransientStale2FT:
+                          type: string
+                        nsdRAIDMaxTransientStale3FT:
+                          type: string
+                        nsdRAIDNonStealableBufPct:
+                          type: string
+                        nsdRAIDReadRGDescriptorTimeout:
+                          type: string
+                        nsdRAIDReconstructAggressiveness:
+                          type: string
+                        nsdRAIDSmallThreadRatio:
+                          type: string
+                        nsdRAIDThreadsPerQueue:
+                          type: string
+                        nsdRAIDTracks:
+                          type: string
+                        nsdSmallThreadRatio:
+                          type: string
+                        nspdBufferMemPerQueue:
+                          type: string
+                        nspdQueues:
+                          type: string
+                        nspdThreadsPerQueue:
+                          type: string
+                        numaMemoryInterleave:
+                          type: string
+                        pagepoolMaxPhysMemPct:
+                          type: string
+                        panicOnIOHang:
+                          type: string
+                        pitWorkerThreadsPerNode:
+                          type: string
+                        prefetchPct:
+                          type: string
+                        prefetchThreads:
+                          type: string
+                        prefetchTimeout:
+                          type: string
+                        proactiveReconnect:
+                          enum:
+                          - "yes"
+                          - "no"
+                          type: string
+                        seqDiscardThreshold:
+                          type: string
+                        tscCmdPortRange:
+                          type: string
+                        verbsPorts:
+                          type: string
+                        verbsRdma:
+                          enum:
+                          - enable
+                          - disable
+                          type: string
+                        verbsRdmaCm:
+                          enum:
+                          - enable
+                          - disable
+                          type: string
+                        verbsRdmaSend:
+                          enum:
+                          - "yes"
+                          - "no"
+                          type: string
+                      type: object
+                    resources:
+                      description: The Memory/CPU resource requests that will be set
+                        for Scale core pods.
+                      properties:
+                        cpu:
+                          description: CPU is measured in cpu units (i.e 1, 2, 100m,
+                            2500m)
+                          type: string
+                        memory:
+                          description: |-
+                            Memory is measured in bytes as plain integer or with kubernetes supported suffixes (i.e 128974848, 129e6, 129M, 123Mi).
+                            The value is a target and will be requested for Scale core pods.
+                            Resource request limits on containers impact pod scheduling and bin packing.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              site:
+                description: Specifies the site name and zone for daemon name resolution.
+                properties:
+                  name:
+                    description: name is the site name.
+                    maxLength: 60
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  zone:
+                    description: |-
+                      zone is the domain name that IBM Spectrum Scale DNS records for this site will be managed.
+                      This will be used to resolve node names for IBM Spectrum Scale.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([\-\.a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                - zone
+                type: object
+              tolerations:
+                description: tolerations that are applied to daemon core pods.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              update:
+                description: update defines the update behavior of the Scale core
+                  pods. If not specified, all core pods are updated one by one.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      maxUnavailable defines either an integer number or percentage of core pods
+                      and nodes that can go Unavailable during an update. This only affects core
+                      pods that do not reside in any update pool (see `pools` parameter).
+                      The default value is 1. A value larger than 1 will mean multiple core pods
+                      and nodes going unavailable during the update, which causes that PV storage
+                      of Storage Scale CSI is unavailable and may affect your workload stress on
+                      the remaining nodes. You cannot set this value to 0 to stop updates;
+                      to stop updates, use the 'paused' property instead.
+                    x-kubernetes-int-or-string: true
+                  paused:
+                    default: false
+                    description: |-
+                      paused specifies whether or not updates should be stopped. This only affects
+                      core pods that do not reside in any update pool (see `pools` parameter).
+                    type: boolean
+                  pools:
+                    description: |-
+                      pools describe a set of update pools. An update pool describes the update
+                      behavior of selected core pods, for example how many pods can be updated in
+                      parallel.
+                    items:
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            maxUnavailable defines either an integer number or percentage of core pods
+                            and nodes in the pool that can go Unavailable during an update.
+                            The default value is 1. A value larger than 1 will mean multiple core pods
+                            and nodes going unavailable during the update, which causes that PV storage
+                            of Storage Scale CSI is unavailable and may affect your workload stress on
+                            the remaining nodes. You cannot set this value to 0 to stop updates;
+                            to stop updates, use the 'paused' property instead.
+                            This parameter must not be specified if the update pool references to an
+                            Openshift MachineConfigPool (means pool name has "mcp/" prefix).
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: |-
+                            name is the name of the update pool. This pool references to an OpenShift
+                            MachineConfigPool if the name has a "mcp/" prefix (for example "mcp/worker").
+                          type: string
+                        nodeSelector:
+                          description: |-
+                            nodeSelector selects the Kubernetes nodes that host the core pods that belong
+                            to this update pool. Nodes that do not host a core pod are ignored.
+                            This parameter must not be specified if the update pool references to an
+                            Openshift MachineConfigPool (means pool name has "mcp/" prefix).
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        paused:
+                          default: false
+                          description: |-
+                            paused specifies whether or not updates to this update pool should be stopped.
+                            This parameter is ignored if the update pool references to an Openshift
+                            MachineConfigPool (means pool name has "mcp/" prefix).
+                          type: boolean
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+            required:
+            - edition
+            - site
+            type: object
+          status:
+            description: status defines the observed state of Daemon
+            properties:
+              clusterID:
+                description: ID representing GPFS cluster
+                type: string
+              clusterName:
+                description: Name of GPFS cluster
+                type: string
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              cordonAndDrain:
+                description: Details about nodes that are cordoned and drained and
+                  pods that are evicted by Scale operator.
+                properties:
+                  nodesCordonedByOperator:
+                    description: List of nodes that are cordoned by Scale operator.
+                      These nodes have status SchedulingDisabled. Nodes that are cordoned
+                      by third party like machine config operator are not listed.
+                    type: string
+                  nodesCordonedByOthers:
+                    description: List of nodes that are cordoned by third party like
+                      machine config operator. These nodes have status SchedulingDisabled.
+                      Nodes that are cordoned by Scale operator are not listed.
+                    type: string
+                  nodesDraining:
+                    description: List of nodes on which the Scale operator is currently
+                      evicting pods
+                    items:
+                      properties:
+                        node:
+                          description: The node that is currently drained by the Scale
+                            operator
+                          type: string
+                        ongoingPodEvictions:
+                          description: The pods that the Scale operator is currently
+                            evicting
+                          items:
+                            type: string
+                          type: array
+                        podEvictionsFailed:
+                          description: The pods that failed to evict. The Scale operator
+                            continues to try to evict these pods.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - node
+                      - ongoingPodEvictions
+                      - podEvictionsFailed
+                      type: object
+                    type: array
+                  podEvictionRequests:
+                    description: List of daemon core pod evictions that are requested
+                      by third party (like machine config operator).
+                    items:
+                      properties:
+                        pods:
+                          description: Scale core pods that has been requested for
+                            eviction.
+                          type: string
+                        requestor:
+                          description: Name of requestor that requests the eviction
+                            of the pod.
+                          type: string
+                      required:
+                      - pods
+                      - requestor
+                      type: object
+                    type: array
+                required:
+                - nodesCordonedByOperator
+                - nodesCordonedByOthers
+                type: object
+              minimumReleaseLevel:
+                description: The currently enabled level of functionality of the cluster.
+                  It is expressed as an IBM Spectrum Scale version number, such as
+                  5.0.2.0.
+                type: string
+              pods:
+                properties:
+                  desired:
+                    description: Number of desired core pods
+                    type: string
+                  total:
+                    description: Number of existing core pods
+                    type: string
+                required:
+                - desired
+                - total
+                type: object
+              podsStatus:
+                properties:
+                  running:
+                    description: Number of running core pods
+                    type: string
+                  starting:
+                    description: Number of starting core pods
+                    type: string
+                  terminating:
+                    description: Number of terminating core pods
+                    type: string
+                  unknown:
+                    description: Number of core pods with unknown status. Pods scheduled
+                      on unreachable nodes are listed here.
+                    type: string
+                  waitingForDelete:
+                    description: Number of core pods that will be deleted
+                    type: string
+                required:
+                - running
+                - starting
+                - terminating
+                - unknown
+                - waitingForDelete
+                type: object
+              quorumPods:
+                properties:
+                  running:
+                    description: Number of running quorum pods
+                    type: string
+                  total:
+                    description: Total number of quorum pods
+                    type: string
+                required:
+                - running
+                - total
+                type: object
+              roles:
+                items:
+                  properties:
+                    name:
+                      description: Name of the role
+                      type: string
+                    nodeCount:
+                      description: Number of nodes that that are assigned to this
+                        role. Nodes are assigned to a role by label, i.e. "scale.spectrum.ibm.com/role=client"
+                      type: string
+                    nodes:
+                      description: List of nodes that are assigned to the role
+                      type: string
+                    podCount:
+                      description: Number of role pods
+                      type: string
+                    pods:
+                      description: List of role pods
+                      type: string
+                    runningCount:
+                      description: Number of running role pods
+                      type: string
+                  required:
+                  - name
+                  - nodeCount
+                  - nodes
+                  - podCount
+                  - pods
+                  - runningCount
+                  type: object
+                type: array
+              statusDetails:
+                properties:
+                  nodesRebooting:
+                    description: List of core pod nodes that are currently rebooting
+                    type: string
+                  nodesUnreachable:
+                    description: List of core pod nodes that are unreachable
+                    type: string
+                  podsStarting:
+                    description: List of starting core pods
+                    type: string
+                  podsTerminating:
+                    description: List of terminating core pods
+                    type: string
+                  podsUnknown:
+                    description: List of core pods with unknown status. Pods scheduled
+                      on unreachable nodes are listed here.
+                    type: string
+                  podsWaitingToBeDeleted:
+                    description: List of core pods that will be deleted soon
+                    items:
+                      properties:
+                        deleteReason:
+                          description: Reason for deleting the core pods
+                          type: string
+                        pods:
+                          description: List of core pods that will be deleted soon
+                          type: string
+                      required:
+                      - deleteReason
+                      - pods
+                      type: object
+                    type: array
+                  quorumPods:
+                    description: List of pods that act as quorum node for Spectrum
+                      Scale
+                    type: string
+                required:
+                - nodesRebooting
+                - nodesUnreachable
+                - podsStarting
+                - podsTerminating
+                - podsUnknown
+                - quorumPods
+                type: object
+              tiebreaker:
+                properties:
+                  version:
+                    type: string
+                type: object
+              update:
+                properties:
+                  pools:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        nodeCount:
+                          type: integer
+                        nodes:
+                          type: string
+                      required:
+                      - name
+                      - nodeCount
+                      - nodes
+                      type: object
+                    type: array
+                type: object
+              versions:
+                description: Details about version of each node in IBM Spectrum Scale
+                  cluster. It contains the version of nodes in the other site if it's
+                  a stretch cluster.
+                items:
+                  properties:
+                    count:
+                      description: Number of pods that that have this version
+                      type: string
+                    pods:
+                      description: List of pods that have this version
+                      type: string
+                    site:
+                      description: The site name in a stretch cluster environment
+                      type: string
+                    version:
+                      description: Value of the pod's product version (expected format
+                        is x.x.x.x or "unavailable" if pod is unavailable)
+                      type: string
+                  required:
+                  - count
+                  - version
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/diskjobs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/diskjobs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,256 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: diskjobs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - scalejobs
+    kind: DiskJob
+    listKind: DiskJobList
+    plural: diskjobs
+    singular: diskjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.filesystem
+      name: Filesystem
+      type: string
+    - jsonPath: .spec.action
+      name: Action
+      priority: 10
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Schedule Time
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Last Successful Time
+      type: date
+    - jsonPath: .status.scheduled.id
+      name: Running
+      type: string
+    - jsonPath: .status.completed.reason
+      name: Completed
+      type: string
+    - jsonPath: .status.consecutiveFailedRuns
+      name: Failed Runs
+      priority: 10
+      type: integer
+    - jsonPath: .status.completed.message
+      name: Completed Message
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DiskJob is the Schema for the jobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DiskJobSpec defines the desired state of DiskJob
+            properties:
+              action:
+                description: action defines what to do with the disk
+                enum:
+                - start
+                - stop
+                - suspend
+                - resume
+                - empty
+                - delete
+                type: string
+              diskNames:
+                description: |-
+                  diskNames is the list of localdisk resources to run disk job on.
+                  This can only be empty for start and resume. If empty, all disks are started or resumed.
+                items:
+                  type: string
+                type: array
+              filesystem:
+                description: filesystem is the name of the filesystem resource to
+                  run disk job on.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              healthEventTriggers:
+                description: healthEventTriggers can contain a list of health events
+                  that trigger running the diskjob
+                items:
+                  description: HealthEvent defines a health event that runs the diskjob
+                  properties:
+                    component:
+                      type: string
+                    eventName:
+                      type: string
+                  required:
+                  - component
+                  - eventName
+                  type: object
+                type: array
+              maxRetryFailed:
+                default: infinity
+                description: |-
+                  maxRetryFailed is the maximum number of retry attempts on consecutive failures.
+                  If set to "0", no retries are performed. If set to "infinity", the job will retry failed runs until success.
+                  The default is "infinity".
+                type: string
+              run:
+                description: |-
+                  run can be: "suspend" or "once". "once" is default.
+                  "suspend" pauses scheduling of subsequent jobs, it does not apply to Running jobs.
+                  "once" will run the job successfully once according to schedule or one time at all if "cron" is not specified.
+                enum:
+                - suspend
+                - once
+                type: string
+              schedule:
+                description: schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+            required:
+            - action
+            - filesystem
+            type: object
+          status:
+            properties:
+              completed:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                required:
+                - message
+                - reason
+                type: object
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailedRuns:
+                description: consecutiveFailedRuns is the number of consecutive failed
+                  job runs
+                type: integer
+              lastScheduleTime:
+                description: lastScheduleTime is the last time the job was scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: lastSuccessfulTime is the last time the job completed
+                  successfully.
+                format: date-time
+                type: string
+              scheduled:
+                properties:
+                  id:
+                    description: id may be an identifier corresponding to the job.
+                    type: string
+                required:
+                - id
+                type: object
+              startDisksDetails:
+                description: startdisks shows additional status for the currently
+                  ongoing or last completed "start" action.
+                properties:
+                  downDiskNames:
+                    description: List of disk names that are down
+                    type: string
+                  downDisksCount:
+                    description: Number of disks that are down
+                    type: string
+                type: object
+            required:
+            - consecutiveFailedRuns
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/dnsconfigs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/dnsconfigs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: dnsconfigs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: DNSConfig
+    listKind: DNSConfigList
+    plural: dnsconfigs
+    singular: dnsconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSConfig is the Schema for the dnsconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSConfigSpec defines the desired state of DNSConfig
+            properties:
+              forward:
+                description: forward defines the upstream DNS server for a specific
+                  domain
+                properties:
+                  cidrs:
+                    description: cidrs for the reverse zone for which the forward
+                      is authoritative
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  upstream:
+                    description: upstream is the DNS server to handle the domain DNS
+                      requests
+                    items:
+                      type: string
+                    maxItems: 15
+                    type: array
+                  zone:
+                    description: zone is the zone to forward to the upstream DNS server
+                    type: string
+                required:
+                - cidrs
+                - upstream
+                - zone
+                type: object
+              hosts:
+                description: hosts defines the list of hostname and IP
+                items:
+                  description: |-
+                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                    pod's hosts file.
+                  properties:
+                    hostnames:
+                      description: Hostnames for the above IP address.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ip:
+                      description: IP address of the host file entry.
+                      type: string
+                  required:
+                  - ip
+                  type: object
+                type: array
+              serviceEndpoints:
+                description: serviceEndpoints defines the endpoints of a service
+                properties:
+                  endpoints:
+                    description: endpoints are the backend IPs of the service
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    description: name is the name of the service
+                    type: string
+                required:
+                - endpoints
+                - name
+                type: object
+            type: object
+          status:
+            description: DNSConfigStatus defines the observed state of DNSConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/dnss.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/dnss.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,210 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: dnss.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: DNS
+    listKind: DNSList
+    plural: dnss
+    singular: dns
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNS is the Schema for the DNS API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of DNS
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: DNSConfigSpec defines the desired state of DNSConfig
+                properties:
+                  forward:
+                    description: forward defines the upstream DNS server for a specific
+                      domain
+                    properties:
+                      cidrs:
+                        description: cidrs for the reverse zone for which the forward
+                          is authoritative
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                      upstream:
+                        description: upstream is the DNS server to handle the domain
+                          DNS requests
+                        items:
+                          type: string
+                        maxItems: 15
+                        type: array
+                      zone:
+                        description: zone is the zone to forward to the upstream DNS
+                          server
+                        type: string
+                    required:
+                    - cidrs
+                    - upstream
+                    - zone
+                    type: object
+                  hosts:
+                    description: hosts defines the list of hostname and IP
+                    items:
+                      description: |-
+                        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                        pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                  serviceEndpoints:
+                    description: serviceEndpoints defines the endpoints of a service
+                    properties:
+                      endpoints:
+                        description: endpoints are the backend IPs of the service
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: name is the name of the service
+                        type: string
+                    required:
+                    - endpoints
+                    - name
+                    type: object
+                type: object
+              status:
+                description: DNSConfigStatus defines the observed state of DNSConfig
+                type: object
+            type: object
+          status:
+            description: status defines the observed state of DNS
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/encryptionconfigs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/encryptionconfigs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: encryptionconfigs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: EncryptionConfig
+    listKind: EncryptionConfigList
+    plural: encryptionconfigs
+    shortNames:
+    - ec
+    singular: encryptionconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of EncryptionConfig
+            properties:
+              backupServers:
+                description: If specified, The backup key servers configured for high
+                  availability.
+                items:
+                  type: string
+                maxItems: 5
+                type: array
+              cacert:
+                description: The ConfigMap storing CA and endpoint certificates used
+                  while adding/renewing key server certificate chain.
+                type: string
+              client:
+                description: The key client to communicate with the key Server.
+                maxLength: 16
+                type: string
+              filesystems:
+                description: If specified, a list of filesystems to be encrypted.
+                items:
+                  properties:
+                    algorithm:
+                      default: DEFAULTNISTSP800131A
+                      description: The algorithm to be used for encryption. Valid
+                        values are `DEFAULTNISTSP800131AFAST` and `DEFAULTNISTSP800131A`.
+                      enum:
+                      - DEFAULTNISTSP800131A
+                      - DEFAULTNISTSP800131AFAST
+                      type: string
+                    name:
+                      description: The name of the filesystem.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              port:
+                default: 9443
+                description: It can be used to override the default port for the key
+                  server.
+                type: integer
+              remoteRKM:
+                description: The RKM ID from the remote cluster corresponding to given
+                  key server and tenant.
+                maxLength: 21
+                type: string
+              secret:
+                description: The name of the basic-auth secret containing the username
+                  and password to the key server.
+                type: string
+              server:
+                description: The key server name to communicate for encryption configuration.
+                type: string
+              tenant:
+                description: 'The default tenant name to the key server. This name
+                  can consist of any alphanumeric characters and only these non-alphanumeric
+                  characters: ''_''.'
+                maxLength: 16
+                type: string
+            required:
+            - client
+            - secret
+            - server
+            - tenant
+            type: object
+          status:
+            description: status defines the observed state of EncryptionConfig
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              rkmId:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/filesystems.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/filesystems.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,478 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: filesystems.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Filesystem
+    listKind: FilesystemList
+    plural: filesystems
+    shortNames:
+    - fs
+    singular: filesystem
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Success")].status
+      name: Established
+      type: string
+    - jsonPath: .spec.remote.cluster
+      name: Remote Cluster
+      priority: 10
+      type: string
+    - jsonPath: .status.maintenanceMode
+      name: Maintenance Mode
+      priority: 10
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Filesystem is the Schema for the filesystems API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Filesystem
+            properties:
+              local:
+                description: If specified, describes the file system to be a local
+                  filesystem.
+                properties:
+                  blockSize:
+                    default: 4M
+                    description: 'blockSize is the desired block size (default: 4M)'
+                    enum:
+                    - 64k
+                    - 128k
+                    - 256k
+                    - 512k
+                    - 1m
+                    - 2m
+                    - 4m
+                    - 8m
+                    - 16m
+                    - 64k
+                    - 128k
+                    - 256K
+                    - 512K
+                    - 1M
+                    - 2M
+                    - 4M
+                    - 8M
+                    - 16M
+                    type: string
+                  pools:
+                    description: |-
+                      pools is a list of storage configurations that will make up a filesystem.
+                      At least a pool with name 'system' must be specified.
+                    items:
+                      properties:
+                        disks:
+                          description: |-
+                            disks is a list of local disk names to be included in this pool.
+                            All local disks that are specified here must have the same "type" ("shared" or "unshared") as this filesystem has defined in the spec.
+                          items:
+                            type: string
+                          type: array
+                        name:
+                          default: system
+                          description: 'name is the desired name of this pool (default:
+                            system)'
+                          type: string
+                      required:
+                      - disks
+                      type: object
+                    maxItems: 8
+                    minItems: 1
+                    type: array
+                  replication:
+                    description: |-
+                      replication is the number of replicas to create for each data/metadata block that is written to the filesystem.
+                      For type unshared only 3-way is allowed.
+                    enum:
+                    - 1-way
+                    - 2-way
+                    - 3-way
+                    type: string
+                  type:
+                    description: |-
+                      type defines the type of the local filesystem to create.
+                      Type "shared" is used for disks that have a path to multiple core pods.
+                      Type "unshared" is used for disks that have a path to only one core pod.
+                      All local disks to be used for this filesystem must have the same type.
+                    enum:
+                    - shared
+                    - unshared
+                    type: string
+                required:
+                - pools
+                - replication
+                - type
+                type: object
+              remote:
+                description: If specified, describes the file system to be remote
+                  mounted filesystem.
+                properties:
+                  cluster:
+                    description: It is the name of the 'remotecluster' custom resource.
+                    maxLength: 128
+                    type: string
+                  fs:
+                    description: It is the name of the filesystem on the remote cluster
+                      to mount.
+                    type: string
+                required:
+                - cluster
+                - fs
+                type: object
+              seLinuxOptions:
+                description: |-
+                  The SELinux context to be applied to the filesystem mount.
+
+
+                  If unspecified, the default context will prevent kubelet from relabeling volumes by
+                  mounting the filesystem with a shared container context.
+
+
+                  The shared container context may not be suitable for users intending to access
+                  container volumes outside of containerized environments. A context can be explicitly
+                  set to customize the mount context to something accessible by both containerized
+                  and non-containerized workloads.
+
+
+                  A user can disable setting of the SELinux context for the filesystem mount by
+                  specifying an empty {} seLinuxOptions field.
+
+
+                  Disabling the SELinux context mount will return back to the default volume relabeling
+                  behavior done by kubelet.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              vdiskNSD:
+                description: If specified, describes the file system to be a vdiskNSD
+                  filesystem.
+                properties:
+                  replication:
+                    default: 1-way
+                    description: |-
+                      replication is the number of replicas to create for each data/metadata block that is written to the filesystem (default: 1-way).
+                      When setting up a stretch cluster, please set it as "2-way".
+                    enum:
+                    - 1-way
+                    - 2-way
+                    type: string
+                  tiebreaker:
+                    description: tiebreaker defines the tiebreaker NSD for the stretched
+                      filesystem
+                    properties:
+                      device:
+                        description: device defines the block device name in tiebreaker
+                          node
+                        type: string
+                      nodeDaemonName:
+                        description: nodeDaemonName defines the tiebreaker node daemon
+                          name
+                        type: string
+                    required:
+                    - device
+                    - nodeDaemonName
+                    type: object
+                  vdiskSets:
+                    description: vdisksets defines the desired state of vdisksets
+                      that comprise the vdiskNSD filesystem
+                    items:
+                      properties:
+                        blockSize:
+                          description: |-
+                            This is the file system block size (vdisk track size) for members of the vdisk set.
+                            It is constrained by the selected RAID code.
+                            Valid values for 3WayReplication and 4WayReplication are 256k, 512k, 1m, or 2m.
+                            Valid values for 4+2P and 4+3P are 512k, 1m, 2m, 4m, or 8m. Valid values for 8+2P and 8+3P are 512k, 1m, 2m, 4m, 8m, or 16m.
+                          enum:
+                          - 256k
+                          - 512k
+                          - 1m
+                          - 2m
+                          - 4m
+                          - 8m
+                          - 16m
+                          - 256K
+                          - 512K
+                          - 1M
+                          - 2M
+                          - 4M
+                          - 8M
+                          - 16M
+                          type: string
+                        declusteredArray:
+                          default: DA1
+                          description: |-
+                            All recovery groups for which this vdisk set is defined must have a declustered array with this name where this vdisk set's members are created.
+                            The expectation is that a vdisk set extends across structurally identical recovery groups where the named declustered array has the same characteristics in each recovery group.
+                            If there is only one user declustered array in each recovery group, it is named DA1 and this is the default.
+                            If there is more than one user declustered array in a recovery group, there is no default and a declustered array name must be specified.
+                          type: string
+                        failureGroup:
+                          default: 1
+                          description: This is the failure group number of all vdisks
+                            defined in the vdiskset. The default value is 1 if it
+                            is omitted.
+                          maximum: 100
+                          minimum: 1
+                          type: integer
+                        nsdUsage:
+                          default: dataAndMetadata
+                          description: |-
+                            This is the IBM Spectrum Scale file system data usage for the NSD.
+                            Valid values are dataAndMetadata, metadataOnly, and dataOnly.
+                            The default is dataAndMetadata.
+                          enum:
+                          - dataAndMetadata
+                          - metadataOnly
+                          - dataOnly
+                          type: string
+                        raidCode:
+                          description: |-
+                            This is the vdisk RAID code for members of the vdisk set.
+                            Valid values are: 3WayReplication, 4WayReplication, 4+2P, 4+3P, 8+2P, or 8+3P
+                          enum:
+                          - 3WayReplication
+                          - 4WayReplication
+                          - 4+2P
+                          - 4+3P
+                          - 8+2P
+                          - 8+3P
+                          type: string
+                        recoveryGroups:
+                          description: One or more recovery groups, each of which
+                            contributes one member vdisk NSD to the vdisk set.
+                          items:
+                            type: string
+                          type: array
+                        setSize:
+                          description: |-
+                            The vdisk set size is the desired aggregate size of the vdisk set members in one recovery group.
+                            The set size can be specified as a percentage (whole numbers from 1% to 100% using the % suffix) or as a number of bytes (a number, optionally followed by one of the base 2 suffixes K, M, G, or T).
+                            If the vdisk set size is given as a percentage, it specifies the raw size to use from the declustered array including RAID code redundancy.
+                            If the vdisk set size is given as a number of bytes, it specifies the desired usable size of the vdisk set excluding RAID code redundancy.
+                            The vdisk set size is used to calculate the usable size of a single vdisk NSD member of the vdisk set in one recovery group.
+                            It is this calculated usable size that becomes part of the vdisk set definition, so if the size of a declustered array should ever change, the size of the individual member vdisk NSDs remains constant.
+                          pattern: ^([1-9]|[1-9][0-9]|100)%$||^([0-9]*)(K|M|G|T)$||^([0-9]){1,8}$
+                          type: string
+                        storagePool:
+                          description: |-
+                            If the NSD usage is dataAndMetadata or metadataOnly, the storage pool value must be system and does not need to be specified.
+                            If the NSD usage is dataOnly, the storage pool must be specified and the value may not be system.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: status defines the observed state of Filesystem
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              maintenanceMode:
+                description: maintenanceMode indicates if the filesystem maintenance
+                  mode is enabled.
+                enum:
+                - enabled
+                - disabled
+                - unknown
+                - not supported
+                type: string
+              pools:
+                description: pools displays status of the filesystem pools
+                items:
+                  properties:
+                    diskCount:
+                      description: diskCount is the number of localdisk objects in
+                        this pool. Used only if spec.local.replication is "1-way".
+                      type: integer
+                    disks:
+                      description: disks lists the names of the localdisk objects
+                        in this pool. Used only if the file system is not replicated
+                        (means if spec.local.replication is "1-way").
+                      type: string
+                    failureGroups:
+                      description: failureGroups shows the status of disks separated
+                        by failure groups. Used only if the file system is replicated
+                        (means if spec.local.replication is "2-way" or "3-way").
+                      items:
+                        properties:
+                          diskCount:
+                            description: diskCount is the number of localdisk objects
+                              in this failure group. Used only if the file system
+                              is replicated (means if spec.local.replication is not
+                              "1-way").
+                            type: integer
+                          disks:
+                            description: disks lists the names of the localdisk objects
+                              in this failure group. Used only if the file system
+                              is replicated (means if spec.local.replication is not
+                              "1-way").
+                            type: string
+                          failureGroup:
+                            description: failureGroup is the number of this failure
+                              group
+                            type: string
+                          totalDiskSize:
+                            description: totalDiskSize is the sum of all disk sizes
+                              in this failure group. Used only if the file system
+                              is replicated (means if spec.local.replication is not
+                              "1-way").
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      default: system
+                      description: 'name is the desired name of this pool (default:
+                        system)'
+                      type: string
+                    totalDiskSize:
+                      description: totalDiskSize is the sum of all disk sizes in this
+                        pool. Used only if spec.local.replication is "1-way".
+                      type: string
+                  type: object
+                type: array
+              seLinuxOptions:
+                description: seLinuxOptions indicates the currently configured mount
+                  context of the filesystem.
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              uid:
+                type: string
+              version:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/grafanabridges.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/grafanabridges.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,173 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: grafanabridges.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: GrafanaBridge
+    listKind: GrafanaBridgeList
+    plural: grafanabridges
+    shortNames:
+    - grbridge
+    singular: grafanabridge
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GrafanaBridge is the Schema for the GrafanaBridges API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of GrafanaBridge
+            properties:
+              enablePrometheusExporter:
+                type: boolean
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector specifies the criteria used to determine
+                  which nodes deploy grafana bridge pods.
+                type: object
+              tolerations:
+                description: tolerations is applied to grafana bridge pods
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status defines the observed state of GrafanaBridge
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/guis.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/guis.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,248 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: guis.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Gui
+    listKind: GuiList
+    plural: guis
+    singular: gui
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Gui is the Schema for the guis API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Gui
+            nullable: true
+            properties:
+              containerResources:
+                description: |-
+                  containerResources allow to specify memory and CPU requests and limits for containers of GUI pods.
+                  In large clusters with high number of PersistentVolumes the GUI containers require more resources than default values.
+                items:
+                  properties:
+                    name:
+                      description: name is the container name.
+                      enum:
+                      - liberty
+                      - postgres
+                      type: string
+                    resources:
+                      description: resources defines the resources for this container
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              enableSessionIPCheck:
+                description: |-
+                  enableSessionIPCheck verifies that all requests to GUI within the same session are send from the same client IP.
+                  Enabling this flag prevents session hijacking. Without IP validation, if an attacker intercepts the session ID,
+                  the attacker can potentially use the session ID from another IP address without being detected.
+                  The client IP check can be disabled in case a load balancer causes that the requests to GUI within same session are send by different IPs.
+                type: boolean
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector that is applied to GUI pods
+                type: object
+              tolerations:
+                description: tolerations that are applied to GUI pods
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status defines the observed state of Gui
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - approvalrequests.scale.spectrum.ibm.com.yaml
+  - asyncreplications.scale.spectrum.ibm.com.yaml
+  - cachevolumeoperations.scale.spectrum.ibm.com.yaml
+  - cachevolumes.scale.spectrum.ibm.com.yaml
+  - callhomes.scale.spectrum.ibm.com.yaml
+  - clusterinterconnects.scale.spectrum.ibm.com.yaml
+  - clusters.scale.spectrum.ibm.com.yaml
+  - compressionjobs.scale.spectrum.ibm.com.yaml
+  - consistencygroups.scale.spectrum.ibm.com.yaml
+  - csiscaleoperators.csi.ibm.com.yaml
+  - daemons.scale.spectrum.ibm.com.yaml
+  - diskjobs.scale.spectrum.ibm.com.yaml
+  - dnsconfigs.scale.spectrum.ibm.com.yaml
+  - dnss.scale.spectrum.ibm.com.yaml
+  - encryptionconfigs.scale.spectrum.ibm.com.yaml
+  - filesystems.scale.spectrum.ibm.com.yaml
+  - grafanabridges.scale.spectrum.ibm.com.yaml
+  - guis.scale.spectrum.ibm.com.yaml
+  - localdisks.scale.spectrum.ibm.com.yaml
+  - pmcollectors.scale.spectrum.ibm.com.yaml
+  - recoverygroups.scale.spectrum.ibm.com.yaml
+  - regionaldrexports.scale.spectrum.ibm.com.yaml
+  - regionaldrs.scale.spectrum.ibm.com.yaml
+  - remoteclusters.scale.spectrum.ibm.com.yaml
+  - restripefsjobs.scale.spectrum.ibm.com.yaml
+  - stretchclusterinitnodes.scale.spectrum.ibm.com.yaml
+  - stretchclusters.scale.spectrum.ibm.com.yaml
+  - stretchclustertiebreakers.scale.spectrum.ibm.com.yaml
+  - upgradeapprovals.scale.spectrum.ibm.com.yaml
+  - volumes.scale.spectrum.ibm.com.yaml

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/localdisks.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/localdisks.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,288 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: localdisks.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: LocalDisk
+    listKind: LocalDiskList
+    plural: localdisks
+    shortNames:
+    - ld
+    - nsd
+    singular: localdisk
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Used")].status
+      name: Used
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.filesystem
+      name: Filesystem
+      type: string
+    - jsonPath: .status.pool
+      name: Pool
+      priority: 10
+      type: string
+    - jsonPath: .status.failuregroup
+      name: Failuregroup
+      priority: 10
+      type: string
+    - jsonPath: .status.size
+      name: Size
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: LocalDisc is the Schema for the localdisks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of LocalDisk
+            properties:
+              device:
+                description: device specifies the device path that is used at creation
+                  time. The device path of a disk may change at later time after node
+                  reboots.
+                type: string
+              existingDataSkipVerify:
+                description: |-
+                  existingDataSkipVerify controls whether existing Spectrum Scale data structure should be overwritten when creating the disk.
+                  A disk can have Spectrum Scale data structures on if it was used in a filesystem before and if it has not properly cleaned up.
+                  If false, a "DiskHasFilesystemData" event is displayed if the disk still has Spectrum Scale data on it, and the disk will not be used.
+                  If true, the disk will be formatted, no matter if it still has data on it.
+                type: boolean
+              failureGroup:
+                description: |-
+                  failureGroup is the failure group number for this disk. This parameter is only used if the filesystem that uses this disk is
+                  replicated (means the Filesystem parameter spec.replication is "2-way" or "3-way"). The replicas of blocks are written to disks with
+                  different failure group numbers.
+                  Specify a positive number greater or equal than zero and use quotation marks, for example "2".
+                  If this parameter is not specified, the failure group numbers are automatically assigned. Refer to the documentation for more
+                  information on automatic failure group assignment.
+                  This parameter cannot be changed anymore as soon as the local disk is used by a filesystem.
+                maxLength: 6
+                pattern: ^([0-9]*)?$
+                type: string
+              node:
+                description: node specifies the kubernetes node name of node where
+                  the local disk device path (see "device" parameter) is gathered
+                  from at creation time.
+                type: string
+              nodeConnectionSelector:
+                description: |-
+                  nodeConnectionSelector selects the nodes which are expected to have a physical connection to the disk. If not specified, all
+                  nodes are expected to have a physical connection to the disk.
+                  The operator verifies if the disks are visible on the selected nodes.
+                  This parameter must not be specified if the disk is only connected to the node specified in spec.node, which means the disk type is "unshared".
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              thinDiskType:
+                default: "no"
+                description: 'thinDiskType specfies the space reclaim disk type of
+                  IBM Spectrum Scale disks (default: no)'
+                enum:
+                - "no"
+                - nvme
+                - scsi
+                - auto
+                type: string
+            required:
+            - device
+            - node
+            type: object
+          status:
+            description: status defines the observed state of LocalDisk
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failuregroup:
+                description: failuregroup is the failuregroup number for this localdisk.
+                  The replicas of data blocks are written to localdisks with different
+                  failuregroup numbers.
+                type: string
+              failuregroupMapping:
+                description: |-
+                  failuregroupMapping describes to which Kubernetes object the failuregroup is mapped to during automatic failuregroup assignment.
+                  This can be a Kubernetes node, a Kubernetes zone or a Kubernetes region. This is empty if the failure group number is configured in spec.failureGroup.
+                type: string
+              filesystem:
+                description: filesystem is the name of the filesystem that uses this
+                  localdisk. If this is empty, the localdisk is not used by a filesystem.
+                type: string
+              nodeConnections:
+                description: nodeConnections is the list of nodes that have a connection
+                  to the disk.
+                type: string
+              pool:
+                description: pool is the name of the filesystem pool that uses this
+                  localdisk. If this is empty, the localdisk is not used by a filesystem.
+                type: string
+              size:
+                description: size is the size of the localdisk
+                type: string
+              type:
+                description: type of the localdisk. This is "shared" if the disk is
+                  connected to all core pods (or the pods selected by spec.nodeConnectionSelector).
+                  This is "partially-shared" if the disk is connected to only a subset
+                  of all core pods (or the pods selected by spec.nodeConnectionSelector).
+                  This is "unshared" if the disk is only connected to one core pod.
+                type: string
+            required:
+            - failuregroup
+            - filesystem
+            - nodeConnections
+            - pool
+            - size
+            - type
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/pmcollectors.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/pmcollectors.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,176 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: pmcollectors.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: Pmcollector
+    listKind: PmcollectorList
+    plural: pmcollectors
+    shortNames:
+    - perfmon
+    singular: pmcollector
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Pmcollector is the Schema for the pmcollectors API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Pmcollector
+            nullable: true
+            properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector that is applied to pmcollector pods
+                type: object
+              storageClass:
+                description: |-
+                  storageClass is used for creating PVCs for pmcollector pods, if not specified default storage class 'ibm-spectrum-scale-internal' is used.
+                  Modifying this field will delete existing PVCs and create new ones with the updated storage class. This leads to the loss of the historical performance data.
+                type: string
+              tolerations:
+                description: tolerations that are applied to pmcollector pods
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status defines the observed state of Pmcollector
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/recoverygroups.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/recoverygroups.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: recoverygroups.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: RecoveryGroup
+    listKind: RecoveryGroupList
+    plural: recoverygroups
+    shortNames:
+    - rg
+    singular: recoverygroup
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RecoveryGroup is the Schema for the recoverygroups API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of RecoveryGroup
+            properties:
+              existingDataSkipVerify:
+                description: |-
+                  existingDataSkipVerify controls whether existing Spectrum Scale data structure should be overwritten when creating the disk.
+                  A disk can have Spectrum Scale data structures on if it was used in a filesystem before and if it has not properly cleaned up.
+                  If false, and the disk still has Spectrum Scale data on it, and an error will occur.
+                  If true, the disk will be formatted, no matter if it still has data on it.
+                  This field is unsupported in production use.
+                type: boolean
+              ignoreDisks:
+                description: |-
+                  ignoreDisks is a list of local disk names to be excluded from the recovery group
+                  This field is unsupported in production use.
+                items:
+                  type: string
+                type: array
+              window:
+                default: 30
+                description: 'window is the amount of time in minutes to defer rebuild
+                  during maintenance actions like rolling upgrade. (Default: 30 minutes)'
+                maximum: 60
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: status defines the observed state of RecoveryGroup
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/regionaldrexports.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/regionaldrexports.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,140 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: regionaldrexports.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: RegionalDRExport
+    listKind: RegionalDRExportList
+    plural: regionaldrexports
+    shortNames:
+    - rdrexport
+    - rdrexp
+    singular: regionaldrexport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RegionalDRExport is the Schema for the RegionalDRExports API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RegionalDRExportSpec defines the desired state of RegionalDRExport
+            properties:
+              consistencyGroup:
+                description: ConsistencyGroup refers to the ConsistencyGroup resource
+                  for which the root fileset will be exported
+                type: string
+            required:
+            - consistencyGroup
+            type: object
+          status:
+            description: RegionalDRExportStatus defines the observed state of RegionalDRExport
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              exportID:
+                description: An identifier for the export, must be unique and betweem
+                  0 and 65535.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/regionaldrs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/regionaldrs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,197 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: regionaldrs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: RegionalDR
+    listKind: RegionalDRList
+    plural: regionaldrs
+    shortNames:
+    - rdr
+    singular: regionaldr
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RegionalDR is the Schema for the regionaldrs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of RegionalDR
+            properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector will be applied to regionaldr pods.
+                type: object
+              tolerations:
+                description: tolerations that are applied to regionaldr pod.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status defines the observed state of Gui
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              remoteRegions:
+                additionalProperties:
+                  properties:
+                    clusterInterconnect:
+                      description: the corresponding ClusterInterconnect CR name
+                      type: string
+                    clusterNamespace:
+                      description: the Scale cluster namespace in remote site
+                      type: string
+                    configured:
+                      default: false
+                      description: |-
+                        indicate whether the remote site is configured well in local site, see condition ConfiguredForRemote
+                        for details if it's false
+                      type: boolean
+                    stunnelRoute:
+                      description: the stunnel route in remote site
+                      type: string
+                  required:
+                  - configured
+                  type: object
+                description: the remote regions information, the key is "<ClusterInterconnect
+                  CR name>-<Scale cluster namespace>"
+                type: object
+              stunnelRoute:
+                description: the stunnel route in local region
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/remoteclusters.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/remoteclusters.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,237 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: remoteclusters.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: RemoteCluster
+    listKind: RemoteClusterList
+    plural: remoteclusters
+    shortNames:
+    - remotegpfs
+    singular: remotecluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.guiVersion
+      name: GUI Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RemoteCluster is the Schema for the remoteclusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of RemoteCluster
+            properties:
+              contactNodes:
+                description: |-
+                  This property is optional and provides a list of nodes from the storage cluster to
+                  be used as the remote cluster contact nodes. The names must be the daemon node
+                  names. If not specified, the operator uses all quorum nodes detected from the storage cluster.
+                  If the contact node names are not resolvable in local cluster, configure the 'hostAliases' with node name
+                  and IP in Cluster CR.
+                items:
+                  type: string
+                type: array
+              gui:
+                description: It specifies the details for the IBM Spectrum Scale Remote
+                  Cluster GUI.
+                properties:
+                  cacert:
+                    description: It specifies the name of the RootCA ConfigMap.
+                    type: string
+                  csiSecretName:
+                    description: |-
+                      It references the secret that contains the username and password of
+                      the CSI admin user in the ibm-spectrum-scale-csi namespace.
+                      This option is mandatory if the storage cluster version is older than 5.2.3.
+                      If the storage cluster is version 5.2.3, this option is no longer used.
+                    type: string
+                  host:
+                    description: |-
+                      host references a REST API endpoint on the remote cluster. This must be resolvable by DNS.
+                      This field is DEPRECATED and will be removed in a future release. Use field 'hosts' instead.
+                    type: string
+                  hosts:
+                    description: |-
+                      hosts references one or more REST API endpoints on the remote cluster. Up to 3 endpoints can be specified.
+                      The hosts must be resolvable by DNS.
+                    items:
+                      type: string
+                    maxItems: 3
+                    type: array
+                  insecureSkipVerify:
+                    description: |-
+                      insecureSkipVerify controls whether a client verifies the server's certificate
+                      chain and host name. If set true, TLS is susceptible to machine-in-the-middle attacks.
+                    type: boolean
+                  passwordRotation:
+                    description: |-
+                      passwordRotation allows to configure automatic password rotation of the container operator and CSI admin GUI users.
+                      Automatic password rotation is disabled if this section is not specified.
+                    properties:
+                      passwordChangeInterval:
+                        default: "80"
+                        description: 'passwordChangeInterval allows the configuration
+                          in days for the operator to change the user passwords on
+                          the storage cluster. Specify the value surrounded by double
+                          quotes (like passwordChangeInterval: "30"). The default
+                          value is 80 days.'
+                        type: string
+                    type: object
+                  port:
+                    default: 443
+                    description: It specifies the port of the Remote Cluster.
+                    type: integer
+                  scheme:
+                    default: https
+                    description: The default value is 'https'. No other value is supported.
+                    enum:
+                    - https
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName references the secret that contains the username and password of the container operator user
+                      that exists in remote cluster GUI. The secret must be created in the ibm-spectrum-scale namespace.
+                      Refer to the documentation for more details.
+                    type: string
+                required:
+                - secretName
+                type: object
+            required:
+            - gui
+            type: object
+          status:
+            description: status defines the observed state of RemoteCluster
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              guiVersion:
+                description: guiVersion specifies the REST API GUI version.
+                type: string
+              lastPasswordChange:
+                description: lastPasswordChange indicates when the passwords for the
+                  remote storage users was last changed by the operator. This field
+                  is only present if the automatic password rotation function is enabled.
+                type: string
+              localKeySHADigest:
+                description: |-
+                  localKeySHADigest is the digest of the public access key that must be used by the remote cluster in order to communicate with the local cluster in a remote filesystem mount relationship.
+                  The new key is displayed if there are two keys.
+                type: string
+              remoteKeySHADigest:
+                description: |-
+                  remoteKeySHADigest is the digest of the public access key that is used by local cluster in order to communicate with the remote cluster in a remote filesystem mount relationship.
+                  The new key is displayed if there are two keys.
+                type: string
+            required:
+            - localKeySHADigest
+            - remoteKeySHADigest
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/restripefsjobs.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/restripefsjobs.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,238 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: restripefsjobs.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - scalejobs
+    kind: RestripeFSJob
+    listKind: RestripeFSJobList
+    plural: restripefsjobs
+    singular: restripefsjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.filesystem
+      name: Filesystem
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Schedule Time
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Last Successful Time
+      type: date
+    - jsonPath: .status.scheduled.id
+      name: Running
+      type: string
+    - jsonPath: .status.completed.reason
+      name: Completed
+      type: string
+    - jsonPath: .status.consecutiveFailedRuns
+      name: Failed Runs
+      priority: 10
+      type: integer
+    - jsonPath: .status.completed.message
+      name: Completed Message
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RestripeFSJob is the Schema for the jobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RestripeFSJobSpec defines the desired state of RestripeFSJob
+            properties:
+              filesystem:
+                description: filesystem is the name of the filesystem resource to
+                  run restripe job on.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              healthEventTriggers:
+                description: healthEventTriggers can contain a list of health events
+                  that trigger running the diskjob
+                items:
+                  description: HealthEvent defines a health event that runs the diskjob
+                  properties:
+                    component:
+                      type: string
+                    eventName:
+                      type: string
+                  required:
+                  - component
+                  - eventName
+                  type: object
+                type: array
+              maxRetryFailed:
+                default: infinity
+                description: |-
+                  maxRetryFailed is the maximum number of retry attempts on consecutive failures.
+                  If set to "0", no retries are performed. If set to "infinity", the job will retry failed runs until success.
+                  The default is "infinity".
+                type: string
+              mode:
+                description: |-
+                  mode describes how to restripe the filesystem. This reffers to the description of Spectrum Scale parameters of Spectrum Scale mmrestripefs CLI.
+                  "migrate" refers to "-m" option of mmrestripefs CLI.
+                  "replicate" refers to "-r" option of mmrestripefs CLI.
+                  "rebalance" refers to "-b" option of mmrestripefs CLI.
+                  "changeReplicas" refers to "-R" option of mmrestripefs CLI.
+                  Refer to the Spectrum Scale docs for a detailed description of the mmrestripefs CLI options.
+                enum:
+                - migrate
+                - replicate
+                - rebalance
+                - changeReplicas
+                type: string
+              run:
+                description: |-
+                  run can be: "suspend" or "once". "once" is default.
+                  "suspend" pauses scheduling of subsequent jobs, it does not apply to Running jobs.
+                  "once" will run the job successfully once according to schedule or one time at all if "cron" is not specified.
+                enum:
+                - suspend
+                - once
+                type: string
+              schedule:
+                description: schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+            required:
+            - filesystem
+            - mode
+            type: object
+          status:
+            properties:
+              completed:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                required:
+                - message
+                - reason
+                type: object
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailedRuns:
+                description: consecutiveFailedRuns is the number of consecutive failed
+                  job runs
+                type: integer
+              lastScheduleTime:
+                description: lastScheduleTime is the last time the job was scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: lastSuccessfulTime is the last time the job completed
+                  successfully.
+                format: date-time
+                type: string
+              scheduled:
+                properties:
+                  id:
+                    description: id may be an identifier corresponding to the job.
+                    type: string
+                required:
+                - id
+                type: object
+            required:
+            - consecutiveFailedRuns
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclusterinitnodes.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclusterinitnodes.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,155 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: stretchclusterinitnodes.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - stretch
+    kind: StretchClusterInitNodes
+    listKind: StretchClusterInitNodesList
+    plural: stretchclusterinitnodes
+    shortNames:
+    - stretchinit
+    singular: stretchclusterinitnodes
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StretchClusterInitNodes is the Schema for the stretchclusterinitnodes
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StretchClusterInitNodesSpec defines the desired state of
+              StretchClusterInitNodes
+            properties:
+              name:
+                description: Name is site name, the site name is defined in StretchCluster
+                  CR
+                type: string
+              nodes:
+                description: |-
+                  Nodes are the nodes in this site, these nodes will be added into the Spectrum Scale cluster
+                  to became a stretch cluster
+                items:
+                  properties:
+                    adminName:
+                      description: AdminName is the node admin name in Spectrum Scale
+                        cluster
+                      type: string
+                    daemonName:
+                      description: DaemonName is the node daemon name in Spectrum
+                        Scale cluster
+                      type: string
+                  required:
+                  - daemonName
+                  type: object
+                type: array
+            required:
+            - name
+            - nodes
+            type: object
+          status:
+            description: StretchClusterInitNodesStatus defines the observed state
+              of StretchClusterInitNodes
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclusters.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclusters.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,182 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: stretchclusters.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - stretch
+    kind: StretchCluster
+    listKind: StretchClusterList
+    plural: stretchclusters
+    shortNames:
+    - stretchgpfs
+    singular: stretchcluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StretchCluster is the Schema for the stretchclusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StretchClusterSpec defines the desired state of StretchCluster
+            properties:
+              sites:
+                description: Defines the two OCPs in the stretch cluster, including
+                  the Kube API endpoint and token.
+                items:
+                  properties:
+                    kubeApi:
+                      description: Define the kube API endpoint of the site
+                      type: string
+                    kubeConfigSecret:
+                      description: Define the secret name which contains the token
+                        to access the OCP Kube API
+                      type: string
+                    name:
+                      description: Define the name of the site.
+                      maxLength: 60
+                      pattern: ^[a-z0-9]([_a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - kubeApi
+                  - kubeConfigSecret
+                  - name
+                  type: object
+                type: array
+              tiebreaker:
+                description: Defines the Tiebreaker node information
+                properties:
+                  admin:
+                    description: Define the tiebreaker admin interface info.
+                    properties:
+                      ip:
+                        description: Define the ip of the interface.
+                        type: string
+                      name:
+                        description: Define the name of the interface.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  daemon:
+                    description: Define the tiebreaker daemon interface info.
+                    properties:
+                      ip:
+                        description: Define the ip of the interface.
+                        type: string
+                      name:
+                        description: Define the name of the interface.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - daemon
+                type: object
+            required:
+            - sites
+            type: object
+          status:
+            description: StretchClusterStatus defines the observed state of StretchCluster
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclustertiebreakers.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/stretchclustertiebreakers.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: stretchclustertiebreakers.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    kind: StretchClusterTiebreaker
+    listKind: StretchClusterTiebreakerList
+    plural: stretchclustertiebreakers
+    singular: stretchclustertiebreaker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StretchClusterTiebreaker is the Schema for the StretchClusterTiebreakers
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StretchClusterTiebreakerSpec defines the desired state of
+              StretchClusterTiebreaker
+            properties:
+              admin:
+                description: Define the tiebreaker admin interface info.
+                properties:
+                  ip:
+                    description: Define the ip of the interface.
+                    type: string
+                  name:
+                    description: Define the name of the interface.
+                    type: string
+                required:
+                - name
+                type: object
+              daemon:
+                description: Define the tiebreaker daemon interface info.
+                properties:
+                  ip:
+                    description: Define the ip of the interface.
+                    type: string
+                  name:
+                    description: Define the name of the interface.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - daemon
+            type: object
+          status:
+            description: StretchClusterTiebreakerStatus defines the observed state
+              of StretchClusterTiebreaker
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/upgradeapprovals.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/upgradeapprovals.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,223 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: upgradeapprovals.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    categories:
+    - scale
+    - scalejobs
+    - scaleapprovals
+    kind: UpgradeApproval
+    listKind: UpgradeApprovalList
+    plural: upgradeapprovals
+    shortNames:
+    - upgradejob
+    singular: upgradeapproval
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.filesystem
+      name: Filesystem
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Schedule Time
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Last Successful Time
+      type: date
+    - jsonPath: .status.scheduled.id
+      name: Running
+      type: string
+    - jsonPath: .status.completed.reason
+      name: Completed
+      type: string
+    - jsonPath: .status.completed.message
+      name: Completed Message
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UpgradeApproval is the Schema for the jobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UpgradeApprovalSpec defines the desired state of UpgradeApproval
+            properties:
+              approved:
+                default: false
+                description: approved is the approval mechanism that tells this job
+                  to enable newest features within the cluster
+                type: boolean
+              filesystem:
+                description: filesystem is the name of the filesystem resource to
+                  run upgrade job on.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              maxRetryFailed:
+                default: infinity
+                description: |-
+                  maxRetryFailed is the maximum number of retry attempts on consecutive failures.
+                  If set to "0", no retries are performed. If set to "infinity", the job will retry failed runs until success.
+                  The default is "infinity".
+                type: string
+              run:
+                description: |-
+                  run can be: "suspend" or "once". "once" is default.
+                  "suspend" pauses scheduling of subsequent jobs, it does not apply to Running jobs.
+                  "once" will run the job successfully once according to schedule or one time at all if "cron" is not specified.
+                enum:
+                - suspend
+                - once
+                type: string
+              schedule:
+                description: schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+              type:
+                default: cluster
+                description: type is the type of upgrade to be performed. Valid values
+                  are "cluster" or "filesystem"
+                enum:
+                - cluster
+                - filesystem
+                type: string
+            required:
+            - approved
+            type: object
+          status:
+            properties:
+              completed:
+                properties:
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                required:
+                - message
+                - reason
+                type: object
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consecutiveFailedRuns:
+                description: consecutiveFailedRuns is the number of consecutive failed
+                  job runs
+                type: integer
+              lastScheduleTime:
+                description: lastScheduleTime is the last time the job was scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: lastSuccessfulTime is the last time the job completed
+                  successfully.
+                format: date-time
+                type: string
+              scheduled:
+                properties:
+                  id:
+                    description: id may be an identifier corresponding to the job.
+                    type: string
+                required:
+                - id
+                type: object
+            required:
+            - consecutiveFailedRuns
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/volumes.scale.spectrum.ibm.com.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/ibm-scale/volumes.scale.spectrum.ibm.com.yaml
@@ -1,0 +1,80 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: volumes.scale.spectrum.ibm.com
+spec:
+  group: scale.spectrum.ibm.com
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    singular: volume
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Volume
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeSpec defines the desired state of Volume
+            properties:
+              accessModes:
+                items:
+                  type: string
+                type: array
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ResourceList is a set of (resource name, quantity) pairs.
+                type: object
+              consistencyGroup:
+                type: string
+              pvcName:
+                type: string
+              pvcNamespace:
+                type: string
+              reclaimPolicy:
+                description: PersistentVolumeReclaimPolicy describes a policy for
+                  end-of-life maintenance of persistent volumes.
+                type: string
+            required:
+            - accessModes
+            - capacity
+            - consistencyGroup
+            - pvcName
+            - pvcNamespace
+            - reclaimPolicy
+            type: object
+          status:
+            description: VolumeStatus defines the observed state of Volume
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-csi-ns.yaml
+++ b/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-csi-ns.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    product: ibm-spectrum-scale-csi
+    release: ibm-spectrum-scale-csi-operator
+  name: ibm-spectrum-scale-csi

--- a/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-dns-ns.yaml
+++ b/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-dns-ns.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: coredns
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+  name: ibm-spectrum-scale-dns

--- a/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-ns.yaml
+++ b/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-ns.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: ibm-spectrum-scale

--- a/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-operator-ns.yaml
+++ b/cluster-scope/base/core/namespaces/ibm-scale/ibm-spectrum-scale-operator-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+    control-plane: controller-manager
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: ibm-spectrum-scale-operator

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/ibm-scale/00-worker-ibm-spectrum-scale-kernel-devel-mc.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/ibm-scale/00-worker-ibm-spectrum-scale-kernel-devel-mc.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-worker-ibm-spectrum-scale-kernel-devel
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions:
+  - kernel-devel

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/ibm-scale/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/ibm-scale/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - 00-worker-ibm-spectrum-scale-kernel-devel-mc.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-csi-operator.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-csi-operator.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+    product: ibm-spectrum-scale-csi
+    release: ibm-spectrum-scale-csi-operator
+  name: ibm-spectrum-scale-csi-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-csi-operator
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-csi-operator
+  namespace: ibm-spectrum-scale-csi

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-operator.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-operator
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-operator
+  namespace: ibm-spectrum-scale-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-privileged.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-privileged.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-privileged
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-operator
+  namespace: ibm-spectrum-scale-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-regional-dr.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/ibm-spectrum-scale-regional-dr.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-regional-dr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-regional-dr
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/ibm-scale/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-csi-operator.yaml
+  - ibm-spectrum-scale-privileged.yaml
+  - ibm-spectrum-scale-operator.yaml
+  - ibm-spectrum-scale-regional-dr.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-csi-operator.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-csi-operator.yaml
@@ -1,0 +1,103 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ibm-spectrum-scale-csi-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - secrets/status
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - ibm-spectrum-scale-csi-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - csi.ibm.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-maintenance.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-maintenance.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-maintenance
+rules:
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusters
+  verbs:
+  - create

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-monitor.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-monitor
+rules:
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusters
+  verbs:
+  - get

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-operator.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-operator.yaml
@@ -1,0 +1,1029 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - PersistentVolume
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmap
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - endpoints/restricted
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - dnses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - csi.ibm.com
+  resources:
+  - csiscaleoperators
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csi.ibm.com
+  resources:
+  - csiscaleoperators/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csi.ibm.com
+  resources:
+  - csiscaleoperators/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - '*/finalizers'
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - '*/status'
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - approvalrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - approvalrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - asyncreplications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - asyncreplications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - asyncreplications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - cachevolumeoperations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - cachevolumeoperations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - cachevolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - cachevolumes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - callhomes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - callhomes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - callhomes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusterinterconnects
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - clusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - compressionjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - compressionjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - compressionjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - consistencygroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - consistencygroups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - daemons
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - daemons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - daemons/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - diskjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - diskjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - diskjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - dnss
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - dnss/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - dnss/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - encryptionconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - encryptionconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - encryptionconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - filesystems
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - filesystems/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - filesystems/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - grafanabridges
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - grafanabridges/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - grafanabridges/status
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - guis
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - guis/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - guis/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - localdisks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - localdisks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - localdisks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - pmcollectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - pmcollectors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - pmcollectors/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - recoverygroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - recoverygroups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - recoverygroups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrexports
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrs/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - regionaldrs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - remoteclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - remoteclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - remoteclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - restripefsjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - restripefsjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - restripefsjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusterinitnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusterinitnodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusterinitnodes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclustertiebreaker
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclustertiebreaker/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - stretchclustertiebreaker/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - upgradeapprovals
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - upgradeapprovals/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-privileged.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-privileged.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-privileged
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - ibm-spectrum-scale-privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-regional-dr.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-regional-dr.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-regional-dr
+rules:
+- apiGroups:
+  - scale.spectrum.ibm.com
+  resources:
+  - asyncreplications
+  - consistencygroups
+  - regionaldrs
+  verbs:
+  - get
+  - list
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-restricted.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/ibm-spectrum-scale-restricted.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-restricted
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - ibm-spectrum-scale-restricted
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/ibm-scale/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-csi-operator.yaml
+  - ibm-spectrum-scale-operator.yaml
+  - ibm-spectrum-scale-restricted.yaml
+  - ibm-spectrum-scale-maintenance.yaml
+  - ibm-spectrum-scale-privileged.yaml
+  - ibm-spectrum-scale-monitor.yaml
+  - ibm-spectrum-scale-regional-dr.yaml

--- a/cluster-scope/bundles/ibm-scale/kustomization.yaml
+++ b/cluster-scope/bundles/ibm-scale/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: ibm-scale
+resources:

--- a/ibm-scale/cluster.yaml
+++ b/ibm-scale/cluster.yaml
@@ -1,0 +1,76 @@
+apiVersion: scale.spectrum.ibm.com/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale
+  namespace: ibm-spectrum-scale
+spec:
+  daemon:
+    # hostAliases is optional
+    # -------------------------------------------------------------------------------
+    # hostAliases is used in an environment where DNS cannot resolve the remote (storage) cluster
+    # hostAliases:
+    #   - hostname: example.com
+    #     ip: 10.0.0.1
+    clusterProfile:
+      controlSetxattrImmutableSELinux: "yes"
+      enforceFilesetQuotaOnRoot: "yes"
+      ignorePrefetchLUNCount: "yes"
+      initPrefetchBuffers: "128"
+      maxblocksize: 16M
+      prefetchPct: "25"
+      prefetchTimeout: "30"
+      # custom stuff
+      maxMBpS: "100000"
+      # nsdRAIDClientOnlyChecksum: "yes"
+      # stuff for roce under this line
+      verbsPorts: eno6np0
+      verbsRdma: enable
+      verbsRdmaSend: "yes"
+      # Only enable `verbsRdmaCm` when deploying RoCE - RDMA over Converged Ethernet
+      verbsRdmaCm: enable
+    # -------------------------------------------------------------------------------
+    # nodeSelector is a User Configurable field.
+    # -------------------------------------------------------------------------------
+    # In conjunction with the nodeSelector configuration, the operator also
+    # applies node affinity according to supported architectures and OS.
+    # More info on node selectors:
+    #       https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    nodeSelector:
+      scale.spectrum.ibm.com/daemon-selector: ""
+    # -------------------------------------------------------------------------------
+    # roles is required
+    # -------------------------------------------------------------------------------
+    # roles is used to set the cluster configuration parameters
+    #   applied to all nodes
+    #   - during initial cluster creation
+    #   - and when changing these parameters at later time
+    roles:
+    - name: client
+      resources:
+        cpu: "16"
+        memory: 24Gi
+  # -------------------------------------------------------------------------------
+  # grafana bridge is optional
+  # -------------------------------------------------------------------------------
+  # Uncomment the grafanaBridge field to enable
+  # grafanaBridge: {}
+  # -------------------------------------------------------------------------------
+  # User must accept the Spectrum Scale license to deploy a CNSA cluster.
+  # By specifying "accept: true" below, user agrees to the terms and conditions set
+  # forth by the IBM Spectrum Scale Container Native Data Access/Data Management license located
+  # at https://www.ibm.com/support/customer/csol/terms/?id=L-WWVS-K7K7DR
+  #
+  # Enter either data-access or data-management to the license.license field. Customers entitled to
+  # the Data Management Edition can use either data-management or data-access. Customers entitled to
+  # the Data Access Edition can only use data-access.
+  # -------------------------------------------------------------------------------
+  license:
+    accept: true
+    license: data-access
+  # -------------------------------------------------------------------------------
+  # networkPolicy enabled by default
+  # -------------------------------------------------------------------------------
+  networkPolicy: {}

--- a/ibm-scale/configmaps/ibm-spectrum-scale-manager-config.yaml
+++ b/ibm-scale/configmaps/ibm-spectrum-scale-manager-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: scale.spectrum.ibm.com/v1alpha1
+    kind: ClusterManagerConfig
+    images:
+      coreECE: cp.icr.io/cp/gpfs/erasure-code/ibm-spectrum-scale-daemon@sha256:8b8647956d6b1f95a2fc35e5bd2f79881a1dd4a2ea263fa91fcfa1f8863346dd
+      coreDME: cp.icr.io/cp/gpfs/data-management/ibm-spectrum-scale-daemon@sha256:4a2a68de2758585aad3642b9072779e863332def99ee97162fd96069e89377e1
+      coreDAE: cp.icr.io/cp/gpfs/data-access/ibm-spectrum-scale-daemon@sha256:0cd0d308fb0659b7e2e9bec1351b168408b23f3856799e408764fcfa7fe61bd2
+      coreInit: cp.icr.io/cp/gpfs/ibm-spectrum-scale-core-init@sha256:d22e6fd244befcc74d6caea61862a4dd69a94956b6a4d42f7e753371f19d71bd
+      gui: cp.icr.io/cp/gpfs/ibm-spectrum-scale-gui@sha256:179fd0f462c15f303c7a006b1a8ad71f01cd4215bcac99ac46722e37a56dba93
+      postgres: cp.icr.io/cp/gpfs/postgres@sha256:0bcc5bbbb2aa9c9b4c6505845918c7eb55d783cf5c1f434fac33012579fb149d
+      logs: cp.icr.io/cp/gpfs/ibm-spectrum-scale-logs@sha256:ef767949384ffdf4f2067496051961a7b2c75e52d9255991ce0152072bfb9d2d
+      pmcollector: cp.icr.io/cp/gpfs/ibm-spectrum-scale-pmcollector@sha256:f4c3d343e92a9931830b2693bc274136a14f6f497e7da92c199a957b9c0a0c7a
+      sysmon: cp.icr.io/cp/gpfs/ibm-spectrum-scale-monitor@sha256:9543dfe369c3d1d4bd93f7c7743f990ae652e9bc2256a0ba6ed1d03e6924afd0
+      grafanaBridge: cp.icr.io/cp/gpfs/ibm-spectrum-scale-grafana-bridge@sha256:b05cf7a8f6e1be3aa576f237075757fb318c9d3174f54410dbc17365176ce121
+      coreDNS: cp.icr.io/cp/gpfs/ibm-spectrum-scale-coredns@sha256:6a317b23fee629c0b07eb95d34ab7593bb38d41bffc5d1cd4cb2870539c66cd4
+      mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:4ce047b7b8f81652fd6c2c0a6682d92c08b5e99e1f31dcdde196e01267f58cc9
+      ganesha: cp.icr.io/cp/gpfs/ibm-spectrum-scale-ganesha@sha256:054e9e382241ec3bc2a6cab30f1a045b74674492b25afd1110896b4060d1ab6f
+      stunnel: cp.icr.io/cp/gpfs/ibm-spectrum-scale-stunnel@sha256:a2c94c1357fe27ef5070d8ea7ba39e9524243d925ffaf3af6300238b565de44b
+      pmsensors: cp.icr.io/cp/gpfs/ibm-spectrum-scale-pmsensors@sha256:c9270e17334eba8fd77733282bb78866fa7266e87d86bcb19146a116d4e83483
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-manager-config
+  namespace: ibm-spectrum-scale-operator

--- a/ibm-scale/configmaps/kustomization.yaml
+++ b/ibm-scale/configmaps/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-manager-config.yaml

--- a/ibm-scale/deployments/ibm-spectrum-scale-controller-manager.yaml
+++ b/ibm-scale/deployments/ibm-spectrum-scale-controller-manager.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+    app.kubernetes.io/version: v5.2.3.0
+    control-plane: controller-manager
+  name: ibm-spectrum-scale-controller-manager
+  namespace: ibm-spectrum-scale-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: ibm-spectrum-scale
+      app.kubernetes.io/name: operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: ibm-spectrum-scale
+        app.kubernetes.io/name: operator
+        app.kubernetes.io/version: v5.2.3.0
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
+          - preference:
+              matchExpressions:
+              - key: scale.spectrum.ibm.com/controller-manager
+                operator: Exists
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+      containers:
+      - args:
+        - --config=/config/controller_manager_config.yaml
+        - --zap-log-level=1
+        command:
+        - /manager
+        env:
+        - name: GOVMOMI_HOME
+          value: /tmp
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        image: icr.io/cpopen/ibm-spectrum-scale-operator@sha256:d2f9ebc3bb196ad85b931f2dabdce13aed2e6598227b8fc2434d6df9f840f696
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 1500m
+            memory: 400Mi
+          requests:
+            cpu: 500m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /config
+          name: manager-config
+        - mountPath: /etc/ssl/service
+          name: cabundle
+      serviceAccountName: ibm-spectrum-scale-operator
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: ibm-spectrum-scale
+            app.kubernetes.io/name: operator
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: ibm-spectrum-scale-webhook-service-cert
+      - configMap:
+          name: ibm-spectrum-scale-manager-config
+        name: manager-config
+      - configMap:
+          name: ibm-spectrum-scale-cabundle
+          optional: true
+        name: cabundle

--- a/ibm-scale/deployments/ibm-spectrum-scale-csi-operator.yaml
+++ b/ibm-scale/deployments/ibm-spectrum-scale-csi-operator.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    productVersion: 2.14.0
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+    product: ibm-spectrum-scale-csi
+    release: ibm-spectrum-scale-csi-operator
+  name: ibm-spectrum-scale-csi-operator
+  namespace: ibm-spectrum-scale-csi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+  template:
+    metadata:
+      annotations:
+        productID: ibm-spectrum-scale-csi-operator
+        productName: IBM Spectrum Scale CSI Operator
+        productVersion: 2.14.0
+      labels:
+        app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
+        app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
+        app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+        name: ibm-spectrum-scale-csi-operator
+        product: ibm-spectrum-scale-csi
+        release: ibm-spectrum-scale-csi-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
+      containers:
+      - args:
+        - --leaderElection=true
+        env:
+        - name: SHORTNAME_NODE_MAPPING
+          value: "yes"
+        - name: CSI_SNAPSHOTTER_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
+        - name: CSI_ATTACHER_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/csi-attacher@sha256:69888dba58159c8bc0d7c092b9fb97900c9ca8710d088b0b7ea7bd9052df86f6
+        - name: CSI_PROVISIONER_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/csi-provisioner@sha256:d5e46da8aff7d73d6f00c761dae94472bcda6e78f4f17b3802dc89d44de0111b
+        - name: CSI_LIVENESSPROBE_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/livenessprobe@sha256:2c5f9dc4ea5ac5509d93c664ae7982d4ecdec40ca7b0638c24e5b16243b8360f
+        - name: CSI_NODE_REGISTRAR_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/csi-node-driver-registrar@sha256:d7138bcc3aa5f267403d45ad4292c95397e421ea17a0035888850f424c7de25d
+        - name: CSI_RESIZER_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/csi-resizer@sha256:8ddd178ba5d08973f1607f9b84619b58320948de494b31c9d7cd5375b316d6d4
+        - name: CSI_DRIVER_IMAGE
+          value: cp.icr.io/cp/gpfs/csi/ibm-spectrum-scale-csi-driver@sha256:4856f2904c1893e8893f6d8e6775c23fe0871f0547c5d24984d70bbbbb7b3580
+        - name: METRICS_BIND_ADDRESS
+          value: "8383"
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:8d74a489683d33a2e21d2b00b774d08b51861213fcd0a93ad93a1a1658595439
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - ./health_check.sh
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        name: operator
+        readinessProbe:
+          exec:
+            command:
+            - ./health_check.sh
+          initialDelaySeconds: 3
+          periodSeconds: 1
+        resources:
+          limits:
+            cpu: 600m
+            ephemeral-storage: 5Gi
+            memory: 600Mi
+          requests:
+            cpu: 50m
+            ephemeral-storage: 1Gi
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      serviceAccountName: ibm-spectrum-scale-csi-operator
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/ibm-scale/deployments/kustomization.yaml
+++ b/ibm-scale/deployments/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-controller-manager.yaml
+  - ibm-spectrum-scale-csi-operator.yaml

--- a/ibm-scale/filesystem.remote.yaml
+++ b/ibm-scale/filesystem.remote.yaml
@@ -1,0 +1,17 @@
+apiVersion: scale.spectrum.ibm.com/v1beta1
+kind: Filesystem
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: essfs-remote
+  namespace: ibm-spectrum-scale
+spec:
+  remote:
+    cluster: remotecluster-sample
+    fs: essfs
+  seLinuxOptions:
+    level: s0
+    role: object_r
+    type: container_file_t
+    user: system_u

--- a/ibm-scale/mutatingwebhookconfigurations/ibm-spectrum-scale-mutating-webhook-configuration.yaml
+++ b/ibm-scale/mutatingwebhookconfigurations/ibm-spectrum-scale-mutating-webhook-configuration.yaml
@@ -1,0 +1,50 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /mutate-scale-spectrum-ibm-com-v1beta1-cluster
+  failurePolicy: Fail
+  name: mcluster.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /mutate-scale-spectrum-ibm-com-v1beta1-filesystem
+  failurePolicy: Ignore
+  name: mfilesystem.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - filesystems
+  sideEffects: None

--- a/ibm-scale/mutatingwebhookconfigurations/kustomization.yaml
+++ b/ibm-scale/mutatingwebhookconfigurations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-mutating-webhook-configuration.yaml

--- a/ibm-scale/remotecluster.yaml
+++ b/ibm-scale/remotecluster.yaml
@@ -1,0 +1,32 @@
+apiVersion: scale.spectrum.ibm.com/v1beta1
+kind: RemoteCluster
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: remotecluster-sample
+  namespace: ibm-spectrum-scale
+spec:
+  # contactNodes are optional and provides a list of nodes from the storage cluster
+  # to be used as the remote cluster contact nodes.  The names should be the daemon
+  # node names.  If not specified, the operator will use any 3 nodes detected
+  # from the storage cluster.
+  # contactNodes:
+  #  storagecluster1node1
+  #  storagecluster1node2
+  gui:
+    # cacert: cacert-storage-cluster-1
+    # This is the secret that contains the CSIAdmin user
+    # credentials in the ibm-spectrum-scale-csi namespace.
+    # Remove the csiSecretName entry if the storage cluster is version 5.2.3 or newer.
+    # csiSecretName: csi-remote-mount-storage-cluster-1
+    # hosts are the the GUI endpoints from the storage cluster. Multiple
+    # hosts (up to 3) can be specified to ensure high availability of GUI.
+    csiSecretName: csi-remote-mount
+    # hosts:
+    # - guihost2.example.com
+    # - guihost3.example.com
+    insecureSkipVerify: true
+    # This is the secret that contains the ContainerOperator user
+    # credentials in the ibm-spectrum-scale namespace.
+    secretName: cnsa-remote-mount

--- a/ibm-scale/rolebindings/ibm-spectrum-scale-leader-election-rolebinding.yaml
+++ b/ibm-scale/rolebindings/ibm-spectrum-scale-leader-election-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-leader-election-rolebinding
+  namespace: ibm-spectrum-scale-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ibm-spectrum-scale-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-operator
+  namespace: ibm-spectrum-scale-operator

--- a/ibm-scale/rolebindings/ibm-spectrum-scale-privileged.yaml
+++ b/ibm-scale/rolebindings/ibm-spectrum-scale-privileged.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-privileged
+  namespace: ibm-spectrum-scale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-privileged
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/rolebindings/ibm-spectrum-scale-regional-dr.yaml
+++ b/ibm-scale/rolebindings/ibm-spectrum-scale-regional-dr.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ibm-spectrum-scale-regional-dr
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale-operator

--- a/ibm-scale/rolebindings/ibm-spectrum-scale-restricted.yaml
+++ b/ibm-scale/rolebindings/ibm-spectrum-scale-restricted.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-restricted
+  namespace: ibm-spectrum-scale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-spectrum-scale-restricted
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-pmcollector
+  namespace: ibm-spectrum-scale
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-gui
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/rolebindings/ibm-spectrum-scale-sysmon.yaml
+++ b/ibm-scale/rolebindings/ibm-spectrum-scale-sysmon.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-sysmon
+  namespace: ibm-spectrum-scale
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ibm-spectrum-scale-sysmon
+subjects:
+- kind: ServiceAccount
+  name: ibm-spectrum-scale-core
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/rolebindings/kustomization.yaml
+++ b/ibm-scale/rolebindings/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-leader-election-rolebinding.yaml
+  - ibm-spectrum-scale-restricted.yaml
+  - ibm-spectrum-scale-privileged.yaml
+  - ibm-spectrum-scale-sysmon.yaml
+  - ibm-spectrum-scale-regional-dr.yaml

--- a/ibm-scale/roles/ibm-spectrum-scale-leader-election-role.yaml
+++ b/ibm-scale/roles/ibm-spectrum-scale-leader-election-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-leader-election-role
+  namespace: ibm-spectrum-scale-operator
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/ibm-scale/roles/ibm-spectrum-scale-regional-dr.yaml
+++ b/ibm-scale/roles/ibm-spectrum-scale-regional-dr.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - stunnel
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/ibm-scale/roles/ibm-spectrum-scale-sysmon.yaml
+++ b/ibm-scale/roles/ibm-spectrum-scale-sysmon.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-sysmon
+  namespace: ibm-spectrum-scale
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list

--- a/ibm-scale/roles/kustomization.yaml
+++ b/ibm-scale/roles/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-leader-election-role.yaml
+  - ibm-spectrum-scale-sysmon.yaml
+  - ibm-spectrum-scale-regional-dr.yaml

--- a/ibm-scale/scc/ibm-spectrum-scale-privileged.yaml
+++ b/ibm-scale/scc/ibm-spectrum-scale-privileged.yaml
@@ -1,0 +1,40 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context. This is permissive and should not be used by any components
+      except for IBM Spectrum Scale core pods.
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-privileged
+  namespace: ibm-spectrum-scale-operator
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- '*'

--- a/ibm-scale/scc/ibm-spectrum-scale-restricted.yaml
+++ b/ibm-scale/scc/ibm-spectrum-scale-restricted.yaml
@@ -1,0 +1,46 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: restricted denies access to all host features and requires
+      pods to be run with a UID, and SELinux context that are allocated to the namespace.
+      This is intended to be used exclusively by IBM Spectrum Scale.
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-restricted
+  namespace: ibm-spectrum-scale-operator
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+- runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/ibm-scale/scc/kustomization.yaml
+++ b/ibm-scale/scc/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-privileged.yaml
+  - ibm-spectrum-scale-restricted.yaml
+  - spectrum-scale-csiaccess.yaml

--- a/ibm-scale/scc/spectrum-scale-csiaccess.yaml
+++ b/ibm-scale/scc/spectrum-scale-csiaccess.yaml
@@ -1,0 +1,46 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: allows hostpath and host network to be accessible
+  name: spectrum-scale-csiaccess
+  namespace: ibm-spectrum-scale-csi
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: []
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:ibm-spectrum-scale-csi:ibm-spectrum-scale-csi-attacher
+- system:serviceaccount:ibm-spectrum-scale-csi:ibm-spectrum-scale-csi-provisioner
+- system:serviceaccount:ibm-spectrum-scale-csi:ibm-spectrum-scale-csi-node
+- system:serviceaccount:ibm-spectrum-scale-csi:ibm-spectrum-scale-csi-snapshotter
+- system:serviceaccount:ibm-spectrum-scale-csi:ibm-spectrum-scale-csi-resizer
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- hostPath
+- persistentVolumeClaim
+- projected
+- secret

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-core-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-core-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-core
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-csi-operator-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-csi-operator-sa.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
+    app.kubernetes.io/name: ibm-spectrum-scale-csi-operator
+    product: ibm-spectrum-scale-csi
+    release: ibm-spectrum-scale-csi-operator
+  name: ibm-spectrum-scale-csi-operator
+  namespace: ibm-spectrum-scale-csi

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-default-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-default-sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+automountServiceAccountToken: false
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-default
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-dns-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-dns-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: coredns
+  name: ibm-spectrum-scale-dns
+  namespace: ibm-spectrum-scale-dns

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-gui-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-gui-sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+automountServiceAccountToken: false
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-gui
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-operator-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-operator-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-operator
+  namespace: ibm-spectrum-scale-operator

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-pmcollector-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-pmcollector-sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+automountServiceAccountToken: false
+imagePullSecrets:
+- name: ibm-entitlement-key
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: cluster
+  name: ibm-spectrum-scale-pmcollector
+  namespace: ibm-spectrum-scale

--- a/ibm-scale/serviceaccounts/ibm-spectrum-scale-regional-dr-sa.yaml
+++ b/ibm-scale/serviceaccounts/ibm-spectrum-scale-regional-dr-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-regional-dr
+  namespace: ibm-spectrum-scale-operator

--- a/ibm-scale/serviceaccounts/kustomization.yaml
+++ b/ibm-scale/serviceaccounts/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccounts/ibm-spectrum-scale-csi-operator-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-dns-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-operator-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-regional-dr-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-core-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-default-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-gui-sa.yaml
+  - serviceaccounts/ibm-spectrum-scale-pmcollector-sa.yaml

--- a/ibm-scale/services/ibm-spectrum-scale-webhook-service.yaml
+++ b/ibm-scale/services/ibm-spectrum-scale-webhook-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ibm-spectrum-scale-webhook-service-cert
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-webhook-service
+  namespace: ibm-spectrum-scale-operator
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+    control-plane: controller-manager

--- a/ibm-scale/services/kustomization.yaml
+++ b/ibm-scale/services/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-webhook-service.yaml

--- a/ibm-scale/storageclass.yaml
+++ b/ibm-scale/storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: ibm-spectrum-scale-fileset
+provisioner: spectrumscale.csi.ibm.com
+parameters:
+    volBackendFs: essfs-remote
+    shared: "true"
+reclaimPolicy: Delete
+allowVolumeExpansion: true

--- a/ibm-scale/validatingwebhookconfigurations/ibm-spectrum-scale-validating-webhook-configuration.yaml
+++ b/ibm-scale/validatingwebhookconfigurations/ibm-spectrum-scale-validating-webhook-configuration.yaml
@@ -1,0 +1,221 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/instance: ibm-spectrum-scale
+    app.kubernetes.io/name: operator
+  name: ibm-spectrum-scale-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-pod-eviction
+  failurePolicy: Fail
+  name: veviction.scale.spectrum.ibm.com
+  namespaceSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/part-of
+      operator: In
+      values:
+      - ibm-spectrum-scale
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - pods/eviction
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1alpha1-approvalrequest
+  failurePolicy: Fail
+  name: vapprovalrequest.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - approvalrequests
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1alpha1-asyncreplication
+  failurePolicy: Fail
+  name: vasyncreplication.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - asyncreplications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1alpha1-cachevolumeoperation
+  failurePolicy: Fail
+  name: vcachevolumeoperation.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - cachevolumeoperations
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1alpha1-clusterinterconnect
+  failurePolicy: Fail
+  name: vclusterinterconnect.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterinterconnects
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1beta1-cluster
+  failurePolicy: Fail
+  name: vcluster.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1beta1-encryptionconfig
+  failurePolicy: Fail
+  name: vencryptionconfig.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - encryptionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1beta1-filesystem
+  failurePolicy: Fail
+  name: vfilesystem.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - filesystems
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1beta1-localdisk
+  failurePolicy: Fail
+  name: vlocaldisk.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - localdisks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ibm-spectrum-scale-webhook-service
+      namespace: ibm-spectrum-scale-operator
+      path: /validate-scale-spectrum-ibm-com-v1beta1-remotecluster
+  failurePolicy: Fail
+  name: vremotecluster.scale.spectrum.ibm.com
+  rules:
+  - apiGroups:
+    - scale.spectrum.ibm.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - remoteclusters
+  sideEffects: None

--- a/ibm-scale/validatingwebhookconfigurations/kustomization.yaml
+++ b/ibm-scale/validatingwebhookconfigurations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ibm-spectrum-scale-validating-webhook-configuration.yaml


### PR DESCRIPTION
Adds ibm-scale operator and deployment resources. This configuration is the one we've used in the dublin cluster to connect to CNSA and test single interface I/O on the H100 nodes. 

This PR does not add the resources to any cluster overlay, it just codifies the deployment for future deployments.