### PR TITLE
edu: remove unused acct-mgt secretstore

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/secretstores/acct-mgt/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/secretstores/acct-mgt/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: acct-mgt
-components:
-  - ../../../../components/nerc-secret-store

--- a/cluster-scope/overlays/nerc-ocp-edu/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/secretstores/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- acct-mgt
 - openshift-config
 - openshift-ingress
 - openshift-logging


### PR DESCRIPTION
The coldfront-plugin-cloud now connects directly to the OpenShift API using the acct-mgt serviceaccount token to configure things so this secretstore is no longer needed.

This should, hopefully, get the cluster-scope-edu argocd app back to Healthy state.