### PR TITLE
feat(obs-metric): add batch metrics to allowlist

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -57,3 +57,4 @@ data:
       - __name__=~"^thanos_.*"
       - __name__=~"^kueue_.*"
       - __name__=~"^ovms_.*"
+      - __name__=~"^batch_.*"


### PR DESCRIPTION
Why this change was necessary:
The batch_* metrics provide essential visibility into GPU workload lifecycle timing, specifically tracking queue wait time, execution duration, and total wall time.
These metrics become critical when DCGM metrics are not available due to NVIDIA profiler being in use, which is common scenario during GPU workload profiling activities.

This change enables monitoring for Meera's GPU workload tracking implementation and supports Jonathan's GPU scheduling classes.

Key changes:
• Add batch_* metric pattern to ACM observability allowlist
• Enable monitoring of GPU job scheduling and execution metrics
• Provide alternative metrics when DCGM is unavailable
• Support GPU workload lifecycle tracking by @memalhot

Ref: nerc-project/operations#1336