### PR TITLE
Enable RHOAI managed Kueue

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -25,7 +25,7 @@ spec:
     ray:
       managementState: Managed
     kueue:
-      managementState: Removed
+      managementState: Managed
     workbenches:
       managementState: Managed
     dashboard:


### PR DESCRIPTION
Kueue was installed by `kubectl` in ocp-test cluster, which is difficult to maintain and upgrade. Now enable RHOAI managed Kueue in ocp-test cluster to be consistent with Prod and Edu cluster. 