### PR TITLE
fix: Add tenant_id to CustomCephStorageFillingUpP.

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -40,9 +40,9 @@ data:
           annotations:
             summary: "{{ $labels.cluster }} Ceph Storage is filling up and is predicted to run out of space in 90 days"
             description: |
-              <https://grafana-open-cluster-management-observability.apps.infra.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ceph_pool_quota_max_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%20-%20on%20(cluster,%20namespace,%20pool,%20pod)%20predict_linear(ceph_pool_used_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%5B90d%5D,%2090%20*%2024%20*%2060%20*%2060)%20%3C%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              <https://grafana-open-cluster-management-observability.apps.infra.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22ceph_pool_quota_max_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%20-%20on%20(cluster,%20namespace,%20pool,%20pod,%20tenant_id)%20predict_linear(ceph_pool_used_bytes%7Bpool%3D~%5C%22(nerc_ocp_prod_.*)%7C(nerc_ocp_infra_.*)%5C%22%7D%5B90d%5D,%2090%20*%2024%20*%2060%20*%2060)%20%3C%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
               The {{ $labels.cluster }} {{ $labels.pool }} pool Ceph Storage is predicted to run out of space in 90 days
-          expr: ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"} - on (cluster, namespace, pool, pod) predict_linear(ceph_pool_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}[90d], 90 * 24 * 60 * 60) <= 0
+          expr: ceph_pool_quota_max_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"} - on (cluster, namespace, pool, pod, tenant_id) predict_linear(ceph_pool_used_bytes{pool=~"(nerc_ocp_prod_.*)|(nerc_ocp_infra_.*)"}[90d], 90 * 24 * 60 * 60) <= 0
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
Thanos Ruler is encountering HTTP 422 errors when it evaluate the CustomCephStorageFillingUpPredicted alert rule. The error message say "many-to-many matching not allowed: matching labels must be unique on one side".

The problem is caused by historical metrics data that contains two different tenant_id labels:
- Old tenant: `490883...-...711d54` (from previous deployment)
- Current tenant: `0e997d...-...54aca4` (active)

Because of the 90-day retention window, both tenant IDs appears in query results. The PromQL query with `predict_linear(...[90d], ...)` spans both tenant data, this make duplicate series that break the matching.

See: https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching

This Thanos Ruler errors prevent managed clusters to retrieve recording rules:

- **nerc-ocp-edu**: DEGRADED since 2025-09-02 (44 days)
- **nerc-ocp-test**: DEGRADED since 2025-09-26 (20 days)
- **Error**: `MetricsCollector: Failed to retrieve recording metrics`

The recording rules includes OPE metrics and GPU activity tracking what managed clusters needs for proper operation.

**Note:** This fix addresses the recording rules retrieval issue but does not resolve the separate scrape timing problem where managed clusters report different pod counts (20 vs 6 pods) due to synchronization issues between scrape intervals.

Add `tenant_id` to the matching labels in the `on` clause (line 45).

This allow the query to handle duplicate series correct by treating each tenant_id as separate match group.

See:
- PromQL Vector Matching: https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching
- predict_linear function: https://prometheus.io/docs/prometheus/latest/querying/functions/

After deployment:
1. Monitor Thanos Ruler logs that HTTP 422 errors disappear
2. Check ManagedClusterAddon status transition from DEGRADED to healthy
3. Verify recording rules retrieval succeed on managed clusters

- CCI-MOC/openshift-usage-scripts/issues/156
- nerc-project/operations#1265