### PR TITLE
Upgrade obs cluster from 4.15.32 to 4.16.44 and logging 6.1

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.0
+  channel: stable-6.1
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-6.0
+  channel: stable-6.1
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators

--- a/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.15
+  channel: stable-4.16
   desiredUpdate:
-    version: 4.15.32
+    version: 4.16.44
   clusterID: 760c86f3-95a0-489e-b72a-2938bb80bcea

--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.15
+    channel: stable-4.16


### PR DESCRIPTION
We are upgrading the obs cluster to catch up to the infra, prod, and edu
clusters. At the same time, we need to upgrade Logging and Loki
operators from 6.0 to 6.1.

Relates to https://github.com/nerc-project/operations/issues/1251