### PR TITLE
edu: add vault config

### DIFF
--- a/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-edu.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/config/nerc-ocp-edu.yaml
@@ -1,0 +1,28 @@
+auth:
+- type: kubernetes
+  path: kubernetes/nerc-ocp-edu
+  config:
+    kubernetes_ca_cert: "${ file `certs/letsencrypt.crt` }"
+    kubernetes_host: https://api.edu.nerc.mghpcc.org:6443
+    token_reviewer_jwt: "${ file `creds/nerc-ocp-edu-token-reviewer` }"
+  roles:
+  - bound_service_account_names:
+    - vault-secret-reader
+    bound_service_account_namespaces:
+    - openshift-storage
+    - group-sync-operator
+    - openshift-config
+    - openshift-ingress
+    - openshift-logging
+    - openshift-ingress-operator
+    - rhods-notebooks
+    name: secret-reader
+    policies:
+    - nerc-common-reader
+    - nerc-ocp-edu-reader
+policies:
+- name: nerc-ocp-edu-reader
+  rules: |
+    path "nerc/data/nerc-ocp-edu/*" {
+      capabilities = ["read"]
+    }

--- a/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
@@ -25,6 +25,7 @@ configMapGenerator:
   - config/nerc-ocp-infra.yaml
   - config/nerc-ocp-obs.yaml
   - config/nerc-ocp-prod.yaml
+  - config/nerc-ocp-edu.yaml
   - config/nerc-ocp-test.yaml
   - config/nerc-ocp-beta-test.yaml
   - config/rhoai-test.yaml


### PR DESCRIPTION
This is the vault config for the new nerc-ocp-edu (academic) cluster. The `vault-credentials` secret on `nerc-ocp-infra` has been updated to include the `eso-vault-auth-token` for the edu cluster.