### PR TITLE
Update Subscription channel to stable-4.19

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
   name: odf-operator
 spec:
-  channel: stable-4.18
+  channel: stable-4.19


### PR DESCRIPTION
Following on from the test cluster upgrade, ODF also need to be upgraded on the test cluster