### PR TITLE
authorino: use stable channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/authorino-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: authorino-operator
   namespace: openshift-operators
 spec:
-  channel: tech-preview-v1
+  channel: stable
   installPlanApproval: Automatic
   name: authorino-operator
   source: redhat-operators

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -154,16 +154,6 @@ patches:
       value: stable-6.2
 - target:
     kind: Subscription
-    name: authorino-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable
-    - op: replace
-      path: /spec/startingCSV
-      value: authorino-operator.v1.2.3
-- target:
-    kind: Subscription
     name: rhods-operator
   patch: |
     - op: replace


### PR DESCRIPTION
The ocp-edu cluster RHOAI model-registry-operator-controller-manager pod is having issues fetching a newer version of the authorino API causing it to go into a crashloopbackoff state:
```
failed to get API group resources: unable to retrieve the complete list of server APIs: authorino.kuadrant.io/v1beta3: the server could not find the requested resource
```
This patch removes the need to patch the authorino subscription in the nerc-ocp-prod overlay.