### PR TITLE
add custom-metrics overlay for nerc-ocp-edu

### DIFF
--- a/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-edu/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/keda.sh/kedacontrollers/keda/


### PR DESCRIPTION
This adds an overlay for the new nerc-ocp-edu academic cluster