### PR TITLE
Add GPU activity recording rules with multiple granularities

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -456,6 +456,7 @@ data:
         # Recording rule to check if GPU was active in the last hour.
         # Returns a boolean value (true/false), represented as 1 (active/true) or 0 (inactive/false) in Prometheus.
         # Per GPU - for detailed billing tracking
+        - record: gpu:active_hourly:bool
           expr: gpu:active_hourly:raw > bool 0
 
         # Per Node - check if node has at least one active GPU (1=yes, 0=no)


### PR DESCRIPTION
fixes https://github.com/OCP-on-NERC/nerc-ocp-config/pull/806
- In PR #806, two commits unintentionally overlapped.
- This PR resolves that issue and cleans up the affected changes.

## Why:
Enables hourly GPU usage tracking to support billing verification and optimize monitoring. Provides per-GPU, per-Node, and per-Cluster metrics for flexible reporting and cost allocation.

## Changes made:
- Add gpu:active_hourly:raw - base metric for hourly max GPU utilization
- Add gpu:active_hourly:bool - per-GPU activity tracking (0 or 1)
- Add gpu:active_hourly:bool_per_node - node-level activity check (0 or 1)
- Add gpu:active_hourly:count_per_node - count of active GPUs per node
- Add gpu:active_hourly:count_per_cluster - cluster-wide GPU count
- Configure 1-hour evaluation interval for all GPU activity rules
- Use recording rule chaining (raw → bool/count) for efficiency
- CLeanUp of non squashed commits and a bug

## Recording rules added:
1. `gpu:active_hourly:raw` - Raw max GPU utilization over last hour Base metric that other rules reference Returns: 0-100 (percentage)

2. `gpu:active_hourly:bool` - Per GPU activity (0 or 1) Returns 1 if GPU was active (utilization > 0%) in last hour, else 0 Labels: cluster, instance, gpu, Hostname, etc. Use case: Detailed billing - which GPU was active?

3. `gpu:active_hourly:bool_per_node` - Per Node activity check (0 or 1) Returns 1 if node has at least one active GPU, else 0 Labels: cluster, instance, Hostname Use case: Quick check - does the node have active GPUs?

4. `gpu:active_hourly:count_per_node` - Active GPU count per Node Returns number of active GPUs (e.g., 3, 8) Labels: cluster, instance, Hostname Use case: Utilization - how many GPUs ran on the node?

5. `gpu:active_hourly:count_per_cluster` - Active GPU count per Cluster Returns total number of active GPUs in cluster Labels: cluster Use case: Cluster overview - how many GPUs total active?

### Example queries:
  #### All active GPUs on node worker-01
  ```bash
  gpu:active_hourly:bool{instance="worker-01"}
  ```
  #### How many GPUs were active on each node?
  ```bash
  gpu:active_hourly:count_per_node
  ```

  #### Total active GPUs in nerc-ocp-prod
  ```bash
  gpu:active_hourly:count_per_cluster{cluster="nerc-ocp-prod"}
  ```

  #### Which specific GPUs were active?
  ```bash
  gpu:active_hourly:bool == 1
  ```

  #### Raw utilization values
  ```bash
  gpu:active_hourly:raw
  ```

Squashes commits:
- e60c9da: Initial GPU recording rules
- a651dd0, e63f087, 90cf39e: Copilot optimizations (add raw metric)
- 386021d: Fix missing record field syntax error