### PR TITLE
ocp-test: upgrade ODF operator to stable-4.20

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
   name: odf-operator
 spec:
-  channel: stable-4.19
+  channel: stable-4.20


### PR DESCRIPTION
This is required now that the ocp-test cluster is running 4.20.12