### PR TITLE
rhoai: use default ingress cert for kserve ingress

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-edu/rhoai/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rhoai/datasciencecluster.yaml
@@ -14,7 +14,7 @@ spec:
       serving:
         ingressGateway:
           certificate:
-            type: SelfSigned
+            type: OpenShiftDefaultIngress
         managementState: Managed
         name: knative-serving
     modelregistry:

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -14,7 +14,7 @@ spec:
       serving:
         ingressGateway:
           certificate:
-            type: SelfSigned
+            type: OpenShiftDefaultIngress
         managementState: Managed
         name: knative-serving
     modelregistry:

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -14,7 +14,7 @@ spec:
       serving:
         ingressGateway:
           certificate:
-            type: SelfSigned
+            type: OpenShiftDefaultIngress
         managementState: Managed
         name: knative-serving
     modelregistry:


### PR DESCRIPTION
This updates the RHOAI installations datasciencecluster resource to use the default OpenShift ingress certificate for the kserve/istio ingress gateway.

This RHOAI documentation page got me close to the solution:

https://ai-on-openshift.io/odh-rhoai/single-stack-serving-certificate/

Exploring the datasciencecluster spec revealed it's possible to just use the existing default OpenShift ingress cert:
```
$ oc explain dsc.spec.components.kserve.serving.ingressGateway.certificate.type
```
Closes nerc-project/operations#1227