### PR TITLE
ocp-prod: disable rhoai notebook controller tile

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -48,7 +48,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: true
+    enabled: false
     notebookNamespace: rhods-notebooks
     pvcSize: 20Gi
   notebookSizes:


### PR DESCRIPTION
Addresses: nerc-project/operations#1267
With courses no longer needing RHOAI tiles in prod we need to disable this option since it breaks our billing Users will no longer be able to launch notebooks in the rhods-notebooks namespace in prod