### PR TITLE
add eck operator back to ocp-prod cluster

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../../bundles/koku-metrics-operator
 - ../../bundles/autopilot
 - ../../bundles/mongodb-operator
+- ../../bundles/elasticsearch-eck-operator
 - ../../bundles/nagios-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit


### PR DESCRIPTION
I mistakenly removed the elasticsearch-eck-operator bundle and pruned the resources after `oc adm upgrade` was complainging about elasticsearch csv during the last upgrade to 4.19. Turns out there were two different elasticsearch operators in use and only the redhat subscription was deprecated/removed.