### PR TITLE
ocp-test: patch test clusterversion to match ocp-prod

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -6,4 +6,4 @@ spec:
   channel: stable-4.19
   clusterID: 2b3d6e03-1bfe-4d1e-bf32-3e2df96fc2bd
   desiredUpdate:
-    version: 4.19.6
+    version: 4.19.9


### PR DESCRIPTION
This resolves the first step in https://github.com/nerc-project/operations/issues/1346 Confirmed all clusteroperators are happpy prior to this commit

From here we can be sure we're on level ground with prod to update test cluster to OCP 4.20