### PR TITLE
add nvidia-network-operator bundle and install on nerc-ocp-test

### DIFF
--- a/cluster-scope/base/core/namespaces/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-network-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/nvidia-network-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-network-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-network-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-network-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-network-operator-group
+spec:
+  targetNamespaces:
+    - nvidia-network-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-network-operator
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nvidia-network-operator
+spec:
+  channel: v25.10
+  installPlanApproval: Automatic
+  name: nvidia-network-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: nvidia-network-operator
+resources:
+- ../../base/core/namespaces/nvidia-network-operator
+- ../../base/operators.coreos.com/operatorgroups/nvidia-network-operator
+- ../../base/operators.coreos.com/subscriptions/nvidia-network-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
 - ../../bundles/node-feature-discovery
 - ../../bundles/patch-operator
 - ../../bundles/nvidia-gpu-operator
+- ../../bundles/nvidia-network-operator
 - ../../bundles/koku-metrics-operator
 - ../../bundles/kubernetes-image-puller-operator
 - ../../bundles/curator

--- a/nvidia-network-operator/base/kustomization.yaml
+++ b/nvidia-network-operator/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-network-operator
+resources:
+  - nic-cluster-policy.yaml

--- a/nvidia-network-operator/base/nic-cluster-policy.yaml
+++ b/nvidia-network-operator/base/nic-cluster-policy.yaml
@@ -1,0 +1,31 @@
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  ofedDriver:
+    image: doca-driver
+    repository: nvcr.io/nvidia/mellanox
+    version: doca3.2.0-25.10-1.2.8.0-2
+    env:
+      - name: UNLOAD_STORAGE_MODULES
+        value: 'true'
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    startupProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 20
+    terminationGracePeriodSeconds: 300
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        enable: true
+        force: true
+        deleteEmptyDir: true
+        timeoutSeconds: 300
+        podSelector: ''
+      maxParallelUpgrades: 2

--- a/nvidia-network-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nvidia-network-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-gpu-operator
+resources:
+  - ../../base
+patches:
+  - path: nicpolicy/nicpolicy_patch.yaml

--- a/nvidia-network-operator/overlays/nerc-ocp-test/nicpolicy/nicpolicy_patch.yaml
+++ b/nvidia-network-operator/overlays/nerc-ocp-test/nicpolicy/nicpolicy_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-H100-80GB-HBM3


### PR DESCRIPTION
This patch does the following:

1. Creates a new bundle, `nvidia-network-operator`, for installing the NVIDIA network operator.
2. Adds the nvidia-network-operator bundle to the `nerc-ocp-test` cluster as part of testing RDMA.
3. Adds initial NIC policy for `nerc-ocp-test` RDMA testing.