### PR TITLE
edu: add udev rules for NICS on v100 nodes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -16,3 +16,13 @@ spec:
             source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWxkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018SSNu6FmEt995qZ0sa9EHOp795kY9q4N5GAuUZKXIAAAAD//4ZflsXAAgAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
+        - contents:
+            compression: gzip
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VUrKqyiJT81T0vF2DfJz9QEJGRgYGFgZWlgZGOgZKOk4Ood4+vvZ2iolpqQo6fg5+rraKuVlJhsqcZFtqiFOU42UuAABAAD//64yhGWsAAAA
+          mode: 420
+          path: /etc/udev/rules.d/90-bnxt_en.rules
+        - contents:
+            compression: gzip
+            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcqsSE9KVdLxdg3yc/UBCRgYGBhYGVpYGRjoGSjpODqHePr72doqJaakKOn4Ofq62irlZSYbKnGRaaYhTjONlLgAAQAA//8YCjzsqAAAAA==
+          mode: 420
+          path: /etc/udev/rules.d/90-ixgbe.rules

--- a/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/bnxt_en.rules
+++ b/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/bnxt_en.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="net",DRIVERS=="bnxt_en",KERNELS=="0000:18:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="bnxt_en",KERNELS=="0000:18:00.1",ACTION=="add",NAME="nic2"

--- a/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
+++ b/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/custom-udev-rules-worker.bu
@@ -10,3 +10,11 @@ storage:
       contents:
         local: mlx5_core.rules
       mode: 0644
+    - path: /etc/udev/rules.d/90-bnxt_en.rules
+      contents:
+        local: bnxt_en.rules
+      mode: 0644
+    - path: /etc/udev/rules.d/90-ixgbe.rules
+      contents:
+        local: ixgbe.rules
+      mode: 0644

--- a/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/ixgbe.rules
+++ b/cluster-scope/overlays/nerc-ocp-edu/machineconfigs/udev-rules/src/ixgbe.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="net",DRIVERS=="ixgbe",KERNELS=="0000:18:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="ixgbe",KERNELS=="0000:18:00.1",ACTION=="add",NAME="nic2"


### PR DESCRIPTION
This adds the requisite udev rules to setup the NICs on the V100 nodes.