### PR TITLE
Upgrade obs cluster from 4.16.44 to 4.17.36 and logging 6.2

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.1
+  channel: stable-6.2
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-6.1
+  channel: stable-6.2
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators

--- a/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.16
   desiredUpdate:
-    version: 4.16.44
+    version: 4.17.36
   clusterID: 760c86f3-95a0-489e-b72a-2938bb80bcea

--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.16
+    channel: stable-4.17


### PR DESCRIPTION
We have finished the previous 4.16.44 upgrade and are ready to move to 4.17.36 in the obs cluster, and logging and loki 6.2 operator. 