### PR TITLE
Enable RHOAI features for testing in ocp-test

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -5,26 +5,34 @@ metadata:
 spec:
   components:
     codeflare:
-      managementState: Removed
-    dashboard:
-      managementState: Managed
-    datasciencepipelines:
       managementState: Managed
     kserve:
       managementState: Managed
+      nim:
+        managementState: Managed
+      rawDeploymentServiceConfig: Headless
       serving:
         ingressGateway:
           certificate:
             type: SelfSigned
         managementState: Managed
         name: knative-serving
-    kueue:
-      managementState: Removed
-    modelmeshserving:
+    modelregistry:
+      managementState: Managed
+      registriesNamespace: rhoai-model-registries
+    trustyai:
       managementState: Managed
     ray:
-      managementState: Removed
-    trustyai:
+      managementState: Managed
+    kueue:
       managementState: Removed
     workbenches:
       managementState: Managed
+    dashboard:
+      managementState: Managed
+    modelmeshserving:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Managed
+    trainingoperator:
+      managementState: Removed


### PR DESCRIPTION
Enables the following features:
- CodeFlare
- Model Registry
- TrustyAI
- Ray

Relevant Issue: https://github.com/nerc-project/operations/issues/1191