### PR TITLE
autopilot: add nerc-ocp-edu overlay

### DIFF
--- a/autopilot/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-edu/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: autopilot
+
+resources:
+- ../../base


### PR DESCRIPTION
This adds an overlay for the new nerc-ocp-edu academic cluster