### PR TITLE
feat(grafana): add persistent service account token for image rendering

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/externalsecrets/grafana-renderer-service-account-token.yaml
+++ b/grafana/overlays/nerc-ocp-obs/externalsecrets/grafana-renderer-service-account-token.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-renderer-service-account-token
+  namespace: grafana
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: grafana-renderer-service-account-token
+  data:
+  - secretKey: GRAFANA_SERVICE_ACCOUNT_TOKEN
+    remoteRef:
+      key: nerc/nerc-ocp-obs/grafana/renderer-token
+      property: SERVICE_ACCOUNT_TOKEN

--- a/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - oauth-client-secret.yaml
 - grafana-renderer-token.yaml
+- grafana-renderer-service-account-token.yaml


### PR DESCRIPTION
Add ExternalSecret to inject persistent Grafana service account token for automated dashboard rendering via API. This enables consistent, programatic access to the rendering endpoint without manual token management.

Changes:
1. Created grafana-renderer-service-account-token ExternalSecret
2. Token sourced from Vault path: nerc/nerc-ocp-obs/grafana/renderer-token with property SERVICE_ACCOUNT_TOKEN
3. Secret key: GRAFANA_SERVICE_ACCOUNT_TOKEN

Why:
Previously, manual Grafana API tokens were needed for curl-based rendering requests.
- Tokens expire or get invalidated
- Manual token creation/rotation required
- Difficult to share accross automation scripts

Now, with ExternalSecret:
- Service account token stored securily in Vault
- Automatic injection into Kubernetes secret
- Consistent token accross rendering automation
- Easy rotation via Vault update

Vault Configuration Required:
In Vault at nerc/nerc-ocp-obs/grafana/renderer-token, add:
  SERVICE_ACCOUNT_TOKEN: <grafana-service-account-token>

To create the service account token in Grafana:
1. Go to Administration → Service accounts
2. Create service account with "Viewer" role
3. Add service account token
4. Store token in Vault

Usage Example:
  TOKEN=$(kubectl get secret grafana-renderer-service-account-token -n grafana -o jsonpath='{.data.GRAFANA_SERVICE_ACCOUNT_TOKEN}' | base64 -d)

  curl -H "Authorization: Bearer $TOKEN" "https://grafana.apps.obs.nerc.mghpcc.org/render/d-solo/<uid>?..." -o dashboard.png

Possible features for:
- RHRQ (Red Hat Quarterly Review) materials (trigger)
- Scheduled operational reports (future projects)
- Automated documentation generation

We can now generate reports automatically instead of doing manual screenshots everytime when we need them for presentations. We can create hires images, not dependent on the screen size.

Belongs to
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/818