### PR TITLE
ocp-prod: bump monitoring PVCs to 400Gi

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/configmaps/cluster-monitoring-config.yaml
@@ -5,7 +5,7 @@ prometheusK8s:
       storageClassName: ocs-external-storagecluster-ceph-rbd
       resources:
         requests:
-          storage: 200Gi
+          storage: 400Gi
 alertmanagerMain:
   volumeClaimTemplate:
     spec:


### PR DESCRIPTION
The underlying PVCs for the openshift-monitoring PVCs have filled up causing us to lose metrics. Doubling storage given we have more users and nodes these days.