### PR TITLE
nerc-ocp-prod H100 RDMA support

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -9,6 +9,8 @@ spec:
     version: "580.126.20"
     repository: "nvcr.io/nvidia"
     image: "driver"
+    rdma:
+      enabled: true
   daemonsets:
     tolerations:
     - effect: NoSchedule

--- a/nvidia-network-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nvidia-network-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-gpu-operator
+resources:
+  - ../../base
+patches:
+  - path: nicpolicy/nicpolicy_patch.yaml

--- a/nvidia-network-operator/overlays/nerc-ocp-prod/nicpolicy/nicpolicy_patch.yaml
+++ b/nvidia-network-operator/overlays/nerc-ocp-prod/nicpolicy/nicpolicy_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  tolerations:
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-A100-SXM4-40GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: Tesla-V100-PCIE-32GB
+    - effect: NoSchedule
+      key: nvidia.com/gpu.product
+      operator: Equal
+      value: NVIDIA-H100-80GB-HBM3

--- a/nvidia-network-operator/overlays/nerc-ocp-prod/nicpolicy/nicpolicy_patch.yaml
+++ b/nvidia-network-operator/overlays/nerc-ocp-prod/nicpolicy/nicpolicy_patch.yaml
@@ -3,6 +3,8 @@ kind: NicClusterPolicy
 metadata:
   name: nic-cluster-policy
 spec:
+  ofedDriver:
+    version: doca3.2.2-25.10-2.4.1.0-4
   tolerations:
     - effect: NoSchedule
       key: nvidia.com/gpu.product

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - networkattachmentdefinitions
+  - sriovnetworknodepolicies

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - lenovo-sd665nv3-h100

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - network-cx7-nic3.yaml
+  - network-cx7-nic4.yaml
+  - network-cx7-nic5.yaml
+  - network-cx7-nic6.yaml

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic3.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic3
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic3
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic3",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.5.0/24",
+        "exclude": [
+          "192.168.5.1",
+          "192.168.5.2",
+          "192.168.5.254",
+          "192.168.5.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.5.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic4.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic4.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic4
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic4
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic4",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.6.0/24",
+        "exclude": [
+          "192.168.6.1",
+          "192.168.6.2",
+          "192.168.6.254",
+          "192.168.6.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.6.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic5.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic5.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic5
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic5
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic5",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.7.0/24",
+        "exclude": [
+          "192.168.7.1",
+          "192.168.7.2",
+          "192.168.7.254",
+          "192.168.7.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.7.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic6.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/networkattachmentdefinitions/lenovo-sd665nv3-h100/network-cx7-nic6.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: network-cx7-nic6
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/cx7_nic6
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "network-cx7-nic6",
+      "type": "sriov",
+      "vlan": 0,
+      "vlanQoS": 0,
+      "logLevel": "info",
+      "isRDMA": true,
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.8.0/24",
+        "exclude": [
+          "192.168.8.1",
+          "192.168.8.2",
+          "192.168.8.254",
+          "192.168.8.255"
+        ],
+        "routes": [
+          {
+            "dst": "192.168.8.0/24"
+          }
+        ]
+      }
+    }

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - lenovo-sd665nv3-h100

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic3.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic3.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic3
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic3
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic3
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic4.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic4.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic4
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic4
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic4
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic5.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic5.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic5
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic5
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic5
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic6.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/cx7-nic6.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: cx7-nic6
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: cx7_nic6
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  mtu: 9000
+  numVfs: 1
+  nicSelector:
+    pfNames:
+      - nic6
+    vendor: "15b3"
+    deviceID: "1021"
+  deviceType: netdevice
+  isRdma: true
+  linkType: eth

--- a/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/kustomization.yaml
+++ b/openshift-sriov-network-operator/overlays/nerc-ocp-prod/sriovnetworknodepolicies/lenovo-sd665nv3-h100/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-sriov-network-operator
+resources:
+  - cx7-nic3.yaml
+  - cx7-nic4.yaml
+  - cx7-nic5.yaml
+  - cx7-nic6.yaml


### PR DESCRIPTION
This patch does the following to enable RDMA support on the H100 worker nodes in the `nerc-ocp-prod` cluster:

- ~~reconfigure NICs on H100 nodes for RDMA support via udev rules~~ (done via #911)
- ~~add nvidia-network-operator and openshift-sriov-network-operator bundles~~ (done via #911)
- add nicclusterpolicy manifest for OFED drivers via nvidia-network-operator
- add SRIOV manifests for RDMA support on H100s