### PR TITLE
ocp-prod: bump odf operator to 4.19-stable channel

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.18
+    channel: stable-4.19


### PR DESCRIPTION
The ocp-prod cluster is now on v4.19.9 so we need to switch the ODF operator to `stable-4.19` channel