### PR TITLE
Add CustomMachineConfigPoolDegraded alert for degraded machine pools

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -312,6 +312,17 @@ data:
           labels:
             severity: critical
 
+        - alert: CustomMachineConfigPoolDegraded
+          annotations:
+            summary: "{{ $labels.cluster }} Machine Config Pool {{ $labels.pool }} is degraded"
+            description: |
+              <https://grafana-open-cluster-management-observability.apps.infra.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22mco_degraded_machine_count%20%3E%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Machine Config Pool {{ $labels.pool }} in cluster {{ $labels.cluster }} has {{ $value }} degraded machines. This indicates the pool is in a degraded state and requires immediate attention.
+          expr: mco_degraded_machine_count > 0
+          for: 5m
+          labels:
+            severity: critical
+
       - name: IBM autopilot
         rules:
         - alert: LowPCIeBandwidth


### PR DESCRIPTION
### Add CustomMachineConfigPoolDegraded alert for degraded machine pools

Added the third useful alert `CustomMachineConfigPoolDegraded` to complete the machine config monitoring coverage.

This alert triggers when `mco_degraded_machine_count > 0`, indicating that a Machine Config Pool is in a degraded state and requires immediate attention. It complements the existing two alerts:
  - `CustomBlockedMachineConfigUpdate` - detects stuck updates
  - `CustomMachineConfigHighUnavailable` - detects unavailable machines

  ## Configuration Details

  - Metric: `mco_degraded_machine_count > 0`
  - Duration: 5 minutes (shorter than others due to critical nature)
  - Severity: Critical
  - Includes: Grafana monitoring link for investigation

  This provides comprehensive monitoring of machine config pool health across all failure states.


Connects to:
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/758
- https://github.com/nerc-project/operations/issues/824
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/747