### PR TITLE
ocp-test: add sriov network operator and config

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: sriov-network-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: openshift-sriov-network-operator
+resources:
+- ../../base/core/namespaces/openshift-sriov-network-operator
+- ../../base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator
+- ../../base/operators.coreos.com/subscriptions/openshift-sriov-network-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../../bundles/patch-operator
 - ../../bundles/nvidia-gpu-operator
 - ../../bundles/nvidia-network-operator
+- ../../bundles/openshift-sriov-network-operator
 - ../../bundles/koku-metrics-operator
 - ../../bundles/kubernetes-image-puller-operator
 - ../../bundles/curator

--- a/openshift-sriov-network-operator/base/kustomization.yaml
+++ b/openshift-sriov-network-operator/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+  - sriovoperatorconfig.yaml

--- a/openshift-sriov-network-operator/base/sriovoperatorconfig.yaml
+++ b/openshift-sriov-network-operator/base/sriovoperatorconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+spec:
+  configurationMode: daemon
+  disableDrain: false
+  enableInjector: true
+  enableOperatorWebhook: true
+  featureGates:
+    resourceInjectorMatchCondition: true
+  logLevel: 2

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
   - networkattachmentdefinitions
+  - sriovnetworknodepolicies

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+  - ../../base

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
-  - networkattachmentdefinitions
+  - lenovo-sd665nv3-h100

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - network-cx7-nic3.yaml
+  - network-cx7-nic4.yaml
+  - network-cx7-nic5.yaml
+  - network-cx7-nic6.yaml

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
@@ -1,0 +1,34 @@
+
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic3
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic3
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic3",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.5.0/24",
+        "exclude": [
+          "192.168.5.1",
+          "192.168.5.2",
+          "192.168.5.254",
+          "192.168.5.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.5.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic4.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic4.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic4
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic4
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic4",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.6.0/24",
+        "exclude": [
+          "192.168.6.1",
+          "192.168.6.2",
+          "192.168.6.254",
+          "192.168.6.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.6.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic5.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic5.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic5
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic5
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic5",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.7.0/24",
+        "exclude": [
+          "192.168.7.1",
+          "192.168.7.2",
+          "192.168.7.254",
+          "192.168.7.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.7.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic6.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic6.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic6
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic6
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic6",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.8.0/24",
+        "exclude": [
+          "192.168.8.1",
+          "192.168.8.2",
+          "192.168.8.254",
+          "192.168.8.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.8.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - lenovo-sd665nv3-h100

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic3.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic3.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic3
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic3
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic3
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic4.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic4.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic4
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic4
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic4
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic5.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic5.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic5
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic5
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic5
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic6.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic6.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic6
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic6
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic6
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-test/sriovnetworknodepolicies/lenovo-sd665nv3-h100/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+  - cx7-nic3.yaml
+  - cx7-nic4.yaml
+  - cx7-nic5.yaml
+  - cx7-nic6.yaml


### PR DESCRIPTION
This patch does the following:

1. Adds a new `openshift-sriov-network-operator` bundle that installs the operator namespace, operatorgroup, and subscription.
2. Adds the `openshift-sriov-network-operator` bundle to the `nerc-ocp-test` cluster.
3. Adds a top-level directory `openshift-sriov-network-operator` that contains the default SRIOVOperatorConfig manifest.
4. Adds an overlay to `openshift-sriov-network-operator` to configure SRIOV on the `nerc-ocp-test` cluster.