### PR TITLE
Manifest changes needed for the infra rebuild

### DIFF
--- a/acm/overlays/nerc-ocp-infra/managedclustersetbindings/argocd-managed.yaml
+++ b/acm/overlays/nerc-ocp-infra/managedclustersetbindings/argocd-managed.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   name: argocd-managed

--- a/acm/overlays/nerc-ocp-infra/managedclustersets/argocd-managed.yaml
+++ b/acm/overlays/nerc-ocp-infra/managedclustersets/argocd-managed.yaml
@@ -3,5 +3,3 @@ kind: ManagedClusterSet
 metadata:
   name: argocd-managed
 spec:
-  clusterSelector:
-    selectorType: LegacyClusterSetLabel

--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
     name: acm
 spec:
-    channel: release-2.8
+    channel: release-2.13
     installPlanApproval: Automatic
     name: advanced-cluster-management
     source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/multicluster-engine-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/multicluster-engine-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: multicluster-engine
   namespace: multicluster-engine
 spec:
-  channel: stable-2.3
+  channel: stable-2.8
   installPlanApproval: Automatic
   name: multicluster-engine
   source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: openshift-gitops-operator
 spec:
-  channel: gitops-1.6
+  channel: gitops-1.16
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/vault/instance/base/rbac.yaml
+++ b/vault/instance/base/rbac.yaml
@@ -4,6 +4,14 @@ metadata:
   name: vault
 rules:
 - apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - vault
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods

--- a/vault/instance/base/ssc.yaml
+++ b/vault/instance/base/ssc.yaml
@@ -1,0 +1,39 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- NET_BIND_SERVICE
+- IPC_LOCK
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+kind: SecurityContextConstraints
+metadata:
+  name: vault
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+- runtime/default
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- ephemeral
+- persistentVolumeClaim
+- projected
+- secret

--- a/vault/instance/base/vault.yaml
+++ b/vault/instance/base/vault.yaml
@@ -5,8 +5,13 @@ metadata:
   labels:
     app.kubernetes.io/name: vault
 spec:
+  vaultEnvsConfig:
+  - name: SKIP_CHOWN
+    value: "1"
+  - name: SKIP_SETCAP
+    value: "1"
   size: 3
-  image: hashicorp/vault:1.15.5
+  image: hashicorp/vault:1.20.0
 
   serviceAccount: vault
   serviceType: ClusterIP
@@ -36,6 +41,7 @@ spec:
       secretNamespace: default
 
   config:
+    disable_mlock: true
     storage:
       raft:
         path: "/vault/data"

--- a/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: vault
 commonLabels:
   app.kubernetes.io/name: vault
 

--- a/vault/operator/base/src/kustomization.yaml
+++ b/vault/operator/base/src/kustomization.yaml
@@ -6,6 +6,6 @@ helmCharts:
   - name: vault-operator
     namespace: vault-operator
     repo: oci://ghcr.io/bank-vaults/helm-charts
-    version: 1.22.2
+    version: 1.22.6
     includeCRDs: true
     releaseName: vault-operator

--- a/vault/operator/base/vault-operator.yaml
+++ b/vault/operator/base/vault-operator.yaml
@@ -498,6 +498,8 @@ spec:
                 type: array
               config:
                 x-kubernetes-preserve-unknown-fields: true
+              configPath:
+                type: string
               credentialsConfig:
                 properties:
                   env:
@@ -11508,7 +11510,7 @@ metadata:
     app.kubernetes.io/instance: vault-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-operator
-    helm.sh/chart: vault-operator-1.22.2
+    helm.sh/chart: vault-operator-1.22.6
   name: vault-operator
   namespace: vault-operator
 ---
@@ -11516,7 +11518,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: vault-operator-1.22.2
+    helm.sh/chart: vault-operator-1.22.6
   name: vault-operator
 rules:
 - apiGroups:
@@ -11597,7 +11599,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: vault-operator-1.22.2
+    helm.sh/chart: vault-operator-1.22.6
   name: vault-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11615,7 +11617,7 @@ metadata:
     app.kubernetes.io/instance: vault-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-operator
-    helm.sh/chart: vault-operator-1.22.2
+    helm.sh/chart: vault-operator-1.22.6
   name: vault-operator
   namespace: vault-operator
 spec:
@@ -11638,7 +11640,7 @@ metadata:
     app.kubernetes.io/instance: vault-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vault-operator
-    helm.sh/chart: vault-operator-1.22.2
+    helm.sh/chart: vault-operator-1.22.6
   name: vault-operator
   namespace: vault-operator
 spec:
@@ -11651,7 +11653,6 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: vault-operator
         app.kubernetes.io/name: vault-operator
     spec:
       affinity: {}
@@ -11672,8 +11673,8 @@ spec:
         - name: OPERATOR_LOG_LEVEL
           value: debug
         - name: BANK_VAULTS_IMAGE
-          value: ghcr.io/bank-vaults/bank-vaults:v1.31.1
-        image: ghcr.io/bank-vaults/vault-operator:v1.22.2
+          value: ghcr.io/bank-vaults/bank-vaults:v1.31.4
+        image: ghcr.io/bank-vaults/vault-operator:v1.22.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This PR the manifest required for the infra rebuild
ACM:
- apiversion changes
- Remove clusterSelector field from managed cluster set resource, `LegacyClusterSetLabel` has been deprecated and the equivalent `ExclusiveClusterSetLabel` is the default
- Changes subscription channel to most recent
MultiCluster:
- Changes subscription channel to most recent
Openshift Gitops:
- Changes subscription channel to most recent
Vault:
- Update rbac to add necessary ssc
- Change instance image to new one
- Add necessary env vars and config to instance
- Upgrade vault operator
- Add namespace to kustomization file for compact route