### PR TITLE
ocp-prod: add clusterrolebinding for listing crds

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: allow-list-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-list-crds
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-list-crds/clusterrole.yaml
@@ -2,8 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: allow-list-crds
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - "apiextensions.k8s.io"

--- a/cluster-scope/bundles/allow-list-crds/kustomization.yaml
+++ b/cluster-scope/bundles/allow-list-crds/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: allow-list-crds
+
+resources:
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -29,9 +29,9 @@ resources:
 - ../../bundles/mongodb-operator
 - ../../bundles/elasticsearch-eck-operator
 - ../../bundles/nagios-monitoring
+- ../../bundles/allow-list-crds
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
 - ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin


### PR DESCRIPTION
It turns out customresourcedefinitions are cluster-scoped which means we can't give access to users via a namespace rolebinding.

This patch adds a new bundle to include both a clusterrole and clusterrolebinding for allowing all authenticated users read-only access to customresourcedefinitions.

This patch also removes the aggregate-to-edit label from the clusterrole given that we have to bind this at the cluster-scope (ie not from a namespace rolebinding to the edit clusterrole).

Finally, it adds the bundle to the ocp-prod overlay.

This is a follow up patch to #832 