### PR TITLE
vault: use full registry domain in image ref

### DIFF
--- a/vault/instance/base/vault.yaml
+++ b/vault/instance/base/vault.yaml
@@ -11,7 +11,7 @@ spec:
   - name: SKIP_SETCAP
     value: "1"
   size: 3
-  image: hashicorp/vault:1.20.0
+  image: docker.io/hashicorp/vault:1.20.0
 
   serviceAccount: vault
   serviceType: ClusterIP


### PR DESCRIPTION
After upgrading the infra cluster to 4.19, the vault pods were failing to pull the image due to using the wrong registry (RedHat) and for some reason weren't failing over to the final default registry of docker.io in the unqualified-search-registries list.

This explicitly pulls from docker hub instead of relying on the unqualified search registries list when using short names. This is also recommended for security reasons in the RH OCP docs.