### PR TITLE
ocp-prod: upgrade RHOAI operator to stable channel 2.22 v2.22.1

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -156,10 +156,10 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: stable-2.19
+      value: stable-2.22
     - op: replace
       path: /spec/startingCSV
-      value: rhods-operator.2.19.0
+      value: rhods-operator.2.22.1
 - target:
     kind: Subscription
     name: gpu-operator-certified


### PR DESCRIPTION
Addresses: https://github.com/nerc-project/operations/issues/1284
Follows up: https://github.com/nerc-project/operations/issues/1268