### PR TITLE
rbac: application edit

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/application-edit/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/application-edit/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: application-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - verbs:
+      - '*'
+    apiGroups:
+      - app.k8s.io
+    resources:
+      - applications

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/application-edit/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/application-edit/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - clusterversion.yaml
 - ../common
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+- ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/core/namespaces/dex
 - externalsecrets


### PR DESCRIPTION
This allows users to manage applications.app.k8s.io resources within their namespace via a new ClusterRole, `aggregate-edit`, that aggregates to the edit ClusterRole.