### PR TITLE
nerc-ocp-prod: upgrade nvidia operator to v25.10 and pin NVIDIA driver version

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -169,7 +169,7 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: v25.3
+      value: v25.10
 - target:
     kind: Subscription
     name: serverless-operator

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -3,6 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: gpu-cluster-policy
 spec:
+  driver:
+    upgradePolicy:
+      autoUpgrade: true
+    version: "580.105.08"
+    repository: "nvcr.io/nvidia"
+    image: "driver"
   daemonsets:
     tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
For merge during 20260410 maintenance.

This patch upgrades the NVIDIA GPU operator version on the `nerc-ocp-prod` cluster to v25.10.1. It also pins the NVIDIA driver version used by the operator to the same default version provided by v25.10.1 of the operator: `580.105.08`. Finally, it enables `autoUpgrade: true` in the clusterpolicy to allow adding new GPU nodes to the cluster outside of maintenance events. This is possible to do without interrupting existing end-user GPU workloads now that the operator installplan is set to Manual and driver version pinning is in place (ie driver versions won't change "below" us due to unattended operator upgrades).