### PR TITLE
ocp-infra: set desiredupdate to 4.19.13

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -1,11 +1,9 @@
-apiVersion: v1
-items:
-- apiVersion: config.openshift.io/v1
-  kind: ClusterVersion
-  metadata:
-    name: version
-  spec:
-    channel: stable-4.19
-    clusterID: 090f2819-f1b3-4f72-bc6f-dc149ced3083
-kind: List
-metadata: {}
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.19
+  desiredUpdate:
+    version: 4.19.13
+  clusterID: 090f2819-f1b3-4f72-bc6f-dc149ced3083


### PR DESCRIPTION
We missed a step in #800

Also, this updates the clusterversion.yaml to be the manifest itself instead of a list of version manifests (with one item).