### PR TITLE
fix: Route autopilot and machine-config alerts to Slack

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -101,7 +101,14 @@ spec:
                 group_interval: 1d
                 repeat_interval: 1d
                 matchers:
-                  - alertname =~ "(CustomBlockedMachineConfigUpdate|CustomMachineConfigHighUnavailable)"
+                  - alertname =~ "(CustomBlockedMachineConfigUpdate|CustomMachineConfigHighUnavailable|CustomMachineConfigPoolDegraded)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, node, deviceid]
+                group_wait: 5m
+                group_interval: 1d
+                repeat_interval: 1d
+                matchers:
+                  - alertname =~ "(LowPCIeBandwidth|DCGMLevel1Errors|GPUPowerSlowdownEnabled|RemappedRowsActive|DCGMLevel3Errors|PingFailures|PVCAlert|GPUNodeHealth|AutopilotPodsFailing)"
 
           receivers:
           - name: default


### PR DESCRIPTION
# fix: Route autopilot and machine-config alerts to Slack

Add Slack routing for
- IBM autopilot alerts and
- group all machine-config alerts together

to ensure proper notification coverage.