### PR TITLE
Migrating bitnami images for ai-telemetry to bitnamilegacy

### DIFF
--- a/ai-telemetry/base/solr/statefulset.yaml
+++ b/ai-telemetry/base/solr/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-server-dir
-          image: docker.io/bitnami/solr:9.7.0-debian-12-r0
+          image: docker.io/bitnamilegacy/solr:9.7.0-debian-12-r0
           imagePullPolicy: "IfNotPresent"
           resources:
             limits:

--- a/ai-telemetry/base/zookeeper/statefulset.yaml
+++ b/ai-telemetry/base/zookeeper/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
         fsGroupChangePolicy: Always
       containers:
         - name: zookeeper
-          image: docker.io/bitnami/zookeeper:3.9.2-debian-12-r15
+          image: docker.io/bitnamilegacy/zookeeper:3.9.2-debian-12-r15
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Temporarily migrating bitnami images for zookeeper and solr, which are
dependencies of AI Telemetry to bitnamilegacy repo, since bitnami images
are now proprietary. We will be migrating to the Zookeeper and Solr
operators instead in the near future.
