### PR TITLE
Fix AlertManager routing for 6:05am status alerts

### DIFF
--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -94,7 +94,7 @@ spec:
                 group_wait: 0s
                 # repeat_interval cannot be zero, group_interval cannot be zero
                 matchers:
-                  - alertname =~ "^Custom6amOpe.*"
+                  - alertname =~ "^Custom(6am|605am)Ope.*"
               - receiver: slack-notifications
                 group_by: [cluster, alertname, pool]
                 group_wait: 5m


### PR DESCRIPTION
fixes https://github.com/nerc-project/operations/issues/1201

# Fix AlertManager routing for 6:05am status alerts

Why this change was necessary:
The recently added 6:05am status alerts for nerc-ocp-edu cluster were not being routed to the OPE Slack channel because the AlertManager routing pattern only matched "Custom6amOpe" alerts, not "Custom605amOpe" alerts.

Changes made:
- Update alertname regex pattern from "^Custom6amOpe.*" to "^Custom(6am|605am)Ope.*"
- Ensure both 6am and 6:05am status alerts are routed to the OPE Slack channel • Maintain existing routing behavior for all other alert patterns