### PR TITLE
ocp-test: enable RDMA in nvidia cluster policy

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -9,6 +9,9 @@ spec:
     config:
       default: all-disabled
       name: test-mig-parted-config
+  driver:
+    rdma:
+      enabled: true
   daemonsets:
     tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
This enables RDMA in the NVIDIA GPU cluster policy now that the nvidia-network-operator is functional with nicclusterpolicy in place.