### PR TITLE
ocp-test: patch odf subscription to 4.18

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
   name: odf-operator
 spec:
-  channel: stable-4.17
+  channel: stable-4.18


### PR DESCRIPTION
Following https://github.com/OCP-on-NERC/nerc-ocp-config/pull/739, we also need to move odf operator to v4.18 to reflect the OCP version