### PR TITLE
ocp-test: add repository and image to clusterpolicy

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -13,6 +13,8 @@ spec:
     upgradePolicy:
       autoUpgrade: true
     version: "580.105.08"
+    repository: "nvcr.io/nvidia"
+    image: "driver"
     rdma:
       enabled: true
   daemonsets:


### PR DESCRIPTION
Minor fix to https://github.com/OCP-on-NERC/nerc-ocp-config/pull/871

These settings are required when overriding/pinning the version used by the operator.

See:

https://github.com/NVIDIA/gpu-operator/issues/585