### PR TITLE
console: add managementState to base manifest

### DIFF
--- a/cluster-scope/base/operator.openshift.io/consoles/cluster/console.yaml
+++ b/cluster-scope/base/operator.openshift.io/consoles/cluster/console.yaml
@@ -7,3 +7,4 @@ spec:
     customLogoFile:
       name: nerc-logo
       key: nerc-logo.png
+  managementState: Managed

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -126,10 +126,3 @@ patches:
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - ocp-test.nerc.mghpcc.org
-- target:
-    kind: Console
-    name: cluster
-  patch: |
-    - op: add
-      path: /spec/managementState
-      value: Managed


### PR DESCRIPTION
On some clusters the console operator gets degraded with the following error:
```
ManagementStateDegraded: Unsupported management state "" for console operator...
```
This is due to missing the `managementState: managed` field in the console spec. 

See https://access.redhat.com/solutions/7002156

Oddly enough, we're missing this parameter in the manifests of most clusters except for nerc-ocp-test and they don't appear to have this issue. Checking on the manifests in various clusters that don't have this in their console spec in this repo, they still seem to have `managementState: managed` in the live resource.

Adding this parameter to the base console spec to force the situation globally.