### PR TITLE
ocp-test: use serverless stable-1.36 channel

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -127,3 +127,10 @@ patches:
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - ocp-test.nerc.mghpcc.org
+- target:
+    kind: Subscription
+    name: serverless-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-1.36


### PR DESCRIPTION
In case it fixes the issue preventing basic kservice manifests from functioning properly with RHOAI operator managing the knative-serving instance.