### PR TITLE
ClusterRoles with aggregate-to-edit for zookeeper and solr

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/solr-edit/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/solr-edit/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solr-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - solr.apache.org
+  resources:
+  - "*"
+  verbs:
+  - "*"

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/solr-edit/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/solr-edit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit/clusterrole.yaml
@@ -1,0 +1,14 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: zookeeper-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
@@ -5,3 +5,5 @@ commonLabels:
 resources:
 - ../../base/helm.openshift.io/helmchartrepositories/solr-helm-repo
 - ../../base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo
+- ../../base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit
+- ../../base/rbac.authorization.k8s.io/clusterroles/solr-edit

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - ../../bundles/opentelemetry
 - ../../bundles/snmp-exporter
 - ../../bundles/cluster-observability-operator
+- ../../bundles/solr-helm-repo
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/core/namespaces/dex
 - ../../base/core/namespaces/aitelemetry


### PR DESCRIPTION
For AI Telemetry in development in nerc-ocp-prod and obs cluster, we are migrating away from proprietary bitnami images to the Zookeeper and Solr Operators, which are already available. We just need these aggregate-to-edit role bindings for users and service accounts of these operators to work in their namespace.
