### PR TITLE
feat(monitoring): add minio metrics collection

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -57,6 +57,7 @@ data:
       - __name__=~"^thanos_.*"
       - __name__=~"^kueue_.*"
       - __name__=~"^ovms_.*"
+      - __name__=~"^minio_.*"
 
       # GPU batch job metrics (when DCGM unavailable):
       - __name__=~"^batch_.*"

--- a/minio/base/kustomization.yaml
+++ b/minio/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - service.yaml
 - console-route.yaml
 - object-storage-route.yaml
+- servicemonitor.yaml

--- a/minio/base/servicemonitor.yaml
+++ b/minio/base/servicemonitor.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  endpoints:
+  - port: object-storage
+    path: /minio/v2/metrics/cluster
+    interval: 5m
+    scheme: http
+    basicAuth:
+      username:
+        name: minio-admin-credentials
+        key: MINIO_ROOT_USER
+      password:
+        name: minio-admin-credentials
+        key: MINIO_ROOT_PASSWORD
+  - port: object-storage
+    path: /minio/v2/metrics/bucket
+    interval: 5m
+    scheme: http
+    basicAuth:
+      username:
+        name: minio-admin-credentials
+        key: MINIO_ROOT_USER
+      password:
+        name: minio-admin-credentials
+        key: MINIO_ROOT_PASSWORD
+  selector:
+    matchLabels:
+      app: minio
+  namespaceSelector:
+    matchNames:
+    - minio


### PR DESCRIPTION
Why this change was necessary:
The MinIO object storage was not monitored before. To get visibility into storage performance and health, we need metrics collection from MinIO endpoints.
MinIO v2 metrics endpoints require authentication by default - wihtout proper credentials, Prometheus get 403 Forbidden responses.
Using basicAuth with the existing minio-admin-credentials secret is necessary for secure access.

Key changes:
- created servicemonitor for minio cluster and bucket metrics
- configured scraping from /minio/v2/metrics endpoints every 5m
- added basicAuth to both endpoints using existing minio-admin-credentials secret
- added servicemonitor to kustomization resources
- allowed minio_* metrics pattern in acm observability allowlist

Key insights:
Storage metrics like bucket sizes and object counts are relatively stable compared to CPU/memory metrics.
The 5 minute scrape interval is sufficient for storage monitoring, it reduces unnecessary load on both MinIO and the Prometheus system.

Fixes: n/a

Triggered by: n/a

Connected to: https://github.com/nerc-project/operations/issues/1373#issuecomment-3670929947

Signed-off-by: /Thor(sten)?/ Schwesig <89909507+schwesig@users.noreply.github.com>