### PR TITLE
ocp-test: add udev rules for H100 nodes

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/mlx5_core.rules
+++ b/cluster-scope/overlays/nerc-ocp-test/machineconfigs/udev-rules/src/mlx5_core.rules
@@ -4,3 +4,13 @@ SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:49:00.0",ACTION=="add",NAME
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:49:00.1",ACTION=="add",NAME="nic2"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.0",ACTION=="add",NAME="nic1"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.1",ACTION=="add",NAME="nic2"
+
+# lenovo-sd665nv3-h100 nodes
+# connectx-6 cards
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:42:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:42:00.1",ACTION=="add",NAME="nic2"
+# connectx-7 cards
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:23:00.0",ACTION=="add",NAME="nic3"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:03:00.0",ACTION=="add",NAME="nic4"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:c3:00.0",ACTION=="add",NAME="nic5"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:a3:00.0",ACTION=="add",NAME="nic6"


### PR DESCRIPTION
This adds udev rules to configure the 6x Mellanox NICs on the Lenovo SD665NV3 H100 nodes. These nodes live in ESI and only 5x of the NICs are cabled/connected: 1x connectx-6 card and 4x connectx-7 cards. We configure the 1x disconnected connectx-6 card given that we need to configure a bond similar to the rest of the cluster. The bond network setup is functional but only has one active NIC.