### PR TITLE
ocp-infra: bump argocd controller memory

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -4,6 +4,12 @@ metadata:
   name: openshift-gitops
   namespace: openshift-gitops
 spec:
+  controller:
+    resources:
+      limits:
+        memory: 20Gi
+      requests:
+        memory: 15Gi
   server:
     insecure: true
     route:


### PR DESCRIPTION
The controller pod is crashing with OOMKiller status. Monitoring it appears to need ~13Gi memory. Bumping to 15Gi with a limit of 20Gi.