### PR TITLE
feat: add alert for pending PVCs (# 840)

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -8,6 +8,7 @@ data:
     names:
       - kube_persistentvolumeclaim_resource_requests_storage_bytes
       - kube_persistentvolumeclaim_info
+      - kube_persistentvolumeclaim_status_phase
       - kube_storageclass_info
       - kubelet_volume_stats_used_bytes
       - node_memory_MemTotal_bytes

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -21,6 +21,17 @@ data:
           labels:
             severity: critical
 
+        - alert: CustomStoragePersistentVolumeClaimPending
+          annotations:
+            summary: "{{ $labels.cluster }} PersistentVolumeClaim is pending"
+            description: |
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?schemaVersion=1&panes=%7B%227rs%22:%7B%22datasource%22:%22a0fa9d88-8932-41f7-af80-6f678d4fb1e7%22,%22queries%22:%5B%7B%22exemplar%22:true,%22expr%22:%22kube_persistentvolumeclaim_status_phase%7Bphase%3D%5C%22Pending%5C%22%7D%20%3D%3D%201%22,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22a0fa9d88-8932-41f7-af80-6f678d4fb1e7%22%7D,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1|Click here to see these metrics in Observability Monitoring>
+              PersistentVolumeClaim {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has been in Pending state for more than 5 minutes.
+          expr: kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1
+          for: 5m
+          labels:
+            severity: warning
+
 
       - name: ceph-storage
         rules:


### PR DESCRIPTION
fixes https://github.com/nerc-project/operations/issues/840

# feat: add alert for pending PVCs [#840](https://github.com/nerc-project/operations/issues/840)

## Why this change was necessary:
PVCs that remain in Pending state indicate storage provisioning problems that need quick attention.
Without this alert such issues could go unnoticed for longer time, what impacts the users.

## Key changes:
- Add kube_persistentvolumeclaim_status_phase to metrics allowlist
- Add CustomStoragePersistentVolumeClaimPending alert with 5min threshold
- Update Grafana exploration URL to new obs.nerc.mghpcc.org domain

Fixes: nerc-project/operations/issues/840

Triggered by: nerc-project/operations#840

Connected to: n/a