### PR TITLE
Bind nerc-infra-routed nncp to worker nodes

### DIFF
--- a/cluster-scope/overlays/hypershift2/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/kustomization.yaml
@@ -127,3 +127,12 @@ patches:
       path: /spec/routeAdmission
       value:
         wildcardPolicy: WildcardsAllowed
+
+- target:
+    kind: Network
+    group: operator.openshift.io
+    name: cluster
+  patch: |
+    - op: add
+      path: /spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding
+      value: Global

--- a/cluster-scope/overlays/hypershift2/nodenetworkconfigurationpolicies/nerc-infra-routed.yaml
+++ b/cluster-scope/overlays/hypershift2/nodenetworkconfigurationpolicies/nerc-infra-routed.yaml
@@ -15,4 +15,6 @@ spec:
       vlan:
         base-iface: mlx1
         id: 2076
-      mtu: 9000
+      mtu: 1500
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
Some networking fixes necessary for the hypershift2 cluster.

The `ipForwarding: Global` change we probably want to move out of the hypershift2 overlay at some point and make it the default on our other clusters.
