### PR TITLE
feat: add wildcard for ACM managed cluster metrics

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -51,3 +51,4 @@ data:
       - __name__=~"(mco_.*)"
       - __name__=~"(llm_performance_.*)"
       - __name__=~"(vllm:.*)"
+      - __name__=~"(acm_managed_cluster_*.*)"


### PR DESCRIPTION
feat(observability): allow wildcard for ACM managed cluster metrics

- Added `__name__=~"(acm_managed_cluster_*.*)"`
- Ensures both `acm_managed_cluster_labels` and `acm_managed_cluster_info` (and future similar metrics) are collected
- Previously only `acm_managed_cluster_labels` was visible

could help to enhance
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/760