### PR TITLE
Configure local storage for hosted etcd

### DIFF
--- a/cluster-scope/overlays/hypershift2/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - externalsecrets
 - dns
 - metallb-config
+- lvmcluster
 
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/metallb

--- a/cluster-scope/overlays/hypershift2/lvmcluster/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/lvmcluster/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- lvmcluster.yaml
+- subscription.yaml

--- a/cluster-scope/overlays/hypershift2/lvmcluster/lvmcluster.yaml
+++ b/cluster-scope/overlays/hypershift2/lvmcluster/lvmcluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: local-storage-vg1
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      fstype: ext4
+      default: true
+      nodeSelector:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nerc.mghpcc.org/local-storage
+            operator: Exists
+      deviceSelector:
+        paths:
+        - /dev/disk/by-path/pci-0000:43:00.0-scsi-0:0:1:0
+        forceWipeDevicesAndDestroyAllData: false
+      thinPoolConfig:
+        name: pool0
+        sizePercent: 90
+        overprovisionRatio: 10
+        chunkSize: 128Ki
+        chunkSizeCalculationPolicy: Static

--- a/cluster-scope/overlays/hypershift2/lvmcluster/subscription.yaml
+++ b/cluster-scope/overlays/hypershift2/lvmcluster/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms
+  namespace: openshift-storage
+spec:
+  installPlanApproval: Automatic
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The hosted control plane guidelines suggest using local storage for etcd
rather than network storage [1]. This adds an LVMCluster configuration to
hypershift2 that will use the free 1TB disk on each worker node as a local
storage pool.

[1]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/hosted_control_planes/deploying-hosted-control-planes#deploying-hosted-control-planes-on-bare-metal

Part of: https://github.com/innabox/issues/issues/177