### PR TITLE
Grant access to nerc-test-perses group to observe dashboards

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-perses.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/nerc-test-perses.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
   - verbs:
       - create
+      - get
     apiGroups:
       - monitoring.coreos.com
     resources:


### PR DESCRIPTION
The default OpenShift Observe dashboards require get permission on the
prometheuses/api resource to view the default cluster dashboards.
