### PR TITLE
feat: Add GPU activity recording rules for 1hour

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -446,6 +446,35 @@ data:
           labels:
             severity: critical
 
+      - name: gpu-activity-1h
+        interval: 1h
+        rules:
+        # Recording rule to check if GPU was active in the last hour (1=active, 0=inactive)
+        # Per GPU - for detailed billing tracking
+        - record: gpu:active_hourly:bool
+          expr: max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > bool 0
+
+        # Per Node - check if node has at least one active GPU (1=yes, 0=no)
+        - record: gpu:active_hourly:bool_per_node
+          expr: |
+            max by (cluster, instance, Hostname) (
+              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])
+            ) > bool 0
+
+        # Count of active GPUs per Node
+        - record: gpu:active_hourly:count_per_node
+          expr: |
+            count by (cluster, instance, Hostname) (
+              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0
+            )
+
+        # Count of active GPUs per Cluster
+        - record: gpu:active_hourly:count_per_cluster
+          expr: |
+            count by (cluster) (
+              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0
+            )
+
       - name: IBM autopilot
         rules:
         - alert: LowPCIeBandwidth

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -453,9 +453,9 @@ data:
         - record: gpu:active_hourly:raw
           expr: max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])
 
-        # Recording rule to check if GPU was active in the last hour (1=active, 0=inactive)
+        # Recording rule to check if GPU was active in the last hour.
+        # Returns a boolean value (true/false), represented as 1 (active/true) or 0 (inactive/false) in Prometheus.
         # Per GPU - for detailed billing tracking
-        - record: gpu:active_hourly:bool
           expr: gpu:active_hourly:raw > bool 0
 
         # Per Node - check if node has at least one active GPU (1=yes, 0=no)

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -456,24 +456,15 @@ data:
 
         # Per Node - check if node has at least one active GPU (1=yes, 0=no)
         - record: gpu:active_hourly:bool_per_node
-          expr: |
-            max by (cluster, instance, Hostname) (
-              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])
-            ) > bool 0
+          expr: max by (cluster, instance, Hostname) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])) > bool 0
 
         # Count of active GPUs per Node
         - record: gpu:active_hourly:count_per_node
-          expr: |
-            count by (cluster, instance, Hostname) (
-              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0
-            )
+          expr: count by (cluster, instance, Hostname) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0)
 
         # Count of active GPUs per Cluster
         - record: gpu:active_hourly:count_per_cluster
-          expr: |
-            count by (cluster) (
-              max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0
-            )
+          expr: count by (cluster) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0)
 
       - name: IBM autopilot
         rules:

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -449,22 +449,26 @@ data:
       - name: gpu-activity-1h
         interval: 1h
         rules:
+        # Raw max GPU utilization over the last hour, per GPU
+        - record: gpu:active_hourly:raw
+          expr: max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])
+
         # Recording rule to check if GPU was active in the last hour (1=active, 0=inactive)
         # Per GPU - for detailed billing tracking
         - record: gpu:active_hourly:bool
-          expr: max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > bool 0
+          expr: gpu:active_hourly:raw > bool 0
 
         # Per Node - check if node has at least one active GPU (1=yes, 0=no)
         - record: gpu:active_hourly:bool_per_node
-          expr: max by (cluster, instance, Hostname) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h])) > bool 0
+          expr: max by (cluster, instance, Hostname) (gpu:active_hourly:raw) > bool 0
 
         # Count of active GPUs per Node
         - record: gpu:active_hourly:count_per_node
-          expr: count by (cluster, instance, Hostname) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0)
+          expr: count by (cluster, instance, Hostname) (gpu:active_hourly:raw > 0)
 
         # Count of active GPUs per Cluster
         - record: gpu:active_hourly:count_per_cluster
-          expr: count by (cluster) (max_over_time(DCGM_FI_DEV_GPU_UTIL[1h]) > 0)
+          expr: count by (cluster) (gpu:active_hourly:raw > 0)
 
       - name: IBM autopilot
         rules:


### PR DESCRIPTION
## Why
Enables hourly GPU usage tracking to support billing verification and optimize monitoring for specific use cases. Provides per-GPU, per-Node, and per-Cluster metrics for flexible reporting and cost allocation.

## Changes made:
- Add gpu:active_hourly:bool for per-GPU activity tracking
- Add gpu:active_hourly:bool_per_node for node-level activity tracking
- Add gpu:active_hourly:count_per_node to count active GPUs per node
- Add gpu:active_hourly:count_per_cluster for cluster-wide GPU counts
- Configure 1-hour evaluation interval for all GPU activity rules

## Recording rules added:
1. **gpu:active_hourly:bool** - Per GPU activity (0 or 1) Returns 1 if GPU was active (utilization > 0%) in last hour, else 0 Labels: cluster, instance, gpu, Hostname, etc. Use case: Detailed billing - which GPU was active?

2. **gpu:active_hourly:bool_per_node** - Per Node activity check (0 or 1) Returns 1 if node has at least one active GPU, else 0 Labels: cluster, instance, Hostname Use case: Quick check - does the node have active GPUs?

3. **gpu:active_hourly:count_per_node** - Active GPU count per Node Returns number of active GPUs (e.g., 3, 8) Labels: cluster, instance, Hostname Use case: Utilization - how many GPUs ran on the node?

4. **gpu:active_hourly:count_per_cluster** - Active GPU count per Cluster Returns total number of active GPUs in cluster Labels: cluster Use case: Cluster overview - how many GPUs total active?

Example queries:
  ### All active GPUs on node worker-01
  gpu:active_hourly:bool{instance="worker-01"}

  ### How many GPUs were active on each node?
  gpu:active_hourly:count_per_node

  ### Total active GPUs in nerc-ocp-prod
  gpu:active_hourly:count_per_cluster{cluster="nerc-ocp-prod"}

  ### Which specific GPUs were active?
  gpu:active_hourly:bool == 1