### PR TITLE
ocp-infra: upgrade to 4.19.7 instead

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/clusterversion.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   channel: stable-4.19
   desiredUpdate:
-    version: 4.19.13
+    version: 4.19.7
   clusterID: 090f2819-f1b3-4f72-bc6f-dc149ced3083


### PR DESCRIPTION
Turns out every version past 4.19.7 has known issues so `oc adm upgrade` is not allowing 4.19.13 for the infra cluster. This is the latest version of 4.19 without known issues according to `oc adm upgrade`.

related: #800 #802