### PR TITLE
Update infra vault overlay

### DIFF
--- a/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: vault
 commonLabels:
   app.kubernetes.io/name: vault
 


### PR DESCRIPTION
Currently the compact route does not get placed in the vault ns unless the command is run from there. Add namespace to manifest.