### PR TITLE
refactor: Clean up metrics regex in allowlist

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -48,7 +48,7 @@ data:
       - __name__=~"^argocd_.*"
 
       # Consolidate kube*:
-      - __name__=~"^kube_(node|pod|job)_.*"
+      - __name__=~"^kube_(?:node|pod|job)_.*"
       - __name__=~"^mco_.*"
       - __name__=~"^llm_performance_.*"
       - __name__=~"^vllm:.*"

--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -40,17 +40,17 @@ data:
       - container_memory_max_usage_bytes
       - container_memory_failures_total
     matches:
-      - __name__=~"(ipmi_.*)"
-      - __name__=~"(ceph_.*)"
-      - __name__=~"(log_.*)"
-      - __name__=~"(gpu_operator_.*)"
-      - __name__=~"(DCGM_FI_.*)"
-      - __name__=~"(argocd_.*)"
-      - __name__=~"(kube_node_.*)"
-      - __name__=~"(kube_pod_.*)"
-      - __name__=~"(kube_job_.*)"
-      - __name__=~"(mco_.*)"
-      - __name__=~"(llm_performance_.*)"
-      - __name__=~"(vllm:.*)"
-      - __name__=~"(acm_managed_cluster_*.*)"
-      - __name__=~"(thanos_.*)"
+      - __name__=~"^ipmi_.*"
+      - __name__=~"^ceph_.*"
+      - __name__=~"^log_.*"
+      - __name__=~"^gpu_operator_.*"
+      - __name__=~"^DCGM_FI_.*"
+      - __name__=~"^argocd_.*"
+
+      # Consolidate kube*:
+      - __name__=~"^kube_(node|pod|job)_.*"
+      - __name__=~"^mco_.*"
+      - __name__=~"^llm_performance_.*"
+      - __name__=~"^vllm:.*"
+      - __name__=~"^acm_managed_cluster_.*"
+      - __name__=~"^thanos_.*"


### PR DESCRIPTION
- Add ^ anchor for better regex specificity, ensures patterns match from the beginning of metric names
- Remove unnecessary parentheses which created capture groups but added no functionality
- Consolidate kube_node, kube_pod, kube_job patterns using alternation
- Fix acm_managed_cluster pattern (removed redundant wildcard)

The ^ anchor is more efficient, explicitly anchors the pattern to the start of the string rather than creating unnecessary capture groups.