### PR TITLE
Add IP Forwarding to network operator patch

### DIFF
--- a/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
+++ b/cluster-scope/base/operator.openshift.io/networks/cluster/network.yaml
@@ -7,3 +7,4 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+        ipForwarding: Global


### PR DESCRIPTION
We are currently configuring IP forwarding with a machine config on all clusters. At first we did not know why this had become an issue. We now know that prior to OCP 4.16 the `spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipforwarding` field in the network.operator manifest defaulted to global if it had not been explicitly set. This behavior was changed, so now it default to "" which if you look at this [file](https://github.com/openshift/cluster-network-operator/blob/release-4.17/bindata/network/ovn-kubernetes/common/008-script-lib.yaml#L584)  cause ip forwarding to get set to 0. By explicitly setting it to global we can fix that.
We already have a machine config doing this but for some reason the machine config did not work on the Barcelona cluster, additionally this way seems to be a lot cleaner that using a machine config since ovn-kube is going to interact with it regardless.
If we go through with this, we should make a separate PR for removing the machine config, which should probably be done during the maintenance window.