### PR TITLE
feat(observability): add cronjob monitoring alerts

### DIFF
--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -482,6 +482,46 @@ data:
         - record: gpu:active_hourly:count_per_cluster
           expr: count by (cluster) (gpu:active_hourly:raw > 0)
 
+      - name: cronjob-monitoring
+        rules:
+
+        - alert: CustomCronJobNotRunningRecently
+          annotations:
+            summary: "{{ $labels.cluster }} CronJob {{ $labels.cronjob }} hasn't run recently"
+            description: |
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-24h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(time()%20-%20kube_cronjob_status_last_schedule_time)%20%3E%20(6%20*%203600)%20and%20kube_cronjob_spec_suspend%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} hasn't run successfully for {{ $value | humanizeDuration }}.
+              This could indicate the CronJob is stuck, failing silently, or the schedule is not being honored.
+          expr: (time() - kube_cronjob_status_last_schedule_time) > (6 * 3600) and kube_cronjob_spec_suspend == 0
+          for: 10m
+          labels:
+            severity: warning
+
+        - alert: CustomCronJobFailed
+          annotations:
+            summary: "{{ $labels.cluster }} CronJob {{ $labels.job_name }} failed"
+            description: |
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22kube_job_status_failed%7Bjob_name%3D~%5C%22.*cronjob.*%5C%22%7D%20%3E%200%20and%20kube_job_status_succeeded%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Job {{ $labels.job_name }} (created by CronJob) in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has failed.
+              Failed pods: {{ $value }}
+              Check pod logs for error details.
+          expr: kube_job_status_failed{job_name=~".*cronjob.*"} > 0 and kube_job_status_succeeded == 0
+          for: 5m
+          labels:
+            severity: critical
+
+        - alert: CustomCronJobMissedSchedule
+          annotations:
+            summary: "{{ $labels.cluster }} CronJob {{ $labels.cronjob }} missed its schedule"
+            description: |
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22increase(kube_cronjob_status_last_schedule_time%5B1h%5D)%20%3D%3D%200%20and%20kube_cronjob_spec_suspend%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has not been scheduled in the last 2 hours despite not being suspended.
+              This could indicate the CronJob controller is not functioning properly or the schedule configuration is incorrect.
+          expr: increase(kube_cronjob_status_last_schedule_time[1h]) == 0 and kube_cronjob_spec_suspend == 0
+          for: 2h
+          labels:
+            severity: warning
+
       - name: IBM autopilot
         rules:
         - alert: LowPCIeBandwidth

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/configmap.yaml
@@ -487,25 +487,31 @@ data:
 
         - alert: CustomCronJobNotRunningRecently
           annotations:
-            summary: "{{ $labels.cluster }} CronJob {{ $labels.cronjob }} hasn't run recently"
+            summary: "{{ $labels.cluster }} CronJob {{ $labels.cronjob }} hasn't been scheduled recently"
             description: |
               <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-24h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22(time()%20-%20kube_cronjob_status_last_schedule_time)%20%3E%20(6%20*%203600)%20and%20kube_cronjob_spec_suspend%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
-              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} hasn't run successfully for {{ $value | humanizeDuration }}.
-              This could indicate the CronJob is stuck, failing silently, or the schedule is not being honored.
+              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} hasn't been scheduled for {{ $value | humanizeDuration }}.
+              Note: this alert is based on kube_cronjob_status_last_schedule_time and reflects when the CronJob was last triggered, not whether the last run succeeded.
+              This could indicate the CronJob controller is not triggering the schedule as expected.
           expr: (time() - kube_cronjob_status_last_schedule_time) > (6 * 3600) and kube_cronjob_spec_suspend == 0
           for: 10m
           labels:
-            severity: warning
+            severity: critical
 
         - alert: CustomCronJobFailed
           annotations:
-            summary: "{{ $labels.cluster }} CronJob {{ $labels.job_name }} failed"
+            summary: "{{ $labels.cluster }} CronJob {{ $labels.owner_name }} job failed"
             description: |
-              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22kube_job_status_failed%7Bjob_name%3D~%5C%22.*cronjob.*%5C%22%7D%20%3E%200%20and%20kube_job_status_succeeded%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
-              Job {{ $labels.job_name }} (created by CronJob) in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has failed.
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22kube_job_status_failed%20%3E%200%20and%20on(cluster%2Cnamespace%2Cjob_name)%20group_left(owner_name)%20kube_job_owner%7Bowner_kind%3D%22CronJob%22%7D%20and%20on(cluster%2Cnamespace%2Cjob_name)%20kube_job_status_succeeded%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              Job {{ $labels.job_name }} (owned by CronJob {{ $labels.owner_name }}) in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has failed.
               Failed pods: {{ $value }}
+              Note: kube_job_status_succeeded == 0 ensures alerts only fire for jobs with no successful pod completions.
+              Jobs that eventually succeeded after retries (succeeded >= 1) are excluded, even if some pods failed along the way.
               Check pod logs for error details.
-          expr: kube_job_status_failed{job_name=~".*cronjob.*"} > 0 and kube_job_status_succeeded == 0
+          expr: |
+            kube_job_status_failed > 0
+            and on(cluster, namespace, job_name) group_left(owner_name) kube_job_owner{owner_kind="CronJob"}
+            and on(cluster, namespace, job_name) kube_job_status_succeeded == 0
           for: 5m
           labels:
             severity: critical
@@ -514,11 +520,11 @@ data:
           annotations:
             summary: "{{ $labels.cluster }} CronJob {{ $labels.cronjob }} missed its schedule"
             description: |
-              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22increase(kube_cronjob_status_last_schedule_time%5B1h%5D)%20%3D%3D%200%20and%20kube_cronjob_spec_suspend%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
-              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has not been scheduled in the last 2 hours despite not being suspended.
+              <https://grafana.apps.obs.nerc.mghpcc.org/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22Observatorium%22,%7B%22exemplar%22:true,%22expr%22:%22time()%20-%20kube_cronjob_status_last_schedule_time%20%3E%202%20*%2060%20*%2060%20and%20kube_cronjob_spec_suspend%20%3D%3D%200%22%7D%5D|Click here to see these metrics in Observability Monitoring>
+              CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} has not been scheduled in over 2 hours despite not being suspended.
               This could indicate the CronJob controller is not functioning properly or the schedule configuration is incorrect.
-          expr: increase(kube_cronjob_status_last_schedule_time[1h]) == 0 and kube_cronjob_spec_suspend == 0
-          for: 2h
+          expr: time() - kube_cronjob_status_last_schedule_time > 2 * 60 * 60 and kube_cronjob_spec_suspend == 0
+          for: 10m
           labels:
             severity: warning
 

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -109,6 +109,13 @@ spec:
                 repeat_interval: 1d
                 matchers:
                   - alertname =~ "(LowPCIeBandwidth|DCGMLevel1Errors|GPUPowerSlowdownEnabled|RemappedRowsActive|DCGMLevel3Errors|PingFailures|PVCAlert|GPUNodeHealth|AutopilotPodsFailing)"
+              - receiver: slack-notifications
+                group_by: [cluster, alertname, namespace, cronjob, job_name]
+                group_wait: 5m
+                group_interval: 1h
+                repeat_interval: 4h
+                matchers:
+                  - alertname =~ "(CustomCronJobNotRunningRecently|CustomCronJobFailed|CustomCronJobMissedSchedule)"
 
           receivers:
           - name: default

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-alertmanager-config/externalsecret.yaml
@@ -110,7 +110,7 @@ spec:
                 matchers:
                   - alertname =~ "(LowPCIeBandwidth|DCGMLevel1Errors|GPUPowerSlowdownEnabled|RemappedRowsActive|DCGMLevel3Errors|PingFailures|PVCAlert|GPUNodeHealth|AutopilotPodsFailing)"
               - receiver: slack-notifications
-                group_by: [cluster, alertname, namespace, cronjob, job_name]
+                group_by: [cluster, alertname, namespace, cronjob, owner_name]
                 group_wait: 5m
                 group_interval: 1h
                 repeat_interval: 4h


### PR DESCRIPTION
### Why this change was necessary:
The billing CronJobs were failing silently for weeks without any detection mechanism. This created a critical gap in operations where important scheduled tasks could fail wihtout anyone noticing. We had no visibility when CronJobs stop running, fail to execute, or miss their scheduled times.

### Key changes:
- Add three new PrometheusRule alerts in thanos-ruler-custom-rules for CronJob monitoring
- Add CustomCronJobNotRunningRecently alert (warning severity, 6+ hours threshold)
- Add CustomCronJobFailed alert (critical severity, 5min threshold)
- Add CustomCronJobMissedSchedule alert (warning severity, 2 hour threshold)
- Configure AlertManager routing to send CronJob alerts to #alerts-nerc-ocp Slack channel
- Set group_by parameters for proper alert grouping by cluster, alertname, namespace, cronjob, and job_name
- Configure repeat_interval of 4h to avoid alert fatigue while maintaining awareness

Fixes: nerc-project/operations#1491

Triggered by: Silent billing CronJob failures that occured for several weeks unnoticed

Connected to: n/a