### PR TITLE
nfd: remove image from manifest

### DIFF
--- a/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
+++ b/nfd-operator/base/nodefeaturediscoveries/nfd-instance.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   instance: ""
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17
     imagePullPolicy: Always
     servicePort: 0
   topologyUpdater: false


### PR DESCRIPTION
This will use the default image for the currently installed nfd operator instead.