### PR TITLE
nerc-ocp-infra: update ODF operator channel to stable-4.19

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.18
+    channel: stable-4.19


### PR DESCRIPTION
Why this change was necessary:
Align the OpenShift Data Foundation (ODF) operator channel with the OpenShift 4.19 cluster upgrade to ensure operator version compatibility and maintain support for the upgraded cluster infrastructure.

Changes made:
- Update ODF operator subscription channel from stable-4.18 to stable-4.19 • Ensure operator compatibility with OpenShift 4.19 cluster version

Related to: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/800
Waiting for: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/800