### PR TITLE
Enable RHOAI components in edu cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/rhoai/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rhoai/datasciencecluster.yaml
@@ -5,10 +5,6 @@ metadata:
 spec:
   components:
     codeflare:
-      managementState: Removed
-    dashboard:
-      managementState: Managed
-    datasciencepipelines:
       managementState: Managed
     kserve:
       managementState: Managed
@@ -21,15 +17,22 @@ spec:
             type: SelfSigned
         managementState: Managed
         name: knative-serving
-    kueue:
-      managementState: Removed
-    modelmeshserving:
-      managementState: Managed
     modelregistry:
+      managementState: Managed
       registriesNamespace: rhoai-model-registries
-    ray:
-      managementState: Removed
     trustyai:
-      managementState: Removed
+      managementState: Managed
+    ray:
+      managementState: Managed
+    kueue:
+      managementState: Managed
     workbenches:
       managementState: Managed
+    dashboard:
+      managementState: Managed
+    modelmeshserving:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Managed
+    trainingoperator:
+      managementState: Removed


### PR DESCRIPTION
This adds the same DataScienceCluster spec that prod cluster uses which enables different RHOAI components. One of which, Kueue, is necessary for running Jonathan's GPU course.