### PR TITLE
ocp-prod: upgrade to OpenShift v4.20.15

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/clusterversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.19
+  channel: stable-4.20
   desiredUpdate:
-    version: 4.19.24
+    version: 4.20.15
   clusterID: fcb727d6-3e61-4d23-913d-756cf41c7982

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -76,6 +76,7 @@ configMapGenerator:
     - ack-4.13-kube-1.27-api-removals-in-4.14=true
     - ack-4.15-kube-1.29-api-removals-in-4.16=true
     - ack-4.18-kube-1.32-api-removals-in-4.19=true
+    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config


### PR DESCRIPTION
To be merged after https://github.com/OCP-on-NERC/nerc-ocp-config/pull/877 during 20260410 maintenance.

<img width="754" height="219" alt="Screenshot 2026-03-10 at 9 16 13 AM" src="https://github.com/user-attachments/assets/25db4bdc-1eb5-433e-8858-af56d47b9293" />

