### PR TITLE
ocp-test: upgrade to OCP v4.19.22

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -6,4 +6,4 @@ spec:
   channel: stable-4.19
   clusterID: 2b3d6e03-1bfe-4d1e-bf32-3e2df96fc2bd
   desiredUpdate:
-    version: 4.19.9
+    version: 4.19.22


### PR DESCRIPTION
Second minor upgrade on route to v4.20
Addresses: [https://github.com/nerc-project/operations/issues/1346](https://github.com/nerc-project/operations/issues/1346)