### PR TITLE
fix (loki, logs): Drop high-cardinality Kubernetes labels from Loki log streams

### DIFF
--- a/logging/overlays/README.md
+++ b/logging/overlays/README.md
@@ -1,0 +1,78 @@
+# Logging Overlays
+
+## Adding a New Cluster
+
+When adding logging configuration for a new cluster that forwards to Loki:
+
+### 1. Create overlay directory structure
+
+```bash
+mkdir -p logging/overlays/<new-cluster-name>/clusterlogforwarders
+mkdir -p logging/overlays/<new-cluster-name>/externalsecrets
+```
+
+### 2. Copy template from existing cluster
+
+```bash
+cp -r logging/overlays/nerc-ocp-prod/* logging/overlays/<new-cluster-name>/
+```
+
+### 3. Update cluster-specific values
+
+Edit `clusterlogforwarders/instance_patch.yaml`:
+- Update Loki endpoint URLs (if different)
+- **Keep the label drops** in all three pipelines
+
+Edit `externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml`:
+- Update Vault secret path
+
+### 4. IMPORTANT: High-Cardinality Label Drops
+
+**Always include these label drops in each pipeline** to prevent S3 object explosion:
+
+```yaml
+labels:
+  kubernetes_pod_name: ""
+  kubernetes_pod_id: ""
+  kubernetes_container_id: ""
+```
+
+**Why:** These labels create millions of log streams (one per pod instance), resulting in
+millions of small S3 objects. See https://github.com/nerc-project/operations/issues/1410
+
+**Impact without label drops:**
+- 3.4M+ S3 objects in 90 days
+- Exceeds OpenStack Object Store quotas
+- High S3 storage costs
+
+**Impact with label drops:**
+- 90%+ reduction in S3 object count
+- 95%+ reduction in active Loki streams
+- Pod names remain searchable in log message content
+
+### 5. Validation
+
+```bash
+kustomize build logging/overlays/<new-cluster-name>
+```
+
+## Architecture Note
+
+Cluster overlays **fully replace** the base `ClusterLogForwarder` spec because each cluster
+has different outputs (Loki endpoints). Therefore, shared configuration like label drops
+cannot be defined in a component or base patch - they must be included in each cluster's
+`instance_patch.yaml` file.
+
+### Why Not Use Kustomize Components?
+
+Components are applied **before** overlay patches in the kustomization pipeline. Since the
+ClusterLogForwarder resource with cluster-specific outputs is created by the overlay patch
+(not inherited from base), any component trying to patch it would fail with "no matches"
+because the resource doesn't exist yet at component application time.
+
+**Kustomize processing order:**
+1. Load base resources
+2. Apply components (ClusterLogForwarder doesn't have send-app-logs pipeline yet)
+3. Apply overlay patches (ClusterLogForwarder spec is fully replaced here)
+
+This is why label drops must be included directly in each overlay's instance_patch.yaml.

--- a/logging/overlays/nerc-ocp-edu/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-edu/clusterlogforwarders/instance_patch.yaml
@@ -26,13 +26,28 @@ spec:
         - application
       outputRefs:
         - loki-app
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-infra-logs
       inputRefs:
         - infrastructure
       outputRefs:
         - loki-infra
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-audit-logs
       inputRefs:
         - audit
       outputRefs:
         - loki-audit
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""

--- a/logging/overlays/nerc-ocp-infra/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-infra/clusterlogforwarders/instance_patch.yaml
@@ -26,13 +26,28 @@ spec:
         - application
       outputRefs:
         - loki-app
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-infra-logs
       inputRefs:
         - infrastructure
       outputRefs:
         - loki-infra
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-audit-logs
       inputRefs:
         - audit
       outputRefs:
         - loki-audit
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""

--- a/logging/overlays/nerc-ocp-prod/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-prod/clusterlogforwarders/instance_patch.yaml
@@ -26,13 +26,28 @@ spec:
         - application
       outputRefs:
         - loki-app
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-infra-logs
       inputRefs:
         - infrastructure
       outputRefs:
         - loki-infra
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-audit-logs
       inputRefs:
         - audit
       outputRefs:
         - loki-audit
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""

--- a/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
+++ b/logging/overlays/nerc-ocp-test/clusterlogforwarders/instance_patch.yaml
@@ -26,13 +26,28 @@ spec:
         - application
       outputRefs:
         - loki-app
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-infra-logs
       inputRefs:
         - infrastructure
       outputRefs:
         - loki-infra
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""
     - name: send-audit-logs
       inputRefs:
         - audit
       outputRefs:
         - loki-audit
+      labels:
+        # Drop high-cardinality labels - see https://github.com/nerc-project/operations/issues/1410
+        kubernetes_pod_name: ""
+        kubernetes_pod_id: ""
+        kubernetes_container_id: ""


### PR DESCRIPTION
# fix (loki, logs): Drop high-cardinality Kubernetes labels from Loki log streams

Fixes https://github.com/nerc-project/operations/issues/1441

Drop kubernetes_pod_name, kubernetes_pod_id, and kubernetes_container_id labels from ClusterLogForwarder pipelines in all 4 clusters to reduce Loki stream cardinality and prevent S3 object explosion (see #1410).

Expected impact: 90%+ reduction in S3 object count, 95%+ reduction in active Loki streams. Pod metadata remains searchable in log message content.

Changes:
- logging/overlays/`{nerc-ocp-prod,nerc-ocp-infra,nerc-ocp-edu,nerc-ocp-test}`/clusterlogforwarders/instance_patch.yaml
  - Add label drops to all three pipelines (app, infra, audit)
- logging/overlays/README.md Document label drop requirement for future cluster additions

See
- https://github.com/nerc-project/operations/issues/1441
- for detailed analysis, architecture decisions, and monitoring plan.

---

## Summary

Reduces Loki stream cardinality by dropping `kubernetes_pod_name`, `kubernetes_pod_id`, and `kubernetes_container_id` labels from log forwarding configuration. This prevents the S3 object explosion that caused the capacity issues in #1410.

## Changes

- Add label drops to ClusterLogForwarder pipelines in 4 cluster overlays:
  - `nerc-ocp-prod`
  - `nerc-ocp-infra`
  - `nerc-ocp-edu`
  - `nerc-ocp-test`

- Add `logging/overlays/README.md` documenting the requirement for future cluster additions

## Expected Impact

- **90%+ reduction** in S3 object count over 30 days
- **95%+ reduction** in active Loki streams
- Pod names remain searchable in log message content via LogQL: `{namespace="foo"} |= "pod-name"`

## Testing

- ✅ Validated with `kustomize build` for all 4 cluster overlays
- ✅ Passed `yamllint` and pre-commit checks
- ✅ Verified label drops are identical accross all clusters (MD5: `bd7f13a6b0367a76aefa3dc3b8c535aa`)

## Rollback Plan

If issues arise:
```bash
git revert <this-commit-sha>
```

Labels will be re-added to new logs. Existing logs remain searchable.

## Post-Merge Monitoring

Track these metrics for 7 days:
- Loki stream count: `sum(loki_distributor_bytes_received_total) by (tenant)`
- S3 object creation rate (via OpenStack Swift metrics)
