### PR TITLE
ocp-prod: upgrade serverless to 1.36

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -177,3 +177,10 @@ patches:
     - op: replace
       path: /spec/channel
       value: v25.3
+- target:
+    kind: Subscription
+    name: serverless-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-1.36


### PR DESCRIPTION
This matches the setup on ocp-test and should hopefully resolve an issue where kservice routes do not become ready until after a bounce of the istio-ingressgateway pod in the istio-system namespace.

See https://github.com/nerc-project/operations/issues/1176#issuecomment-3563878846