### PR TITLE
ocp-test: set clusterversion channel=stable-4.20

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.19
+  channel: stable-4.20
   clusterID: 2b3d6e03-1bfe-4d1e-bf32-3e2df96fc2bd
   desiredUpdate:
     version: 4.20.12


### PR DESCRIPTION
Minor fix to #865 caught by @IsaiahStapleton 