### PR TITLE
feat: Add Thanos metrics to ACM observability

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -53,3 +53,4 @@ data:
       - __name__=~"(llm_performance_.*)"
       - __name__=~"(vllm:.*)"
       - __name__=~"(acm_managed_cluster_*.*)"
+      - __name__=~"(thanos_.*)"


### PR DESCRIPTION
Adds thanos_.* pattern to custom metrics allowlist to enable collection of Thanos-related metrics in ACM observability stack.