### PR TITLE
Upgrade to latest prom-keycloak-proxy 2.4.0 features. Add init container for loading AI Telemetry courses. Add persistent-metrics-zookeeper AI Telemetry custom metrics. Adding a missing solr serviceaccount. Adding kube_namespace_status_phase and kube_namespace_labels. 

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -49,8 +49,7 @@ data:
       - __name__=~"^argocd_.*"
 
       # Consolidate kube*:
-      - __name__=~"^kube_(?:node|pod|job)_.*"
-
+      - __name__=~"^kube_(?:node|pod|job|namespace)_.*"
       - __name__=~"^mco_.*"
       - __name__=~"^llm_performance_.*"
       - __name__=~"^vllm:.*"

--- a/ai-telemetry/base/aitelemetry/site/deployment.yaml
+++ b/ai-telemetry/base/aitelemetry/site/deployment.yaml
@@ -13,6 +13,28 @@ spec:
   selector:
   template:
     spec:
+      volumes:
+        - name: "ai-telemetry-developer"
+          emptyDir: {}
+      initContainers:
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: git-cloner
+          command:
+            - sh
+            - '-c'
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: "ai-telemetry-developer"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+          terminationMessagePolicy: File
+          envFrom:
+            - secretRef:
+                name: aitelemetry-worker
+          image: docker.io/alpine/git
+          args:
+            - >-
+              git clone https://computate.org:$GITHUB_DEVELOPERS_TOKEN@github.com/computate-org/ai-telemetry-developer.git /home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer;
       containers:
         - name: aitelemetry
           image: 'quay.io/nerc-images/ai-telemetry:latest'
@@ -47,6 +69,9 @@ spec:
             limits:
               cpu: '1'
               memory: '2Gi'
+          volumeMounts:
+            - name: "ai-telemetry-developer"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
           env:
             - name: ENABLE_ZOOKEEPER_CLUSTER
               value: 'true'

--- a/ai-telemetry/base/aitelemetry/worker/deployment.yaml
+++ b/ai-telemetry/base/aitelemetry/worker/deployment.yaml
@@ -12,6 +12,28 @@ spec:
       maxSurge: 1
   template:
     spec:
+      volumes:
+        - name: "ai-telemetry-developer"
+          emptyDir: {}
+      initContainers:
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: git-cloner
+          command:
+            - sh
+            - '-c'
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: "ai-telemetry-developer"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+          terminationMessagePolicy: File
+          envFrom:
+            - secretRef:
+                name: aitelemetry-worker
+          image: docker.io/alpine/git
+          args:
+            - >-
+              git clone https://computate.org:$GITHUB_DEVELOPERS_TOKEN@github.com/computate-org/ai-telemetry-developer.git /home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer;
       containers:
         - name: aitelemetry
           image: 'quay.io/nerc-images/ai-telemetry:latest'
@@ -46,6 +68,9 @@ spec:
             limits:
               cpu: '1'
               memory: '2Gi'
+          volumeMounts:
+            - name: "ai-telemetry-developer"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
           env:
             - name: ENABLE_ZOOKEEPER_CLUSTER
               value: 'false'

--- a/ai-telemetry/base/kustomization.yaml
+++ b/ai-telemetry/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - postgres
 - kafka
 - aitelemetry
+- persistent-metrics-zookeeper

--- a/ai-telemetry/base/persistent-metrics-zookeeper/deployments/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/deployments/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - persistent-metrics-zookeeper/

--- a/ai-telemetry/base/persistent-metrics-zookeeper/deployments/persistent-metrics-zookeeper/deployment.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/deployments/persistent-metrics-zookeeper/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: persistent-metrics-zookeeper
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: persistent-metrics-zookeeper
+    spec:
+      containers:
+        - name: persistent-metrics-zookeeper
+          env:
+            - name: ZOOKEEPER_HOST_NAME
+              value: zookeeper-client
+            - name: ZOOKEEPER_PORT
+              value: '2181'
+            - name: LOG_LEVEL
+              value: 'WARNING'
+          image: quay.io/computateorg/persistent-metrics-zookeeper:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/bin/curl
+                - http://localhost:8081/metrics
+            failureThreshold: 6
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/bin/curl
+                - http://localhost:8081/metrics
+            failureThreshold: 6
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: '1'
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}

--- a/ai-telemetry/base/persistent-metrics-zookeeper/deployments/persistent-metrics-zookeeper/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/deployments/persistent-metrics-zookeeper/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/ai-telemetry/base/persistent-metrics-zookeeper/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: zookeeper
+labels:
+  - pairs:
+      app: persistent-metrics-zookeeper
+      deployment: persistent-metrics-zookeeper
+    includeSelectors: true
+
+resources:
+  - deployments/
+  - services/

--- a/ai-telemetry/base/persistent-metrics-zookeeper/services/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/services/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - persistent-metrics-zookeeper/

--- a/ai-telemetry/base/persistent-metrics-zookeeper/services/persistent-metrics-zookeeper/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/services/persistent-metrics-zookeeper/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml

--- a/ai-telemetry/base/persistent-metrics-zookeeper/services/persistent-metrics-zookeeper/service.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/services/persistent-metrics-zookeeper/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: persistent-metrics-zookeeper
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8081
+    targetPort: 8081
+  selector:
+    app: persistent-metrics-zookeeper
+    deployment: persistent-metrics-zookeeper
+  sessionAffinity: None
+  type: ClusterIP

--- a/ai-telemetry/base/solr/serviceaccounts.yaml
+++ b/ai-telemetry/base/solr/serviceaccounts.yaml
@@ -18,3 +18,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: solr-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: solr

--- a/prom-keycloak-proxy/base/deployments/prom-keycloak-proxy/deployment.yaml
+++ b/prom-keycloak-proxy/base/deployments/prom-keycloak-proxy/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               value: CLUSTER
             - name: PROXY_PROJECT_KEY
               value: PROJECT
-          image: quay.io/nerc-images/prom-keycloak-proxy:2.3.0
+          image: quay.io/nerc-images/prom-keycloak-proxy:2.4.0
           imagePullPolicy: Always
           livenessProbe:
             exec:


### PR DESCRIPTION
- **Upgrade to latest prom-keycloak-proxy 2.4.0 features**
- **Add persistent-metrics-zookeeper AI Telemetry custom metrics** — This is a simple python application connected to zookeeper, which is a distributed counter for creating accurate, persistent custom metrics.
- **Adding a missing solr serviceaccount**
- **Adding kube_namespace_status_phase and kube_namespace_labels** — These metrics are useful for reporting on namespaces stuck deleting, and for namespace labels. These metrics account for all namespaces in the cluster which we can't already do.
- **Add init container for loading AI Telemetry courses** — This init container pulls the AI Telemetry courses and automatically imports them when the server starts up. Requires Admin or AiTelemetryDeveloper permissions to view the courses. See the courses here: https://aitelemetry.apps.obs.nerc.mghpcc.org/en-us/search/ai-telemetry-developer

<img width="1130" height="938" alt="image" src="https://github.com/user-attachments/assets/ae2ec6fd-1a67-4b99-9307-902a9b4a92b7" />
