### PR TITLE
ocp-test: upgrade RHOAI to most recent version

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: redhat-ods-operator
 spec:
   channel: stable
-  startingCSV: rhods-operator.2.16.0
+  startingCSV: rhods-operator.2.23.0


### PR DESCRIPTION
Addresses: https://github.com/nerc-project/operations/issues/1268 This PR will update the subscription version to 2.23.0 The upgrade will require manual approval in cluster to kick of install