### PR TITLE
edu: Update clusterqueue coveredResources and their quota

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/kueue-config/kueue-clusterqueue.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/kueue-config/kueue-clusterqueue.yaml
@@ -5,12 +5,16 @@ metadata:
 spec:
   namespaceSelector: {}
   resourceGroups:
-    - coveredResources: ["nvidia.com/gpu"]
+    - coveredResources: ["nvidia.com/gpu", "cpu", "memory"]
       flavors:
         - name: "v100-flavor"
           resources:
             - name: "nvidia.com/gpu"
-              nominalQuota: 4
+              nominalQuota: 3
+            - name: "cpu"
+              nominalQuota: 20
+            - name: "memory"
+              nominalQuota: 50Gi
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
@@ -19,12 +23,16 @@ metadata:
 spec:
   namespaceSelector: {}
   resourceGroups:
-    - coveredResources: ["nvidia.com/gpu"]
+    - coveredResources: ["nvidia.com/gpu", "cpu", "memory"]
       flavors:
         - name: "a100-flavor"
           resources:
             - name: "nvidia.com/gpu"
               nominalQuota: 0
+            - name: "cpu"
+              nominalQuota: 20
+            - name: "memory"
+              nominalQuota: 50Gi
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
@@ -33,9 +41,13 @@ metadata:
 spec:
   namespaceSelector: {}
   resourceGroups:
-    - coveredResources: ["nvidia.com/gpu"]
+    - coveredResources: ["nvidia.com/gpu", "cpu", "memory"]
       flavors:
         - name: "h100-flavor"
           resources:
             - name: "nvidia.com/gpu"
               nominalQuota: 0
+            - name: "cpu"
+              nominalQuota: 20
+            - name: "memory"
+              nominalQuota: 50Gi


### PR DESCRIPTION
This addresses the issue when a job is submitted and get suspended because of the following reason
```
kueue-admission  couldn't assign flavors to pod set main: resource memory unavailable in ClusterQueue
  Warning  Pending  6m50s                  
kueue-admission  couldn't assign flavors to pod set main: resource cpu unavailable in ClusterQueue
```
