### PR TITLE
fix: OpenTelemetry Collector metrics configuration

### DIFF
--- a/opentelemetry/base/opentelemetry-collector.yaml
+++ b/opentelemetry/base/opentelemetry-collector.yaml
@@ -40,7 +40,12 @@ spec:
     service:
       telemetry:
         metrics:
-          address: ":8888"
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: '0.0.0.0'
+                    port: 8888
       pipelines:
         traces:
           receivers: [otlp]


### PR DESCRIPTION
Current OpenTelemetry Collector Version: 0.135.0

Replace deprecated 'address' field with new 'readers' configuration in service.telemetry.metrics to resolve collector pod crash loops.

The 'address' field has been deprecated since OpenTelemetry Collector v0.111.0 and is completely ignored as of v0.123.0. The new configuration uses a readers-based approach with a pull exporter for Prometheus metrics.

Reference: https://opentelemetry.io/docs/collector/internal-telemetry/

Changes:
- Remove deprecated 'address: ":8888"' field
- Add new 'readers' configuration with pull exporter
- Configure Prometheus exporter with host '0.0.0.0' and port 8888
- Ensure compatibility with OpenTelemetry Collector v0.135.0+