### PR TITLE
Upgrade ocp-test cluster to 4.20

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -6,4 +6,4 @@ spec:
   channel: stable-4.19
   clusterID: 2b3d6e03-1bfe-4d1e-bf32-3e2df96fc2bd
   desiredUpdate:
-    version: 4.19.22
+    version: 4.20.12

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -60,6 +60,7 @@ configMapGenerator:
   behavior: merge
   literals:
     - ack-4.18-kube-1.32-api-removals-in-4.19=true
+    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
Upgrade ocp-test cluster to 4.20
ocp-test: Provide admin acks for test cluster upgrade
Confirmed removed apis are not being served in cluster
See https://access.redhat.com/articles/7130599