### PR TITLE
Fix argocd permissions

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -27,8 +27,7 @@ spec:
       - "*"
   rbac:
     policy: |
-      p, role:operator, applications, sync, */*, allow
-      p, role:operator, applications, update, */*, allow
+      p, role:operator, applications, *, */*, allow
 
       g, system:cluster-admins, role:admin
       g, cluster-admins, role:admin


### PR DESCRIPTION
After the recent upgrade, members of the `nerc-ops` groups were no longer
able to see argocd applications. This commits updates the ArgoCD RBAC to
grant all permissions to the `operator` ArgoCD role.

Closes: nerc-project/operations#1261
