### PR TITLE
ocp-test: add strimzi-kafka-operator bundle for testing

### DIFF
--- a/cluster-scope/base/core/namespaces/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/strimzi-kafka-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/strimzi-kafka-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/strimzi-kafka-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: strimzi-kafka-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: strimzi-kafka-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/operatorgroup.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: strimzi-kafka-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: strimzi-kafka-operator
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: strimzi-kafka-operator
+  namespace: strimzi-kafka-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: strimzi-kafka-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: strimzi-kafka-operator
+resources:
+- ../../base/core/namespaces/strimzi-kafka-operator
+- ../../base/operators.coreos.com/operatorgroups/strimzi-kafka-operator
+- ../../base/operators.coreos.com/subscriptions/strimzi-kafka-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -45,6 +45,7 @@ resources:
 - ../../bundles/authorino-operator
 - ../../bundles/servicemesh-operator
 - ../../bundles/cluster-observability-operator
+- ../../bundles/strimzi-kafka-operator
 
 components:
   - ../../components/nerc-oauth-github
@@ -145,3 +146,10 @@ patches:
     - op: replace
       path: /spec/channel
       value: v25.10
+- target:
+    kind: Subscription
+    name: strimzi-kafka-operator
+  patch: |
+    - op: replace
+      path: /spec/channel
+      value: strimzi-0.50.x


### PR DESCRIPTION
This patch adds a new operator bundle, strimzi-kafka-operator, and installs this operator on the ocp-test cluster for testing. This testing is in preparation for installing the operator on the EDU cluster for course use.

Github: https://github.com/strimzi/strimzi-kafka-operator
Web: https://strimzi.io/
