### PR TITLE
ocp-prod: add ack and remove elasticsearch operator for 4.19 upgrade

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -73,6 +73,7 @@ configMapGenerator:
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
     - ack-4.13-kube-1.27-api-removals-in-4.14=true
     - ack-4.15-kube-1.29-api-removals-in-4.16=true
+    - ack-4.18-kube-1.32-api-removals-in-4.19=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -27,7 +27,6 @@ resources:
 - ../../bundles/koku-metrics-operator
 - ../../bundles/autopilot
 - ../../bundles/mongodb-operator
-- ../../bundles/elasticsearch-eck-operator
 - ../../bundles/nagios-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit


### PR DESCRIPTION
https://access.redhat.com/articles/7112216

and 

```
  * Cluster operator operator-lifecycle-manager should not be upgraded between minor versions: IncompatibleOperatorsInstalled: ClusterServiceVersions blocking minor version upgrades to 4.19.0 or higher:
  - maximum supported OCP version for openshift-operators-redhat/elasticsearch-operator.v5.8.21 is 4.18
  ```