### PR TITLE
feat(observability): add batch metrics to uwl allowlist

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -63,4 +63,5 @@ data:
       - __name__=~"^batch_.*"
   uwl_metrics_list.yaml: |
     matches:
+      # GPU batch job metrics (when DCGM unavailable):
       - __name__=~"^batch_.*"

--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -50,6 +50,7 @@ data:
 
       # Consolidate kube*:
       - __name__=~"^kube_(?:node|pod|job)_.*"
+
       - __name__=~"^mco_.*"
       - __name__=~"^llm_performance_.*"
       - __name__=~"^vllm:.*"
@@ -57,4 +58,9 @@ data:
       - __name__=~"^thanos_.*"
       - __name__=~"^kueue_.*"
       - __name__=~"^ovms_.*"
+
+      # GPU batch job metrics (when DCGM unavailable):
+      - __name__=~"^batch_.*"
+  uwl_metrics_list.yaml: |
+    matches:
       - __name__=~"^batch_.*"


### PR DESCRIPTION
The batch_* metrics was already added to the platform monitoring allowlist in metrics_list.yaml, but because Push Gateway runs in user namespace and get scraped by User Workload Monitoring, we needs to add this entry also to uwl_metrics_list.yaml section.

This allow proper collection of batch job metrics from the user workload monitoring stack.

Triggered-By: https://github.com/nerc-project/operations/issues/1336
Connected-To: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/831