### PR TITLE
ocp-prod: switch to authorino stable channel (v0.1.2.3)

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -152,6 +152,16 @@ patches:
       value: stable-6.2
 - target:
     kind: Subscription
+    name: authorino-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable
+    - op: replace
+      path: /spec/startingCSV
+      value: authorino-operator.v1.2.3
+- target:
+    kind: Subscription
     name: rhods-operator
   patch: |
     - op: replace


### PR DESCRIPTION
Current stable version is v1.2.3. This appears to be required by the latest stable RHOAI operator (v0.22.2) given that the model registry operator manager pod is currently complaining about not being able to fetch a version of the authorino API that isn't available in the tech-preview-v1 channel/version:

```
ERROR   controller-runtime.source.EventHandler failed to get informer
from cache       {"error": "failed to get API group resources: unable to
  retrieve the complete list of server APIs:
    authorino.kuadrant.io/v1beta3: the server could not find the
    requested resource"}
```

The tech-preview-v1 version currently installed provides v1beta2:

```
$ oc api-resources --api-group=authorino.kuadrant.io
NAME          SHORTNAMES   APIVERSION                      NAMESPACED   KIND
authconfigs                authorino.kuadrant.io/v1beta2   true         AuthConfig
```