### PR TITLE
vault: update backup tasks to use vault 1.20.0

### DIFF
--- a/vault/backup-job/base/task.yaml
+++ b/vault/backup-job/base/task.yaml
@@ -18,7 +18,7 @@ spec:
       mountPath: /scripts
   steps:
     - name: create-snapshot
-      image: docker.io/hashicorp/vault:1.15.5
+      image: docker.io/hashicorp/vault:1.20.0
       workingDir: /workspace
       env:
         - name: VAULT_CACERT


### PR DESCRIPTION
This updates vault backup tasks to use vault 1.20.0 which is the current production version on the infra cluster.