### PR TITLE
Add OpenVino & Kueue metrics to ACM Obs

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -54,3 +54,5 @@ data:
       - __name__=~"^vllm:.*"
       - __name__=~"^acm_managed_cluster_.*"
       - __name__=~"^thanos_.*"
+      - __name__=~"^kueue_.*"
+      - __name__=~"^ovms_.*"


### PR DESCRIPTION
This will allow us to collect metrics from models served using OpenVino servingruntime and metrics from Kueue which is useful for the GPU course running in edu cluster.

Closes: https://github.com/nerc-project/operations/issues/1269#issuecomment-3308679734