### PR TITLE
fix(grafana): correct image renderer callback URL to use grafana-service

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -31,7 +31,7 @@ spec:
       mode: console
     rendering:
       server_url: 'http://grafana-image-renderer:8081/render'
-      callback_url: 'http://grafana-service:3000/'
+      callback_url: '${GF_RENDERING_CALLBACK_URL}'
       renderer_token: '${GF_RENDERING_RENDERER_TOKEN}'
   deployment:
     spec:

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -31,7 +31,7 @@ spec:
       mode: console
     rendering:
       server_url: 'http://grafana-image-renderer:8081/render'
-      callback_url: 'http://grafana:3000/'
+      callback_url: 'http://grafana-service:3000/'
       renderer_token: '${GF_RENDERING_RENDERER_TOKEN}'
   deployment:
     spec:
@@ -46,6 +46,8 @@ spec:
                     secretKeyRef:
                       name: grafana-renderer-token
                       key: GF_RENDERING_RENDERER_TOKEN
+                - name: GF_RENDERING_CALLBACK_URL
+                  value: 'http://grafana-service:3000/'
               envFrom:
                 - secretRef:
                     name: oauth-client-secret


### PR DESCRIPTION
Fix callback_url for Grafana image renderer to use the correct service name 'grafana-service' instead of 'grafana'. This resolves the ERR_NAME_NOT_RESOLVED error where the image renderer pod could not reach back to Grafana, resulting in blank/white rendered images.

Changes:
1. Updated rendering.callback_url from 'http://grafana:3000/' to 'http://grafana-service:3000/' in Grafana CR spec.config
2. Added GF_RENDERING_CALLBACK_URL environment variable to explicitely override the config and ensure Grafana Operator respects the setting

Why:
The image renderer's Chromium browser needs to fetch the dashboard content from Grafana. It uses the callback_url to know where to make this request. The service name 'grafana' does not exist - the actual service is named 'grafana-service' as shown by 'kubectl get svc -n grafana'.

Error before fix:
  {"failure":"net::ERR_NAME_NOT_RESOLVED","level":"error",
   "message":"Browser request failed","method":"GET",
   "url":"http://grafana:3000/d-solo/..."}

With this fix, the renderer can sucessfully resolve and connect to grafana-service:3000 to fetch dashboard content for rendering.

Testing:
After applying this change, rendering should produce actual dashboard images instead of blank white PNGs:
  curl -H "Authorization: Bearer $TOKEN" \
    "https://grafana.apps.obs.nerc.mghpcc.org/render/d-solo/<uid>?..." \
    -o panel.png