### PR TITLE
ocp-prod: upgrade to OCP 4.19.9

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.18
+  channel: stable-4.19
   desiredUpdate:
-    version: 4.18.21
+    version: 4.19.9
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982


### PR DESCRIPTION
This will upgrade the cluster from 4.18.21 to 4.19.9 according to `Red Hat OpenShift Container Platform Update Graph`