### PR TITLE
Add jland-redhat and liangwen12year to nerc-test-perses

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - nerc-test-people.yaml
+- nerc-test-perses.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-perses.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-perses.yaml
@@ -1,0 +1,33 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nerc-test-perses
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses/api
+  - verbs:
+      - '*'
+    apiGroups:
+      - perses.dev
+    resources:
+      - perses
+      - persesdatasources
+      - persesdashboards
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nerc-test-perses
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nerc-test-perses
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: nerc-test-perses


### PR DESCRIPTION
Adding a new GitHub group nerc-test-perses for development of Perses
datasources and dashboards in the Cluster Observability Operator in the
test cluster.
