### PR TITLE
Update targetNamespaces for AAP operatorgroup

### DIFF
--- a/cluster-scope/overlays/hypershift2/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/kustomization.yaml
@@ -154,3 +154,14 @@ patches:
     - op: replace
       path: /spec/channel
       value: stable-2.5
+
+- patch: |
+    apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: ansible-automation-platform-operator
+      namespace: aap
+    spec:
+      targetNamespaces:
+      - aap
+      - innabox


### PR DESCRIPTION
AAP doesn't support "all namespaces" installation mode, so we need to
explicitly list the namespaces the operator will watch.
