### PR TITLE
Add ACM metrics for kube_job_* for job start and completion

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -48,6 +48,7 @@ data:
       - __name__=~"(argocd_.*)"
       - __name__=~"(kube_node_.*)"
       - __name__=~"(kube_pod_.*)"
+      - __name__=~"(kube_job_.*)"
       - __name__=~"(mco_.*)"
       - __name__=~"(llm_performance_.*)"
       - __name__=~"(vllm:.*)"


### PR DESCRIPTION
Useful to the OPE team for tracking GPU job start and completion stats.
