### PR TITLE
fix(logging): OBS Cluster - update collection config for v6.3.x compa…

### DIFF
--- a/logging/base/clusterloggings/instance.yaml
+++ b/logging/base/clusterloggings/instance.yaml
@@ -10,5 +10,4 @@ spec:
     lokistack:
       name: logging-loki
   collection:
-    logs:
-      type: vector
+    type: vector


### PR DESCRIPTION
# fix(logging): OBS Cluster - update collection config for v6.3.x compatibility

## Why this change was necessary:
The cluster-logging operator v6.3.x deprecated the nested spec.collection.logs.type structure in favor from a flattened spec.collection.type. This was causing ClusterLogForwarderDeprecations alert to fire, which indicate that configuration needs update to remain compatible with future versions.

## Key changes:

- Changed spec.collection.logs.type to spec.collection.type in ClusterLogging instance
- Maintained vector as collection type value

Fixes: Alert ClusterLogForwarderDeprecations

Triggered by: ClusterLogForwarderDeprecations on OBS alertname=ClusterLogForwarderDeprecations&version=6.3.2

Connected to: cluster-logging operator v6.3.x upgrade

## Source:
- https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/pdf/upgrading_logging/Red_Hat_OpenShift_Logging-6.3-Upgrading_logging-en-US.pdf
  - page 8, 1.3.1., 4
- https://access.redhat.com/solutions/7072929
- https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html-single/upgrading_logging/index