### PR TITLE
ocp-prod: add strimzi kafka operator

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
 - ../../bundles/elasticsearch-eck-operator
 - ../../bundles/nagios-monitoring
 - ../../bundles/allow-list-crds
+- ../../bundles/strimzi-kafka-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit


### PR DESCRIPTION
This installs the [Strimzi Operator](https://strimzi.io/) on the NERC OCP Prod cluster. This has already been tested and is in use on the EDU cluster. This is required to run a Kafka cluster on NERC, as [explained here](https://nerc-project.github.io/nerc-docs/other-tools/kafka/kafka-on-openshift/).