### PR TITLE
ocp-prod: upgrade RHOAI operator to 2.22.2

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -159,7 +159,7 @@ patches:
       value: stable-2.22
     - op: replace
       path: /spec/startingCSV
-      value: rhods-operator.2.19.0
+      value: rhods-operator.2.22.2
 - target:
     kind: Subscription
     name: gpu-operator-certified


### PR DESCRIPTION
Forgot to bump staringCSV to 2.22.2