### PR TITLE
Reduce SNMP exporter scrape interval to 60 seconds

### DIFF
--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-pdus.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-pdus.yaml
@@ -17,6 +17,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -58,6 +59,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -99,6 +101,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -140,6 +143,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -181,6 +185,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -222,6 +227,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -263,6 +269,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -304,6 +311,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -345,6 +353,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -386,6 +395,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -427,6 +437,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -468,6 +479,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:

--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
@@ -17,6 +17,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -70,6 +71,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -123,6 +125,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -176,6 +179,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:
@@ -228,6 +232,7 @@ spec:
   - port: http
     honorLabels: true
     path: /snmp
+    interval: 60s
     scrapeTimeout: 30s
     params:
       module:


### PR DESCRIPTION
# Reduce SNMP exporter scrape interval to 60 seconds

This change was mainly for jschless switch speed and GPU nodes testing, specifically to improve the granularity of network metrics like rate(network_switch_ifHCInOctets[5m]) * 8 for better monitoring.


e.g. this dashboard
<img width="1390" height="1075" alt="image" src="https://github.com/user-attachments/assets/280aa3e9-689d-4333-aa91-3b12438b25fc" />

https://grafana.apps.obs.nerc.mghpcc.org/d/ev2-barcelona-gpu-switch-heatmap/e-v2?from=2025-09-10T08:33:27.138Z&to=2025-09-10T14:33:27.138Z&timezone=browser&var-node=$__all&var-port=$__all