### PR TITLE
NVIDIA GPU Driver Version Pinning

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-operator-certified
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -138,3 +138,10 @@ patches:
     - op: replace
       path: /spec/channel
       value: stable-1.36
+- target:
+    kind: Subscription
+    name: gpu-operator-certified
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: v25.10

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -10,6 +10,9 @@ spec:
       default: all-disabled
       name: test-mig-parted-config
   driver:
+    upgradePolicy:
+      autoUpgrade: true
+    version: "580.105.08"
     rdma:
       enabled: true
   daemonsets:


### PR DESCRIPTION
The NVIDIA driver version is dependent on either version pinning in the clusterpolicy or, in the absence of a version pin, the version of the GPU operator that's installed. This patch disables automatic upgrades, uses a version-specific subscription channel, and pins the version for the current operator version in the cluster policy in order to prevent unplanned driver upgrades on nodes. This will allow us to keep `autoUpgrade: true` in the cluster policy without fear of user workloads being interrupted due to unintended driver updates.

This patch first tests this new setup on ocp-test. If it works without issue we'll apply to prod and edu clusters as well.

The default NVIDIA driver version used by a given version of the NVIDIA GPU operator can be found in the GPU operator component matrix:

https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html

See: 
https://github.com/nerc-project/operations/issues/1249
https://github.com/nerc-project/operations/issues/768