### PR TITLE
Create Alert for blocked machineconfig

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -288,6 +288,19 @@ data:
             description: |
               info: kube_pod_owner: {{ $value }} pod owners
 
+      - name: machine-config
+        rules:
+        - alert: CustomBlockedMachineConfigUpdate
+          annotations:
+            summary: "{{ $labels.cluster }} Machine Config Pool {{ $labels.pool }} stuck updating for >30min"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.infra.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(mco_machine_count%20-%20mco_updated_machine_count)%20%3E%200%20and%20mco_unavailable_machine_count%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Machine Config Pool {{ $labels.pool }} in cluster {{ $labels.cluster }} has been updating for more than 30 minutes. This could indicate a stuck update that might require manual intervention.
+          expr: ((mco_machine_count - mco_updated_machine_count) > 0 and mco_unavailable_machine_count > 0) > 0
+          for: 30m
+          labels:
+            severity: critical
+
       - name: IBM autopilot
         rules:
         - alert: LowPCIeBandwidth

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -301,6 +301,17 @@ data:
           labels:
             severity: critical
 
+        - alert: CustomMachineConfigHighUnavailable
+          annotations:
+            summary: "{{ $labels.cluster }} Machine Config Pool {{ $labels.pool }} has unavailable machines for >15min"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.infra.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22mco_unavailable_machine_count%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Machine Config Pool {{ $labels.pool }} in cluster {{ $labels.cluster }} has {{ $value }} unavailable machines for more than 15 minutes. This indicates machines are not ready and might require investigation.
+          expr: mco_unavailable_machine_count > 0
+          for: 15m
+          labels:
+            severity: critical
+
       - name: IBM autopilot
         rules:
         - alert: LowPCIeBandwidth

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -101,7 +101,7 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "(CustomBlockedMachineConfigUpdate)"
+                  - alertname =~ "(CustomBlockedMachineConfigUpdate|CustomMachineConfigHighUnavailable)"
 
           receivers:
           - name: default

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -95,6 +95,13 @@ spec:
                 # repeat_interval cannot be zero, group_interval cannot be zero
                 matchers:
                   - alertname =~ "^Custom6amOpe.*"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, pool]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(CustomBlockedMachineConfigUpdate)"
 
           receivers:
           - name: default


### PR DESCRIPTION
Closes https://github.com/nerc-project/operations/issues/824

## Add alert for blocked MachineConfig updates
Implements CustomBlockedMachineConfigUpdate alert that triggers when a MachineConfigPool is stuck updating for more than 30 minutes. The alert monitors when machines are unavailable during updates and provides a direct link to Grafana metrics for troubleshooting.

- Add alert rule in thanos-ruler-custom-rules configmap with critical severity
- Configure Slack notification routing for the new alert
- Alert fires when (mco_machine_count - mco_updated_machine_count) > 0 and mco_unavailable_machine_count > 0

## Add CustomMachineConfigHighUnavailable alert for monitoring machine unavailability
Implements CustomMachineConfigHighUnavailable alert that triggers when machines in a MachineConfigPool are unavailable for more than 15 minutes. This alert monitors the mco_unavailable_machine_count metric to detect when machines are not ready.

- Add alert rule with critical severity to machine-config group
- Alert fires when mco_unavailable_machine_count > 0 for 15 minutes
- Provides direct link to Grafana metrics for troubleshooting
- Complements the existing CustomBlockedMachineConfigUpdate alert

---
### Test
  - Verify alert rules are properly loaded in Thanos Ruler
  - Confirm Slack notifications are routing correctly
  - Validate Grafana dashboard links in alert descriptions work correctly
