### PR TITLE
feat(grafana): add image renderer plugin to obs cluster

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/externalsecrets/grafana-renderer-token.yaml
+++ b/grafana/overlays/nerc-ocp-obs/externalsecrets/grafana-renderer-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-renderer-token
+  namespace: grafana
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: grafana-renderer-token
+  data:
+  - secretKey: GF_RENDERING_RENDERER_TOKEN
+    remoteRef:
+      key: nerc/nerc-ocp-obs/grafana/renderer-token
+      property: TOKEN
+  - secretKey: AUTH_TOKEN
+    remoteRef:
+      key: nerc/nerc-ocp-obs/grafana/renderer-token
+      property: TOKEN

--- a/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - oauth-client-secret.yaml
+- grafana-renderer-token.yaml

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-deployment.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-image-renderer
+  namespace: grafana
+  labels:
+    app: grafana-image-renderer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana-image-renderer
+  template:
+    metadata:
+      labels:
+        app: grafana-image-renderer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: grafana-image-renderer
+          image: grafana/grafana-image-renderer:3.11.3
+          ports:
+            - containerPort: 8081
+              name: http
+              protocol: TCP
+          env:
+            - name: BROWSER_TZ
+              value: UTC
+            - name: ENABLE_METRICS
+              value: 'true'
+            - name: HTTP_PORT
+              value: '8081'
+          envFrom:
+            - secretRef:
+                name: grafana-renderer-token
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-networkpolicy.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-image-renderer
+  namespace: grafana
+spec:
+  podSelector:
+    matchLabels:
+      app: grafana-image-renderer
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: grafana
+      ports:
+        - protocol: TCP
+          port: 8081

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-service.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-image-renderer
+  namespace: grafana
+  labels:
+    app: grafana-image-renderer
+spec:
+  ports:
+    - port: 8081
+      targetPort: 8081
+      protocol: TCP
+      name: http
+  selector:
+    app: grafana-image-renderer
+  type: ClusterIP

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-service.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana-image-renderer-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - port: 8081
-      targetPort: 8081
+      targetPort: http
       protocol: TCP
       name: http
   selector:

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -29,6 +29,10 @@ spec:
       scopes: openid email groups profile
     log:
       mode: console
+    rendering:
+      server_url: 'http://grafana-image-renderer:8081/render'
+      callback_url: 'http://grafana:3000/'
+      renderer_token: '${GF_RENDERING_RENDERER_TOKEN}'
   deployment:
     spec:
       template:
@@ -36,6 +40,12 @@ spec:
           containers:
             - image: 'grafana/grafana:11.3.0'
               name: grafana
+              env:
+                - name: GF_RENDERING_RENDERER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-renderer-token
+                      key: GF_RENDERING_RENDERER_TOKEN
               envFrom:
                 - secretRef:
                     name: oauth-client-secret

--- a/grafana/overlays/nerc-ocp-obs/grafanas/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
   - grafana.yaml
+  - grafana-image-renderer-deployment.yaml
+  - grafana-image-renderer-service.yaml
+  - grafana-image-renderer-networkpolicy.yaml


### PR DESCRIPTION
Enable automated high-resolution report generation for Grafana
in the observability cluster to support RHRQ and operational needs.

Why:
1. For RHRQ (Red Hat Quarterly Reviews), we need high-resolution
   screenshots since the quality from regular screenshots is not
   good enough for presentations and documentation that we have to
   provide to stakeholders
2. In the future we will need regular reports and slides, so it makes
   sense to automate this now instead of doing manual screenshots each
   time till we implement it later

Benefits:
The grafana-image-renderer provides server-side rendering capabilities
for panels and dashboards, so we can generate PNG images through the
Grafana API automatically. This is becomming very useful for automation
workflows where we need consistent, high-quality visuals without manual
work or browser-based rendering each time.

Changes:
1. Added grafana-image-renderer as separate Deployment with dedicated
   container (grafana/grafana-image-renderer:3.11.3) running on port 8081
   with resource limits (CPU: 500m, Memory: 512Mi) to handle Chromium
   browser rendering workloads
2. Created Service for image renderer to expose rendering endpoint
3. Configured Grafana with rendering.server_url, rendering.callback_url,
   and rendering.renderer_token for secure communication
4. Applied OpenShift security context constraints (runAsNonRoot, drop ALL
   capabilities, seccompProfile) to ensure compatibility with restricted SCC
5. Added ExternalSecret to inject renderer token from Vault path:
   nerc/nerc-ocp-obs/grafana/renderer-token
6. Used explicit env variable with secretKeyRef instead of envFrom to avoid
   Grafana Operator reconcile conflicts

Security Improvements:
1. Authentication Token (CVE-2022-31176 mitigation):
   - Configured renderer_token in Grafana (GF_RENDERING_RENDERER_TOKEN)
   - Configured AUTH_TOKEN in image renderer service
   - Token stored in Vault and injected via ExternalSecret operator
   - Prevents unauthorized file disclosure (CVSS 8.3 HIGH vulnerability)
   - Required for renderer v3.6.1+ to avoid security issues
   - Both services must use identical token for authentication to work

2. NetworkPolicy Implementation:
   - Restricts ingress traffic to renderer pod on port 8081/TCP
   - Only Grafana pods (app=grafana label) can access renderer service
   - Follows OpenShift NetworkPolicy best practices (default deny-all)
   - Prevents unauthorized access from other pods in namespace

This approach uses the remote rendering service pattern instead of
plugin mode, which avoids dependency issues with missing libraries
in the Grafana container and provides better security isolation.

Technical Details:
- Image: grafana/grafana-image-renderer:3.11.3
- Port: 8081/TCP (ClusterIP Service)
- Vault Secret Path: nerc/nerc-ocp-obs/grafana/renderer-token
- Required Token Length: 64 characters (32 bytes hex recommended)
- Grafana Version Requirement: v9.1.2+ (or v9.0.8+, v8.5.11+, v8.4.11+, v8.3.11+)
- Renderer Version Requirement: v3.6.1+

Findings:
Grafana Operator v5 Reconcile Behavior:
   During deployment I discovered that the Grafana Operator v5 overwrites
   or doesn't fully respect the grafana-renderer-token when added via envFrom
   secretRef. The operator reconciles the deployment regularly and removed
   the renderer token from the pod configuration, even though it was in the
   Grafana CR spec.

   Solution - Explicit env with secretKeyRef:
       Instead of using envFrom with secretRef for the renderer token, I use
       explicit env variable with valueFrom.secretKeyRef. This pattern is more
       stable with the Grafana Operator because it treats explicit env variables
       different than envFrom during reconciliation. The operator respects
       individual env entries with secretKeyRef better than full secret imports
       via envFrom.

   Configuration pattern:
   ```yaml
   env:
     - name: GF_RENDERING_RENDERER_TOKEN
       valueFrom:
         secretKeyRef:
           name: grafana-renderer-token
           key: GF_RENDERING_RENDERER_TOKEN
   ```

   This is the recommended approach for operator-managed deployments when
   specific environment variables need to persist across reconcile cycles.

Testing:
After deployment, verify rendering with:
  curl -fSL -H "Authorization: Bearer $TOKEN" \
    "$GRAFANA_URL/render/d/<dashboard-uid>?width=3840&height=2160&scale=2"

Goal:
Enable image rendering in Grafana for automated report generation,
supporting both quarterly review materials and scheduled operational
reports with consistent output quality and security.

References:
- Deploying Grafana on OpenShift 4: https://cloud.redhat.com/experts/o11y/ocp-grafana/
- Grafana Image Renderer Plugin: https://grafana.com/grafana/plugins/grafana-image-renderer/
- Grafana Image Renderer GitHub: https://github.com/grafana/grafana-image-renderer
- Remote Rendering Setup: https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/
- CVE-2022-31176 Security Advisory: https://grafana.com/security/security-advisories/cve-2022-31176/
- OpenShift NetworkPolicy: https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/networking/network-policy
- Grafana Operator: https://github.com/grafana/grafana-operator
- Grafana Operator Credential Secret: https://grafana.github.io/grafana-operator/docs/examples/credential_secret/readme/
- Kubernetes NetworkPolicy: https://kubernetes.io/docs/concepts/services-networking/network-policies/