### PR TITLE
disable dashboard

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/odhdashboardconfigs/odh-dashboard-config.yaml
@@ -48,7 +48,7 @@ spec:
         cpu: "6"
         memory: 16Gi
   notebookController:
-    enabled: true
+    enabled: false
     notebookNamespace: rhods-notebooks
     pvcSize: 20Gi
   notebookSizes:


### PR DESCRIPTION
Disable dashboard on production cluster so students no longer have access to the dashboard. Was turned on briefly for testing prod.