### PR TITLE
Add NAIRR2025 status reports to ai-telemetry project static content

### DIFF
--- a/ai-telemetry/base/aitelemetry/site/deployment.yaml
+++ b/ai-telemetry/base/aitelemetry/site/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       volumes:
         - name: "ai-telemetry-developer"
           emptyDir: {}
+        - name: "nairr"
+          emptyDir: {}
       initContainers:
         - resources: {}
           terminationMessagePath: /dev/termination-log
@@ -27,6 +29,8 @@ spec:
           volumeMounts:
             - name: "ai-telemetry-developer"
               mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+            - name: "nairr"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025"
           terminationMessagePolicy: File
           envFrom:
             - secretRef:
@@ -35,6 +39,7 @@ spec:
           args:
             - >-
               git clone https://computate.org:$GITHUB_DEVELOPERS_TOKEN@github.com/computate-org/ai-telemetry-developer.git /home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer;
+              git clone https://computate:$GITHUB_PERSONAL_TOKEN@github.com/computate/NAIRR2025.git /home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025;
       containers:
         - name: aitelemetry
           image: 'quay.io/nerc-images/ai-telemetry:latest'
@@ -72,6 +77,8 @@ spec:
           volumeMounts:
             - name: "ai-telemetry-developer"
               mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+            - name: "nairr"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025"
           env:
             - name: ENABLE_ZOOKEEPER_CLUSTER
               value: 'true'

--- a/ai-telemetry/base/aitelemetry/worker/deployment.yaml
+++ b/ai-telemetry/base/aitelemetry/worker/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       volumes:
         - name: "ai-telemetry-developer"
           emptyDir: {}
+        - name: "nairr"
+          emptyDir: {}
       initContainers:
         - resources: {}
           terminationMessagePath: /dev/termination-log
@@ -26,6 +28,8 @@ spec:
           volumeMounts:
             - name: "ai-telemetry-developer"
               mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+            - name: "nairr"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025"
           terminationMessagePolicy: File
           envFrom:
             - secretRef:
@@ -34,6 +38,7 @@ spec:
           args:
             - >-
               git clone https://computate.org:$GITHUB_DEVELOPERS_TOKEN@github.com/computate-org/ai-telemetry-developer.git /home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer;
+              git clone https://computate:$GITHUB_PERSONAL_TOKEN@github.com/computate/NAIRR2025.git /home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025;
       containers:
         - name: aitelemetry
           image: 'quay.io/nerc-images/ai-telemetry:latest'
@@ -71,6 +76,8 @@ spec:
           volumeMounts:
             - name: "ai-telemetry-developer"
               mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/ai-telemetry-developer"
+            - name: "nairr"
+              mountPath: "/home/default/ai-telemetry-static/webawesome/templates/en-us/user/project/NAIRR2025"
           env:
             - name: ENABLE_ZOOKEEPER_CLUSTER
               value: 'false'


### PR DESCRIPTION
This automatically imports NAIRR markdown files with corresponding
metadata for result.extends super page template, result.hubId,
result.clusterName, and result.projectName to correctly patch the
project with the right markdown template file path for status updates.

```md
---
result.extends: en-us/Article.htm
result.hubId: moc
result.clusterName: nerc-ocp-prod
result.projectName: "reliability-for-llm-agents-3fc129"
---

# Reliability for LLM Agents
```