### PR TITLE
Upgrade obs cluster from 4.15.16 to 4.15.32

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.15
   desiredUpdate:
-    version: 4.15.16
+    version: 4.15.32
   clusterID: 760c86f3-95a0-489e-b72a-2938bb80bcea


### PR DESCRIPTION
The obs cluster is behind on OpenShift versions and we need to upgrade to match the infra and prod clusters at version `4.18.21`. See this issue https://github.com/nerc-project/operations/issues/1251