### PR TITLE
rhoai: disable migrated-gpu acceleratorprofile

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/rhoai/acceleratorprofiles/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rhoai/acceleratorprofiles/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - migrated-gpu.yaml
   - a100-acceleratorprofile.yaml
   - v100-acceleratorprofile.yaml
   - h100-acceleratorprofile.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/rhoai/acceleratorprofiles/migrated-gpu.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rhoai/acceleratorprofiles/migrated-gpu.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  annotations:
+    opendatahub.io/modified-date: "2025-01-29T19:53:27.027Z"
+  name: migrated-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA GPU
+  enabled: false
+  identifier: nvidia.com/gpu
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    operator: Exists

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - migrated-gpu.yaml
   - a100-acceleratorprofile.yaml
   - v100-acceleratorprofile.yaml
   - h100-acceleratorprofile.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/migrated-gpu.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/acceleratorprofiles/migrated-gpu.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  annotations:
+    opendatahub.io/modified-date: "2025-01-29T19:53:27.027Z"
+  name: migrated-gpu
+  namespace: redhat-ods-applications
+spec:
+  displayName: NVIDIA GPU
+  enabled: false
+  identifier: nvidia.com/gpu
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    operator: Exists


### PR DESCRIPTION
This GPU profile gets configured by RHOAI. This adds the manifest for that resource and sets enabled False to prevent it from showing up in the RHOAI UI.