### PR TITLE
nerc-ocp-infra: upgrade to OCP 4.19

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -5,7 +5,7 @@ items:
   metadata:
     name: version
   spec:
-    channel: stable-4.18
+    channel: stable-4.19
     clusterID: 090f2819-f1b3-4f72-bc6f-dc149ced3083
 kind: List
 metadata: {}

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -48,6 +48,7 @@ configMapGenerator:
     - ack-4.11-kube-1.25-api-removals-in-4.12=true
     - ack-4.12-kube-1.26-api-removals-in-4.13=true
     - ack-4.13-kube-1.27-api-removals-in-4.14=true
+    - ack-4.18-kube-1.32-api-removals-in-4.19=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
Fixes: https://github.com/nerc-project/operations/issues/1253

- The nerc-ocp-infra cluster needs to be upgraded from OpenShift 4.18 to 4.19
- This requires updating the upgrade channel and acknowledging API removals.

Changes made:
- Update cluster version channel from stable-4.18 to stable-4.19
- Add admin acknowledgment for Kubernetes 1.32 API removals in 4.19
- Ensure upgrade path compliance with OpenShift upgrade requirements

References:
- Red Hat upgrade preparation guide: https://access.redhat.com/articles/7112216
- OpenShift Container Platform 4.19 updating clusters documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/pdf/updating_clusters/index

Follow Up: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/801