### PR TITLE
fix: Remove prometheus label from SNMP exporter ServiceMonitors

### DIFF
--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-pdus.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-pdus.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -53,7 +52,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -95,7 +93,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -137,7 +134,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -179,7 +175,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -221,7 +216,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -263,7 +257,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -305,7 +298,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -347,7 +339,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -389,7 +380,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -431,7 +421,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -473,7 +462,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http

--- a/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
+++ b/snmp-exporter/base/servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -65,7 +64,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -119,7 +117,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -173,7 +170,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http
@@ -226,7 +222,6 @@ metadata:
     app.kubernetes.io/part-of: prometheus-snmp-exporter
     app.kubernetes.io/name: prometheus-snmp-exporter
     app.kubernetes.io/version: "v0.27.0"
-    prometheus: "kube-prometheus"
 spec:
   endpoints:
   - port: http


### PR DESCRIPTION
Why:
Error in obs: PrometheusOperatorRejectedResources
The ServiceMonitors had the label `prometheus: kube-prometheus` which is meant for the platform Prometheus instance in the openshift-monitoring namespace. This caused that the user-workload Prometheus operator rejected these resources.

Findings:
OpenShift is using two separate Prometheus Operators:
- Platform Monitoring (openshift-monitoring): for OpenShift core components
- User Workload Monitoring (openshift-user-workload-monitoring): for user applications

Problem:
- Each Prometheus instance has a ServiceMonitorSelector, which decides which ServiceMonitors it will take.
- The label `prometheus: kube-prometheus` is normally for the `platform monitoring` and therefore causing `user-workload` Prometheus to reject them.

Changes:
- Removed the prometheus label from all 17 ServiceMonitors
  - 5 network switches and 12 PDUs, to that proper scraping by user-workload monitoring is possible again.

Goal:
- This should resolve the PrometheusOperatorRejectedResources alert on the obs cluster.

References:
- https://access.redhat.com/solutions/6992399
- https://access.redhat.com/solutions/7007873
- https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md
- https://docs.openshift.com/container-platform/4.10/monitoring/troubleshooting-monitoring-issues.html