### PR TITLE
fix(obs): apply system-reserved to worker nodes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kubeletconfigs/system-reserved-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kubeletconfigs/system-reserved-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved
+  namespace: openshift-config-operator
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      $patch: replace
+      machineconfiguration.openshift.io/mco-built-in: ""

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -59,6 +59,7 @@ configMapGenerator:
   namespace: openshift-monitoring
 
 patches:
+- path: kubeletconfigs/system-reserved-patch.yaml
 - target:
     kind: SecretStore
   patch: |


### PR DESCRIPTION
2026-01-09: question was answered in Slack: https://massopencloud.slack.com/archives/C027TDE52TZ/p1767950346289259
we can reboot the worker bodes in the OBS cluster outside of maintenance window.
So I am changing this from WiP to real PR.

~#### WIP~
- [x] until the question is discussed and solved: `Schedule this change during a maintenance window? Or is it OK for OBS cluster to do it "when needed"?`
- see https://github.com/nerc-project/operations/issues/1406)


### Why this change was necessary:

- The OBS cluster was triggering SystemMemoryExceedsReservation alert on worker node wrk-1 because the system-reserved KubeletConfig only applied to master nodes.
- The original configuration used selector "pools.operator.machineconfiguration.openshift.io/master" which excludes worker nodes.
- Other clusters (prod, test, edu) already had a patch what changes the selector to "machineconfiguration.openshift.io/mco-built-in" which applies to both master and worker nodes, but OBS was missing this fix.
- This implementation follows the same pattern and uses identical patch as the other cluster overlays to ensure consistency.

### Key changes:

- Add kubeletconfigs/system-reserved-patch.yaml to nerc-ocp-obs overlay
- Update kustomization.yaml to reference new patch
- Patch changes machineConfigPoolSelector from master-only to mco-built-in label
- Implementation follows same pattern as prod, test, and edu overlays

Fixes: https://github.com/nerc-project/operations/issues/1406

Triggered by: SystemMemoryExceedsReservation alert on wrk-1

Connected to: n/a

Note: This will cause rolling reboots of OBS worker nodes when ArgoCD syncs the changes.