### PR TITLE
ocp-infra: bump argocd controller cpu

### DIFF
--- a/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/patches/argocds/openshift-gitops.yaml
@@ -7,8 +7,10 @@ spec:
   controller:
     resources:
       limits:
+        cpu: "8"
         memory: 20Gi
       requests:
+        cpu: "4"
         memory: 15Gi
   server:
     insecure: true


### PR DESCRIPTION
The controller pod appears to consistently use most of its limit of 2 CPUs. While this isn't causing any crashes, it likely will perform better with more CPU. This bumps the request to 4 CPUs with a limit of 8 CPUs.

```
$ oc adm top pods -n openshift-gitops
...
openshift-gitops-application-controller-0                    1977m        12530Mi
...
```