### PR TITLE
feat(observability): add cronjob metrics to allowlist

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -50,7 +50,7 @@ data:
       - __name__=~"^argocd_.*"
 
       # Consolidate kube*:
-      - __name__=~"^kube_(?:node|pod|job|namespace)_.*"
+      - __name__=~"^kube_(?:node|pod|job|cronjob|namespace)_.*"
       - __name__=~"^mco_.*"
       - __name__=~"^llm_load_test_.*"
       - __name__=~"^vllm:.*"


### PR DESCRIPTION
Why this change was necessary:
CronJob monitoring was not possible because kube_cronjob_* metrics where not included in the ACM observability metrics allowlist. This prevents proper monitoring of scheduled jobs and their execution status.

Key changes:

- Extended kube metrics regex pattern from "node|pod|job|namespace" to include "cronjob"

- This enables collection of all kube_cronjob_* metrics trough ACM observability

Fixes: nerc-project/operations#1491

Triggered by: nerc-project/operations#1491

Connected to: n/a