### PR TITLE
ocp-prod: allow end-users read-only access to customresourcedefinitions

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-list-crds
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - watch
+      - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - ../../bundles/nagios-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
 - ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin


### PR DESCRIPTION
This patch adds a new clusterrole, allow-list-crds, that gives end-users read-only access to customresourcedefinitions (aliases: crd,crds). It also enables this access on the ocp-prod cluster. This new cluster role aggregates to the edit cluster role.

This is needed by end-users attempting to provision resources via OpenTofu/Terraform using the kubernetes provider(s).