### PR TITLE
feat(obs-metric): add process_start_time_seconds to metrics allowlist

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -39,6 +39,7 @@ data:
       - container_cpu_cfs_throttled_seconds_total
       - container_memory_max_usage_bytes
       - container_memory_failures_total
+      - process_start_time_seconds
     matches:
       - __name__=~"^ipmi_.*"
       - __name__=~"^ceph_.*"


### PR DESCRIPTION
Add process_start_time_seconds metric to the obs custom allowlist to enable tracking of process start times across managed clusters. This metric is useful for documenting the start time in the "Total Admitted Since Start" panel which uses the query sum(kueue_admitted_workloads_total{cluster="nerc-ocp-edu"}). Without the start time reference, its difficult to interpret the accumulated totals correctly.

Related to: https://github.com/nerc-project/operations/issues/1295