### PR TITLE
Replace deprecated commonLabels syntax with labels syntax

### DIFF
--- a/.github/workflows/check-policy.yaml
+++ b/.github/workflows/check-policy.yaml
@@ -1,0 +1,16 @@
+name: Check policy
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Check policy
+        run: |
+          ./ci/check-policy.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: check-added-large-files
-        exclude: '^cluster-scope/base/openapi/openshift-api-schema.json$'
+        exclude: "^cluster-scope/base/openapi/openshift-api-schema.json$"
       - id: check-case-conflict
       - id: check-json
       - id: check-symlinks
@@ -23,4 +23,12 @@ repos:
       - id: yamllint
         files: \.(yaml|yml)$
         types: [file, yaml]
-        entry: yamllint --strict
+
+  - repo: local
+    hooks:
+      - id: prohibit-commonlabels
+        name: Prohibit commonLabels
+        entry: ./ci/prohibit-commonlabels.sh
+        language: script
+        files: |-
+          kustomization.ya?ml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.6
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: v1.38.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,3 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true

--- a/acct-mgt/base/kustomization.yaml
+++ b/acct-mgt/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: acct-mgt
-commonLabels:
-  app: acct-mgt
 resources:
-  - configmaps.yaml
-  - deployment.yaml
-  - route.yaml
-  - service.yaml
-  - serviceaccount.yaml
+- configmaps.yaml
+- deployment.yaml
+- route.yaml
+- service.yaml
+- serviceaccount.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: acct-mgt

--- a/acct-mgt/base/kustomization.yaml
+++ b/acct-mgt/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: acct-mgt
-commonLabels:
-  app: acct-mgt
 resources:
   - configmaps.yaml
   - deployment.yaml
   - route.yaml
   - service.yaml
   - serviceaccount.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: acct-mgt

--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/kustomization.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - configmap.yaml
+  - configmap.yaml

--- a/acm-observability/base/kustomization.yaml
+++ b/acm-observability/base/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      nerc.mghpcc.org/kustomized: "true"
+  - includeSelectors: true
+    pairs:
       app.kubernetes.io/component: acm-observability
-    includeSelectors: true
+      nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - core/configmaps/observability-metrics-custom-allowlist/

--- a/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/kustomization.yaml
+++ b/acm-observability/overlays/nerc-ocp-infra/configmaps/thanos-ruler-custom-rules/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - configmap.yaml
+  - configmap.yaml

--- a/acm/base/kustomization.yaml
+++ b/acm/base/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
 - metal3.io/provisionings/provisioning-configuration/provisioning.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/acm/base/kustomization.yaml
+++ b/acm/base/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
-- metal3.io/provisionings/provisioning-configuration/provisioning.yaml
+  - agent-install.openshift.io/agentserviceconfigs/agent/agentserviceconfig.yaml
+  - metal3.io/provisionings/provisioning-configuration/provisioning.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/acm/overlays/nerc-ocp-infra/clusters/hypershift1/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/hypershift1/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- klusterletaddonconfig.yaml
-- managedcluster.yaml
+  - klusterletaddonconfig.yaml
+  - managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-edu/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-edu/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- klusterletaddonconfig.yaml
-- managedcluster.yaml
+  - klusterletaddonconfig.yaml
+  - managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-obs/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-obs/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- klusterletaddonconfig.yaml
-- managedcluster.yaml
+  - klusterletaddonconfig.yaml
+  - managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-prod/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-prod/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- klusterletaddonconfig.yaml
-- managedcluster.yaml
+  - klusterletaddonconfig.yaml
+  - managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/clusters/nerc-ocp-test/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- klusterletaddonconfig.yaml
-- managedcluster.yaml
+  - klusterletaddonconfig.yaml
+  - managedcluster.yaml

--- a/acm/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,15 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
+
+
+# See https://rcarrata.com/openshift/argo-and-acm/
 
 resources:
 - ../../base
-
-# See https://rcarrata.com/openshift/argo-and-acm/
 - gitopscluster/argocd-managed.yaml
 - managedclustersetbindings/argocd-managed.yaml
 - managedclustersets/argocd-managed.yaml
 - placements/argocd-managed.yaml
-
 - clusters
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/acm/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/acm/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,15 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
-
-resources:
-- ../../base
 
 # See https://rcarrata.com/openshift/argo-and-acm/
-- gitopscluster/argocd-managed.yaml
-- managedclustersetbindings/argocd-managed.yaml
-- managedclustersets/argocd-managed.yaml
-- placements/argocd-managed.yaml
 
-- clusters
+resources:
+  - ../../base
+  - gitopscluster/argocd-managed.yaml
+  - managedclustersetbindings/argocd-managed.yaml
+  - managedclustersets/argocd-managed.yaml
+  - placements/argocd-managed.yaml
+  - clusters
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/configmaps/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/configmaps/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- configmap-cloud-setup-playbook.yaml
-- configmap-cloud-setup-defaults.yaml
-- configmap-cloud-setup-tasks.yaml
+  - configmap-cloud-setup-playbook.yaml
+  - configmap-cloud-setup-defaults.yaml
+  - configmap-cloud-setup-tasks.yaml

--- a/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/jobs/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/jobs/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       job: aitelemetry-setup
-    includeSelectors: true
 resources:
-- aitelemetry-setup.yaml
+  - aitelemetry-setup.yaml

--- a/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/serviceaccounts/aitelemetry-setup/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/jobs/aitelemetry-setup/serviceaccounts/aitelemetry-setup/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- serviceaccount.yaml
+  - serviceaccount.yaml

--- a/ai-telemetry/base/aitelemetry/jobs/db-to-solr-sync/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/jobs/db-to-solr-sync/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- job.yaml
+  - job.yaml

--- a/ai-telemetry/base/aitelemetry/jobs/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/jobs/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- db-to-solr-sync/
-- aitelemetry-setup/
+  - db-to-solr-sync/
+  - aitelemetry-setup/

--- a/ai-telemetry/base/aitelemetry/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: aitelemetry
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       app: aitelemetry
       app.kubernetes.io/name: aitelemetry
-    includeSelectors: true
 resources:
   - site/
   - worker/

--- a/ai-telemetry/base/aitelemetry/site/externalsecrets/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/site/externalsecrets/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      deployment: aitelemetry-site
+  - includeSelectors: true
+    pairs:
       app.kubernetes.io/instance: aitelemetry-site
-    includeSelectors: true
+      deployment: aitelemetry-site
 resources:
   - externalsecret-auth.yaml
   - externalsecret-database.yaml

--- a/ai-telemetry/base/aitelemetry/site/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/site/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      deployment: aitelemetry-site
+  - includeSelectors: true
+    pairs:
       app.kubernetes.io/instance: aitelemetry-site
-    includeSelectors: true
+      deployment: aitelemetry-site
 resources:
   - externalsecrets/
   - deployment.yaml

--- a/ai-telemetry/base/aitelemetry/worker/externalsecrets/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/worker/externalsecrets/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      deployment: aitelemetry-worker
+  - includeSelectors: true
+    pairs:
       app.kubernetes.io/instance: aitelemetry-worker
-    includeSelectors: true
+      deployment: aitelemetry-worker
 resources:
   - externalsecret-worker.yaml

--- a/ai-telemetry/base/aitelemetry/worker/kustomization.yaml
+++ b/ai-telemetry/base/aitelemetry/worker/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      deployment: aitelemetry-worker
+  - includeSelectors: true
+    pairs:
       app.kubernetes.io/instance: aitelemetry-worker
-    includeSelectors: true
+      deployment: aitelemetry-worker
 resources:
   - externalsecrets/
   - deployment.yaml

--- a/ai-telemetry/base/kustomization.yaml
+++ b/ai-telemetry/base/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- externalsecrets
-- zookeeper
-- solr
-- postgres
-- kafka
-- aitelemetry
-- persistent-metrics-zookeeper
+  - externalsecrets
+  - zookeeper
+  - solr
+  - postgres
+  - kafka
+  - aitelemetry
+  - persistent-metrics-zookeeper

--- a/ai-telemetry/base/persistent-metrics-zookeeper/kustomization.yaml
+++ b/ai-telemetry/base/persistent-metrics-zookeeper/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zookeeper
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       app: persistent-metrics-zookeeper
       deployment: persistent-metrics-zookeeper
-    includeSelectors: true
 
 resources:
   - deployments/

--- a/ai-telemetry/base/postgres/kustomization.yaml
+++ b/ai-telemetry/base/postgres/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: postgres
 resources:
-- postgrescluster.yaml
+  - postgrescluster.yaml

--- a/ai-telemetry/base/solr/kustomization.yaml
+++ b/ai-telemetry/base/solr/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: solr
 resources:
-- serviceaccounts.yaml
-- rolebindings.yaml
-- deployments.yaml
-- solrclouds.yaml
-- networkpolicies.yaml
+  - serviceaccounts.yaml
+  - rolebindings.yaml
+  - deployments.yaml
+  - solrclouds.yaml
+  - networkpolicies.yaml

--- a/ai-telemetry/base/zookeeper/kustomization.yaml
+++ b/ai-telemetry/base/zookeeper/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zookeeper
 resources:
-- serviceaccounts.yaml
-- configmaps.yaml
-- jobs.yaml
-- rolebindings.yaml
-- deployments.yaml
-- zookeeperclusters.yaml
-- networkpolicies.yaml
+  - serviceaccounts.yaml
+  - configmaps.yaml
+  - jobs.yaml
+  - rolebindings.yaml
+  - deployments.yaml
+  - zookeeperclusters.yaml
+  - networkpolicies.yaml

--- a/ai-telemetry/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/ai-telemetry/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/solr-externalsecret.yaml

--- a/autopilot/base/clusterrolebindings/kustomization.yaml
+++ b/autopilot/base/clusterrolebindings/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot.yaml
-- autopilot-privileged.yaml
-- prometheus-k8s-autopilot.yaml
+  - autopilot.yaml
+  - autopilot-privileged.yaml
+  - prometheus-k8s-autopilot.yaml

--- a/autopilot/base/clusterroles/kustomization.yaml
+++ b/autopilot/base/clusterroles/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot.yaml
-- prometheus-k8s-autopilot.yaml
+  - autopilot.yaml
+  - prometheus-k8s-autopilot.yaml

--- a/autopilot/base/daemonsets/kustomization.yaml
+++ b/autopilot/base/daemonsets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot.yaml
+  - autopilot.yaml

--- a/autopilot/base/kustomization.yaml
+++ b/autopilot/base/kustomization.yaml
@@ -7,7 +7,9 @@ resources:
 - services
 - daemonsets
 - servicemonitors
-commonLabels:
-  app.kubernetes.io/name: autopilot
-  app.kubernetes.io/component: autopilot
-  app.kubernetes.io/part-of: autopilot
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: autopilot
+    app.kubernetes.io/name: autopilot
+    app.kubernetes.io/part-of: autopilot

--- a/autopilot/base/kustomization.yaml
+++ b/autopilot/base/kustomization.yaml
@@ -1,13 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- serviceaccounts
-- clusterroles
-- clusterrolebindings
-- services
-- daemonsets
-- servicemonitors
-commonLabels:
-  app.kubernetes.io/name: autopilot
-  app.kubernetes.io/component: autopilot
-  app.kubernetes.io/part-of: autopilot
+  - serviceaccounts
+  - clusterroles
+  - clusterrolebindings
+  - services
+  - daemonsets
+  - servicemonitors
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: autopilot
+      app.kubernetes.io/name: autopilot
+      app.kubernetes.io/part-of: autopilot

--- a/autopilot/base/serviceaccounts/kustomization.yaml
+++ b/autopilot/base/serviceaccounts/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot.yaml
+  - autopilot.yaml

--- a/autopilot/base/servicemonitors/kustomization.yaml
+++ b/autopilot/base/servicemonitors/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot-metrics-monitor.yaml
+  - autopilot-metrics-monitor.yaml

--- a/autopilot/base/services/kustomization.yaml
+++ b/autopilot/base/services/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- autopilot-metrics-service.yaml
-- autopilot-healthchecks.yaml
-- autopilot-readinessprobe.yaml
+  - autopilot-metrics-service.yaml
+  - autopilot-healthchecks.yaml
+  - autopilot-readinessprobe.yaml

--- a/autopilot/observability/kustomization.yaml
+++ b/autopilot/observability/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafanadashboards
-commonLabels:
-  app.kubernetes.io/name: autopilot
-  app.kubernetes.io/component: autopilot
-  app.kubernetes.io/part-of: autopilot
+- grafanadashboards
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: autopilot
+    app.kubernetes.io/name: autopilot
+    app.kubernetes.io/part-of: autopilot

--- a/autopilot/observability/kustomization.yaml
+++ b/autopilot/observability/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - grafanadashboards
-commonLabels:
-  app.kubernetes.io/name: autopilot
-  app.kubernetes.io/component: autopilot
-  app.kubernetes.io/part-of: autopilot
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: autopilot
+      app.kubernetes.io/name: autopilot
+      app.kubernetes.io/part-of: autopilot

--- a/autopilot/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-edu/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: autopilot
 
 resources:
-- ../../base
+  - ../../base

--- a/autopilot/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-obs/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: grafana
 
 resources:
-- ../../observability
+  - ../../observability

--- a/autopilot/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-prod/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: autopilot
 
 resources:
-- ../../base
+  - ../../base

--- a/autopilot/overlays/nerc-ocp-test/kustomization.yaml
+++ b/autopilot/overlays/nerc-ocp-test/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: autopilot
 
 resources:
-- ../../base
+  - ../../base

--- a/ci/check-policy.sh
+++ b/ci/check-policy.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+docker run --rm -v "$PWD:/project" openpolicyagent/conftest test \
+  --all-namespaces \
+  --ignore '\.venv|/charts/' \
+  .

--- a/ci/prohibit-commonlabels.sh
+++ b/ci/prohibit-commonlabels.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+found_common_labels=0
+for path in "$@"; do
+  if grep -q commonLabels "$path"; then
+    echo "commonLabels found in file: $path"
+    found_common_labels=1
+  fi
+done
+
+if [ "$found_common_labels" = 1 ]; then
+  echo "'commonLabels' is deprecated. Please use 'labels' instead."
+  echo "Run 'kustomize edit fix' to update your Kustomization automatically."
+  exit 1
+fi

--- a/cluster-scope/base/agent-install.openshift.io/agentserviceconfigs/agent/kustomization.yaml
+++ b/cluster-scope/base/agent-install.openshift.io/agentserviceconfigs/agent/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - agentserviceconfig.yaml
+  - agentserviceconfig.yaml

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/curator/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/curator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
-  - fetchdata.curator.curator.yaml
-  - reportapis.curator.curator.yaml
-  - reports.curator.curator.yaml
+- fetchdata.curator.curator.yaml
+- reportapis.curator.curator.yaml
+- reports.curator.curator.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: curator

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/curator/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/curator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
   - fetchdata.curator.curator.yaml
   - reportapis.curator.curator.yaml
   - reports.curator.curator.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: curator

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr-helm-repo
 resources:
 - solrbackups.yaml
 - solrclouds.yaml
 - solrprometheusexporters.yaml
 - zookeeperclusters.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: solr-helm-repo

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr-helm-repo
 resources:
-- solrbackups.yaml
-- solrclouds.yaml
-- solrprometheusexporters.yaml
-- zookeeperclusters.yaml
+  - solrbackups.yaml
+  - solrclouds.yaml
+  - solrprometheusexporters.yaml
+  - zookeeperclusters.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: solr-helm-repo

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterissuer.yaml
+  - clusterissuer.yaml

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-staging-http01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterissuer.yaml
+  - clusterissuer.yaml

--- a/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/selfsigned/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterissuer.yaml
+  - clusterissuer.yaml

--- a/cluster-scope/base/config.openshift.io/apiservers/cluster/kustomization.yaml
+++ b/cluster-scope/base/config.openshift.io/apiservers/cluster/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - apiserver.yaml
+  - apiserver.yaml

--- a/cluster-scope/base/core/configmaps/admin-acks/kustomization.yaml
+++ b/cluster-scope/base/core/configmaps/admin-acks/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - configmap.yaml
+  - configmap.yaml

--- a/cluster-scope/base/core/configmaps/nerc-logo/kustomization.yaml
+++ b/cluster-scope/base/core/configmaps/nerc-logo/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - configmap.yaml
+  - configmap.yaml

--- a/cluster-scope/base/core/namespaces/acct-mgt/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/acct-mgt/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: acct-mgt
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/aitelemetry/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/aitelemetry/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/dex/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/dex/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/grafana/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/grafana/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/group-sync-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/node-feature-discovery/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-gpu-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/nvidia-network-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/open-cluster-management-observability/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/open-cluster-management-observability/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/open-cluster-management/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/open-cluster-management/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-distributed-tracing/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-distributed-tracing/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-gitops/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-sriov-network-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-storage/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-storage/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-tempo-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-tempo-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/redhat-ods-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/redhat-ods-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/strimzi-kafka-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml

--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/kustomization.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - persistentvolumeclaim.yaml
+  - persistentvolumeclaim.yaml

--- a/cluster-scope/base/core/secrets/eso-vault-auth-token/kustomization.yaml
+++ b/cluster-scope/base/core/secrets/eso-vault-auth-token/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets-operator
 resources:
-    - secret.yaml
+  - secret.yaml

--- a/cluster-scope/base/core/secrets/moc-metrics-collector-token/kustomization.yaml
+++ b/cluster-scope/base/core/secrets/moc-metrics-collector-token/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - secret.yaml
+  - secret.yaml

--- a/cluster-scope/base/core/serviceaccounts/eso-vault-auth/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/eso-vault-auth/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets-operator
 resources:
-    - serviceaccount.yaml
+  - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/moc-metrics-collector/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/moc-metrics-collector/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- serviceaccount.yaml
+  - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/odf-node-patcher/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/odf-node-patcher/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- serviceaccount.yaml
+  - serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/vault-secret-reader/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/vault-secret-reader/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets-operator
 resources:
-- serviceaccount.yaml
+  - serviceaccount.yaml

--- a/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/clustersecretstores/nerc-cluster-secrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clustersecretstore.yaml
+  - clustersecretstore.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/clusterissuer-dns01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - aws-route53-credentials.yaml
+  - aws-route53-credentials.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/github-client-secret/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/github-client-secret/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - externalsecret.yaml
+  - externalsecret.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/oauth-htpasswd/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - externalsecret.yaml
+  - externalsecret.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/oauths-clientsecret-nerc/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/oauths-clientsecret-nerc/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - externalsecret.yaml
+  - externalsecret.yaml

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-  - externalsecret.yaml
+- externalsecret.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-acm-metrics-2ti-object-storage/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - externalsecret.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-  - externalsecret.yaml
+- externalsecret.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-multiclusterhub-operator-pull-secret/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - externalsecret.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-  - externalsecret.yaml
+- externalsecret.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage/kustomization.yaml
+++ b/cluster-scope/base/external-secrets.io/externalsecrets/open-cluster-management-observability-thanos-object-storage/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - externalsecret.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/kustomization.yaml
+++ b/cluster-scope/base/imageregistry.operator.openshift.io/configs/cluster/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - config.yaml
+  - config.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/kubeletconfigs/system-reserved/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/kubeletconfigs/system-reserved/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - kubeletconfig.yaml
+  - kubeletconfig.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - machineconfig.yaml
+  - machineconfig.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/sysctl-ip-forward/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/sysctl-ip-forward/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- machineconfig.yaml
+  - machineconfig.yaml

--- a/cluster-scope/base/metal3.io/provisionings/provisioning-configuration/kustomization.yaml
+++ b/cluster-scope/base/metal3.io/provisionings/provisioning-configuration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - provisioning.yaml
+  - provisioning.yaml

--- a/cluster-scope/base/metallb.io/metallbs/metallb/kustomization.yaml
+++ b/cluster-scope/base/metallb.io/metallbs/metallb/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - metallb.yaml
+  - metallb.yaml

--- a/cluster-scope/base/nmstate.io/nmstates/nmstate/kustomization.yaml
+++ b/cluster-scope/base/nmstate.io/nmstates/nmstate/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - nmstate.yaml
+  - nmstate.yaml

--- a/cluster-scope/base/objectbucket.io/objectbucketclaims/observability/kustomization.yaml
+++ b/cluster-scope/base/objectbucket.io/objectbucketclaims/observability/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-  - objectbucketclaim.yaml
+- objectbucketclaim.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/objectbucket.io/objectbucketclaims/observability/kustomization.yaml
+++ b/cluster-scope/base/objectbucket.io/objectbucketclaims/observability/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - objectbucketclaim.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/kustomization.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-  - multiclusterobservability.yaml
+- multiclusterobservability.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/kustomization.yaml
+++ b/cluster-scope/base/observability.open-cluster-management.io/multiclusterobservabilities/observability/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
   - multiclusterobservability.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/base/ocs.openshift.io/ocsinitializations/ocsinit/kustomization.yaml
+++ b/cluster-scope/base/ocs.openshift.io/ocsinitializations/ocsinit/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - ocsinitialization.yaml
+  - ocsinitialization.yaml

--- a/cluster-scope/base/odf.openshift.io/storageclusters/ocs-external-storagecluster/kustomization.yaml
+++ b/cluster-scope/base/odf.openshift.io/storageclusters/ocs-external-storagecluster/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-    - storagecluster.yaml
+  - storagecluster.yaml

--- a/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.external-secrets.io/operatorconfigs/cluster/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets-operator
 resources:
-    - operatorconfig.yaml
+  - operatorconfig.yaml

--- a/cluster-scope/base/operator.open-cluster-management.io/multiclusterhubs/multiclusterhub/kustomization.yaml
+++ b/cluster-scope/base/operator.open-cluster-management.io/multiclusterhubs/multiclusterhub/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: open-cluster-management
 resources:
-- multiclusterhub.yaml
+  - multiclusterhub.yaml

--- a/cluster-scope/base/operator.openshift.io/consoles/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.openshift.io/consoles/cluster/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - console.yaml
+  - console.yaml

--- a/cluster-scope/base/operator.openshift.io/ingresscontrollers/default/kustomization.yaml
+++ b/cluster-scope/base/operator.openshift.io/ingresscontrollers/default/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - ingresscontroller.yaml
+  - ingresscontroller.yaml

--- a/cluster-scope/base/operator.openshift.io/networks/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.openshift.io/networks/cluster/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - network.yaml
+  - network.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/group-sync-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: group-sync-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: koku-metrics-operator
 resources:
-    - operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-gpu-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/nvidia-network-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nvidia-network-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/open-cluster-management/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/open-cluster-management/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: open-cluster-management
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cluster-observability-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cluster-observability-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-distributed-tracing/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-logging/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-logging/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nmstate/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-nmstate
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-operators-redhat/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-operators-redhat/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-sriov-network-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-storage/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-tempo-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/redhat-ods-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: redhat-ods-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/strimzi-kafka-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: strimzi-kafka-operator
 resources:
-- operatorgroup.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: open-cluster-management
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-operators
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-logging/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/cluster-observability-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cluster-observability-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/elasticsearch-eck-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/external-secrets-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/gatekeeper-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/group-sync-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: group-sync-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-image-puller-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-image-puller-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-operators
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-nmstate
 resources:
-- subscriptions.yaml
+  - subscriptions.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubevirt-hyperconverged/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubevirt-hyperconverged/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/loki-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metallb-system
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-gpu-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nvidia-gpu-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nvidia-network-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/odf-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-gitops-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-operators
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-operators
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-sriov-network-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-sriov-network-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/redhat-ods-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-kafka-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: strimzi-kafka-operator
 resources:
-- subscription.yaml
+  - subscription.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/instructlab-admins/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/instructlab-admins/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kruize-admins/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-metrics-collector-binding/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-metrics-collector-binding/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-ops/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/nerc-ops/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/odf-node-labeler/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/odf-node-labeler/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrolebinding.yaml
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-metrics-collector/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-metrics-collector/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-operators/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-operators/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-pod-exec/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-pod-exec/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-portforward/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-portforward/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/nerc-ops/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/node-labeler/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/node-labeler/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/openshift-gitops-openshift-gitops-argocd-application-controller/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/openshift-gitops-openshift-gitops-argocd-application-controller/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/patch-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/patch-operator/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterrole.yaml
+  - clusterrole.yaml

--- a/cluster-scope/base/redhatcop.redhat.io/groupsyncs/github-ocp-on-nerc/kustomization.yaml
+++ b/cluster-scope/base/redhatcop.redhat.io/groupsyncs/github-ocp-on-nerc/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - groupsync.yaml
+  - groupsync.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - securitycontextconstraints.yaml
+  - securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - securitycontextconstraints.yaml
+  - securitycontextconstraints.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- securitycontextconstraints.yaml
+  - securitycontextconstraints.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - storageclass.yaml
+  - storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - storageclass.yaml
+  - storageclass.yaml

--- a/cluster-scope/base/user.openshift.io/groups/cluster-admins/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cluster-admins/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - group.yaml
+  - group.yaml

--- a/cluster-scope/bundles/acct-mgt/kustomization.yaml
+++ b/cluster-scope/bundles/acct-mgt/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acct-mgt
 
 resources:
-  - ../../base/core/namespaces/acct-mgt
-  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount
+- ../../base/core/namespaces/acct-mgt
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: acct-mgt

--- a/cluster-scope/bundles/acct-mgt/kustomization.yaml
+++ b/cluster-scope/bundles/acct-mgt/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acct-mgt
 
 resources:
   - ../../base/core/namespaces/acct-mgt
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: acct-mgt

--- a/cluster-scope/bundles/acm-cim/kustomization.yaml
+++ b/cluster-scope/bundles/acm-cim/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acm-cim
 resources:
 - ../acm
 - ../../base/metal3.io/provisionings/provisioning-configuration
 - ../../base/agent-install.openshift.io/agentserviceconfigs/agent
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: acm-cim

--- a/cluster-scope/bundles/acm-cim/kustomization.yaml
+++ b/cluster-scope/bundles/acm-cim/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acm-cim
 resources:
-- ../acm
-- ../../base/metal3.io/provisionings/provisioning-configuration
-- ../../base/agent-install.openshift.io/agentserviceconfigs/agent
+  - ../acm
+  - ../../base/metal3.io/provisionings/provisioning-configuration
+  - ../../base/agent-install.openshift.io/agentserviceconfigs/agent
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: acm-cim

--- a/cluster-scope/bundles/acm-observability/kustomization.yaml
+++ b/cluster-scope/bundles/acm-observability/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
-      nerc.mghpcc.org/kustomized: "true"
+  - includeSelectors: true
+    pairs:
       nerc.mghpcc.org/bundle: acm-observability
-    includeSelectors: true
+      nerc.mghpcc.org/kustomized: "true"
 resources:
   - ../../base/core/namespaces/open-cluster-management-observability

--- a/cluster-scope/bundles/acm/kustomization.yaml
+++ b/cluster-scope/bundles/acm/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acm
 resources:
 - ../../base/operators.coreos.com/subscriptions/acm
 - ../../base/core/namespaces/open-cluster-management
 - ../../base/operators.coreos.com/operatorgroups/open-cluster-management
 - ../../base/operator.open-cluster-management.io/multiclusterhubs/multiclusterhub
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: acm

--- a/cluster-scope/bundles/acm/kustomization.yaml
+++ b/cluster-scope/bundles/acm/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: acm
 resources:
-- ../../base/operators.coreos.com/subscriptions/acm
-- ../../base/core/namespaces/open-cluster-management
-- ../../base/operators.coreos.com/operatorgroups/open-cluster-management
-- ../../base/operator.open-cluster-management.io/multiclusterhubs/multiclusterhub
+  - ../../base/operators.coreos.com/subscriptions/acm
+  - ../../base/core/namespaces/open-cluster-management
+  - ../../base/operators.coreos.com/operatorgroups/open-cluster-management
+  - ../../base/operator.open-cluster-management.io/multiclusterhubs/multiclusterhub
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: acm

--- a/cluster-scope/bundles/allow-list-crds/kustomization.yaml
+++ b/cluster-scope/bundles/allow-list-crds/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: allow-list-crds
 
 resources:
-  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
-  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds
+- ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: allow-list-crds

--- a/cluster-scope/bundles/allow-list-crds/kustomization.yaml
+++ b/cluster-scope/bundles/allow-list-crds/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: allow-list-crds
 
 resources:
   - ../../base/rbac.authorization.k8s.io/clusterroles/allow-list-crds
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-list-crds
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: allow-list-crds

--- a/cluster-scope/bundles/amq-broker-rhel8-operator/kustomization.yaml
+++ b/cluster-scope/bundles/amq-broker-rhel8-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: amq-broker-rhel8-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/amq-broker-rhel8
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: amq-broker-rhel8-operator

--- a/cluster-scope/bundles/amq-broker-rhel8-operator/kustomization.yaml
+++ b/cluster-scope/bundles/amq-broker-rhel8-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: amq-broker-rhel8-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/amq-broker-rhel8
+  - ../../base/operators.coreos.com/subscriptions/amq-broker-rhel8
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: amq-broker-rhel8-operator

--- a/cluster-scope/bundles/amq-streams-operator/kustomization.yaml
+++ b/cluster-scope/bundles/amq-streams-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: amq-streams-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/amq-streams
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: amq-streams-operator

--- a/cluster-scope/bundles/amq-streams-operator/kustomization.yaml
+++ b/cluster-scope/bundles/amq-streams-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: amq-streams-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/amq-streams
+  - ../../base/operators.coreos.com/subscriptions/amq-streams
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: amq-streams-operator

--- a/cluster-scope/bundles/ansible-automation-platform-operator/kustomization.yaml
+++ b/cluster-scope/bundles/ansible-automation-platform-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: ansible-automation-platform-operator
 resources:
 - ../../base/core/namespaces/aap
 - ../../base/operators.coreos.com/operatorgroups/aap
 - ../../base/operators.coreos.com/subscriptions/ansible-automation-platform-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: ansible-automation-platform-operator

--- a/cluster-scope/bundles/ansible-automation-platform-operator/kustomization.yaml
+++ b/cluster-scope/bundles/ansible-automation-platform-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: ansible-automation-platform-operator
 resources:
-- ../../base/core/namespaces/aap
-- ../../base/operators.coreos.com/operatorgroups/aap
-- ../../base/operators.coreos.com/subscriptions/ansible-automation-platform-operator
+  - ../../base/core/namespaces/aap
+  - ../../base/operators.coreos.com/operatorgroups/aap
+  - ../../base/operators.coreos.com/subscriptions/ansible-automation-platform-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: ansible-automation-platform-operator

--- a/cluster-scope/bundles/authorino-operator/kustomization.yaml
+++ b/cluster-scope/bundles/authorino-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: authorino-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/authorino-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: authorino-operator

--- a/cluster-scope/bundles/authorino-operator/kustomization.yaml
+++ b/cluster-scope/bundles/authorino-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: authorino-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/authorino-operator
+  - ../../base/operators.coreos.com/subscriptions/authorino-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: authorino-operator

--- a/cluster-scope/bundles/autopilot/kustomization.yaml
+++ b/cluster-scope/bundles/autopilot/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: autopilot
 resources:
 - ../../base/core/namespaces/autopilot
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: autopilot

--- a/cluster-scope/bundles/autopilot/kustomization.yaml
+++ b/cluster-scope/bundles/autopilot/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: autopilot
 resources:
-- ../../base/core/namespaces/autopilot
+  - ../../base/core/namespaces/autopilot
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: autopilot

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: cert-manager
 resources:
 - ../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../base/cert-manager.io/clusterissuers/selfsigned
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/
 - ../../base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: cert-manager

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: cert-manager
 resources:
-- ../../base/operators.coreos.com/subscriptions/cert-manager
-- ../../base/cert-manager.io/clusterissuers/selfsigned
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/
-- ../../base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/
+  - ../../base/operators.coreos.com/subscriptions/cert-manager
+  - ../../base/cert-manager.io/clusterissuers/selfsigned
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/allow-restricted-runtime-default-scc/
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-restricted-runtime-default-scc/
+  - ../../base/security.openshift.io/securitycontextconstraints/restricted-runtime-default/
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: cert-manager

--- a/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: cluster-admin-rbac
 resources:
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader
 - ../../base/user.openshift.io/groups/cluster-admins
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: cluster-admin-rbac

--- a/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-admin-rbac/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: cluster-admin-rbac
 resources:
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader
-- ../../base/user.openshift.io/groups/cluster-admins
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-sudoer
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-reader
+  - ../../base/user.openshift.io/groups/cluster-admins
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-portforward-all
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-nerc-portforward
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: cluster-admin-rbac

--- a/cluster-scope/bundles/cluster-observability-operator/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-observability-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
 - ../../base/core/namespaces/openshift-cluster-observability-operator
 - ../../base/operators.coreos.com/operatorgroups/openshift-cluster-observability-operator
 - ../../base/operators.coreos.com/subscriptions/cluster-observability-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/cluster-observability-operator/kustomization.yaml
+++ b/cluster-scope/bundles/cluster-observability-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
-- ../../base/core/namespaces/openshift-cluster-observability-operator
-- ../../base/operators.coreos.com/operatorgroups/openshift-cluster-observability-operator
-- ../../base/operators.coreos.com/subscriptions/cluster-observability-operator
+  - ../../base/core/namespaces/openshift-cluster-observability-operator
+  - ../../base/operators.coreos.com/operatorgroups/openshift-cluster-observability-operator
+  - ../../base/operators.coreos.com/subscriptions/cluster-observability-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/clusterissuer-http01/kustomization.yaml
+++ b/cluster-scope/bundles/clusterissuer-http01/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base/cert-manager.io/clusterissuers/letsencrypt-staging-http01
-- ../../base/cert-manager.io/clusterissuers/letsencrypt-production-http01
+  - ../../base/cert-manager.io/clusterissuers/letsencrypt-staging-http01
+  - ../../base/cert-manager.io/clusterissuers/letsencrypt-production-http01

--- a/cluster-scope/bundles/console/kustomization.yaml
+++ b/cluster-scope/bundles/console/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: console
 resources:
 - ../../base/operator.openshift.io/consoles/cluster
 - ../../base/core/configmaps/nerc-logo
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: console

--- a/cluster-scope/bundles/console/kustomization.yaml
+++ b/cluster-scope/bundles/console/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: console
 resources:
-- ../../base/operator.openshift.io/consoles/cluster
-- ../../base/core/configmaps/nerc-logo
+  - ../../base/operator.openshift.io/consoles/cluster
+  - ../../base/core/configmaps/nerc-logo
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: console

--- a/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
+++ b/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: crunchy-postgres-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/crunchy-postgres-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: crunchy-postgres-operator

--- a/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
+++ b/cluster-scope/bundles/crunchy-postgres-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: crunchy-postgres-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/crunchy-postgres-operator
+  - ../../base/operators.coreos.com/subscriptions/crunchy-postgres-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: crunchy-postgres-operator

--- a/cluster-scope/bundles/curator/kustomization.yaml
+++ b/cluster-scope/bundles/curator/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
-  - ../../base/core/namespaces/curator-system
-  - ../../base/apiextensions.k8s.io/customresourcedefinitions/curator
-  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/curator
-  - ../../base/rbac.authorization.k8s.io/clusterroles/curator
+- ../../base/core/namespaces/curator-system
+- ../../base/apiextensions.k8s.io/customresourcedefinitions/curator
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/curator
+- ../../base/rbac.authorization.k8s.io/clusterroles/curator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: curator

--- a/cluster-scope/bundles/curator/kustomization.yaml
+++ b/cluster-scope/bundles/curator/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
   - ../../base/core/namespaces/curator-system
   - ../../base/apiextensions.k8s.io/customresourcedefinitions/curator
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/curator
   - ../../base/rbac.authorization.k8s.io/clusterroles/curator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: curator

--- a/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
+++ b/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: elasticsearch-eck-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/elasticsearch-eck-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: elasticsearch-eck-operator

--- a/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
+++ b/cluster-scope/bundles/elasticsearch-eck-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: elasticsearch-eck-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/elasticsearch-eck-operator
+  - ../../base/operators.coreos.com/subscriptions/elasticsearch-eck-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: elasticsearch-eck-operator

--- a/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: external-secrets-clustersecretstore
 resources:
 - ../../base/core/serviceaccounts/vault-secret-reader
 - ../../base/external-secrets.io/clustersecretstores/nerc-cluster-secrets
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: external-secrets-clustersecretstore

--- a/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-clustersecretstore/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: external-secrets-clustersecretstore
 resources:
-- ../../base/core/serviceaccounts/vault-secret-reader
-- ../../base/external-secrets.io/clustersecretstores/nerc-cluster-secrets
+  - ../../base/core/serviceaccounts/vault-secret-reader
+  - ../../base/external-secrets.io/clustersecretstores/nerc-cluster-secrets
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: external-secrets-clustersecretstore

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: external-secrets
 resources:
 - ../../base/core/namespaces/external-secrets-operator
 - ../../base/core/serviceaccounts/eso-vault-auth
@@ -10,3 +8,7 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview
 - ../../base/operators.coreos.com/operatorgroups/external-secrets
 - ../../base/core/secrets/eso-vault-auth-token/
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: external-secrets

--- a/cluster-scope/bundles/external-secrets/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets/kustomization.yaml
@@ -1,12 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: external-secrets
 resources:
-- ../../base/core/namespaces/external-secrets-operator
-- ../../base/core/serviceaccounts/eso-vault-auth
-- ../../base/operator.external-secrets.io/operatorconfigs/cluster
-- ../../base/operators.coreos.com/subscriptions/external-secrets-operator
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview
-- ../../base/operators.coreos.com/operatorgroups/external-secrets
-- ../../base/core/secrets/eso-vault-auth-token/
+  - ../../base/core/namespaces/external-secrets-operator
+  - ../../base/core/serviceaccounts/eso-vault-auth
+  - ../../base/operator.external-secrets.io/operatorconfigs/cluster
+  - ../../base/operators.coreos.com/subscriptions/external-secrets-operator
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/eso-tokenreview
+  - ../../base/operators.coreos.com/operatorgroups/external-secrets
+  - ../../base/core/secrets/eso-vault-auth-token/
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: external-secrets

--- a/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
+++ b/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: gatekeeper
 resources:
-  - ../../base/operators.coreos.com/subscriptions/gatekeeper-operator
+- ../../base/operators.coreos.com/subscriptions/gatekeeper-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: gatekeeper

--- a/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
+++ b/cluster-scope/bundles/gatekeeper-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: gatekeeper
 resources:
   - ../../base/operators.coreos.com/subscriptions/gatekeeper-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: gatekeeper

--- a/cluster-scope/bundles/grafana/kustomization.yaml
+++ b/cluster-scope/bundles/grafana/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
 - ../../base/core/namespaces/grafana
 - ../../base/operators.coreos.com/operatorgroups/grafana
 - ../../base/operators.coreos.com/subscriptions/grafana-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/grafana/kustomization.yaml
+++ b/cluster-scope/bundles/grafana/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
-- ../../base/core/namespaces/grafana
-- ../../base/operators.coreos.com/operatorgroups/grafana
-- ../../base/operators.coreos.com/subscriptions/grafana-operator
+  - ../../base/core/namespaces/grafana
+  - ../../base/operators.coreos.com/operatorgroups/grafana
+  - ../../base/operators.coreos.com/subscriptions/grafana-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/group-sync-github/kustomization.yaml
+++ b/cluster-scope/bundles/group-sync-github/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../group-sync-operator
-- ../../base/redhatcop.redhat.io/groupsyncs/github-ocp-on-nerc
+  - ../group-sync-operator
+  - ../../base/redhatcop.redhat.io/groupsyncs/github-ocp-on-nerc

--- a/cluster-scope/bundles/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/bundles/group-sync-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: group-sync-operator
 resources:
 - ../../base/core/namespaces/group-sync-operator
 - ../../base/operators.coreos.com/operatorgroups/group-sync-operator
 - ../../base/operators.coreos.com/subscriptions/group-sync-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: group-sync-operator

--- a/cluster-scope/bundles/group-sync-operator/kustomization.yaml
+++ b/cluster-scope/bundles/group-sync-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: group-sync-operator
 resources:
-- ../../base/core/namespaces/group-sync-operator
-- ../../base/operators.coreos.com/operatorgroups/group-sync-operator
-- ../../base/operators.coreos.com/subscriptions/group-sync-operator
+  - ../../base/core/namespaces/group-sync-operator
+  - ../../base/operators.coreos.com/operatorgroups/group-sync-operator
+  - ../../base/operators.coreos.com/subscriptions/group-sync-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: group-sync-operator

--- a/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: hostpath-provisioner
 
 resources:
 - ../../base/core/namespaces/kubevirt-hostpath-provisioner
@@ -10,3 +8,7 @@ resources:
 - ../../base/security.openshift.io/securitycontextconstraints/hostpath-provisioner
 - ../../base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner
 - ../../base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: hostpath-provisioner

--- a/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/bundles/hostpath-provisioner/kustomization.yaml
@@ -1,12 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: hostpath-provisioner
 
 resources:
-- ../../base/core/namespaces/kubevirt-hostpath-provisioner
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner
-- ../../base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner
-- ../../base/security.openshift.io/securitycontextconstraints/hostpath-provisioner
-- ../../base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner
-- ../../base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux
+  - ../../base/core/namespaces/kubevirt-hostpath-provisioner
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/kubevirt-hostpath-provisioner
+  - ../../base/storage.k8s.io/storageclasses/kubevirt-hostpath-provisioner
+  - ../../base/security.openshift.io/securitycontextconstraints/hostpath-provisioner
+  - ../../base/rbac.authorization.k8s.io/clusterroles/kubevirt-hostpath-provisioner
+  - ../../base/machineconfiguration.openshift.io/machineconfigs/hostpath-provisioner-selinux
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: hostpath-provisioner

--- a/cluster-scope/bundles/image-registry/kustomization.yaml
+++ b/cluster-scope/bundles/image-registry/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: image-registry
 resources:
 - ../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../base/core/persistentvolumeclaims/image-registry-storage
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: image-registry

--- a/cluster-scope/bundles/image-registry/kustomization.yaml
+++ b/cluster-scope/bundles/image-registry/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: image-registry
 resources:
-- ../../base/imageregistry.operator.openshift.io/configs/cluster
-- ../../base/core/persistentvolumeclaims/image-registry-storage
+  - ../../base/imageregistry.operator.openshift.io/configs/cluster
+  - ../../base/core/persistentvolumeclaims/image-registry-storage
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: image-registry

--- a/cluster-scope/bundles/keycloak/kustomization.yaml
+++ b/cluster-scope/bundles/keycloak/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: keycloak
 resources:
 - ../../base/core/namespaces/keycloak
 - ../../base/operators.coreos.com/operatorgroups/keycloak
 - ../../base/operators.coreos.com/subscriptions/rhbk-operator
 - ../../base/operators.coreos.com/subscriptions/keycloak-permissions-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: keycloak

--- a/cluster-scope/bundles/keycloak/kustomization.yaml
+++ b/cluster-scope/bundles/keycloak/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: keycloak
 resources:
-- ../../base/core/namespaces/keycloak
-- ../../base/operators.coreos.com/operatorgroups/keycloak
-- ../../base/operators.coreos.com/subscriptions/rhbk-operator
-- ../../base/operators.coreos.com/subscriptions/keycloak-permissions-operator
+  - ../../base/core/namespaces/keycloak
+  - ../../base/operators.coreos.com/operatorgroups/keycloak
+  - ../../base/operators.coreos.com/subscriptions/rhbk-operator
+  - ../../base/operators.coreos.com/subscriptions/keycloak-permissions-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: keycloak

--- a/cluster-scope/bundles/kubernetes-image-puller-operator/kustomization.yaml
+++ b/cluster-scope/bundles/kubernetes-image-puller-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: kubernetes-image-puller-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/kubernetes-image-puller-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: kubernetes-image-puller-operator

--- a/cluster-scope/bundles/kubernetes-image-puller-operator/kustomization.yaml
+++ b/cluster-scope/bundles/kubernetes-image-puller-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: kubernetes-image-puller-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/kubernetes-image-puller-operator
+  - ../../base/operators.coreos.com/subscriptions/kubernetes-image-puller-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: kubernetes-image-puller-operator

--- a/cluster-scope/bundles/logging/kustomization.yaml
+++ b/cluster-scope/bundles/logging/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
 - ../../base/core/namespaces/openshift-logging
 - ../../base/operators.coreos.com/operatorgroups/openshift-logging
 - ../../base/operators.coreos.com/subscriptions/cluster-logging
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/logging/kustomization.yaml
+++ b/cluster-scope/bundles/logging/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: logging
 resources:
-- ../../base/core/namespaces/openshift-logging
-- ../../base/operators.coreos.com/operatorgroups/openshift-logging
-- ../../base/operators.coreos.com/subscriptions/cluster-logging
+  - ../../base/core/namespaces/openshift-logging
+  - ../../base/operators.coreos.com/operatorgroups/openshift-logging
+  - ../../base/operators.coreos.com/subscriptions/cluster-logging
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: logging

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: metallb
 resources:
 - ../../base/core/namespaces/metallb-system
 - ../../base/operators.coreos.com/subscriptions/metallb-operator
 - ../../base/operators.coreos.com/operatorgroups/metallb-system
 - ../../base/metallb.io/metallbs/metallb
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: metallb

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: metallb
 resources:
-- ../../base/core/namespaces/metallb-system
-- ../../base/operators.coreos.com/subscriptions/metallb-operator
-- ../../base/operators.coreos.com/operatorgroups/metallb-system
-- ../../base/metallb.io/metallbs/metallb
+  - ../../base/core/namespaces/metallb-system
+  - ../../base/operators.coreos.com/subscriptions/metallb-operator
+  - ../../base/operators.coreos.com/operatorgroups/metallb-system
+  - ../../base/metallb.io/metallbs/metallb
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: metallb

--- a/cluster-scope/bundles/minio/kustomization.yaml
+++ b/cluster-scope/bundles/minio/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: minio
 resources:
 - ../../base/core/namespaces/minio
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: minio

--- a/cluster-scope/bundles/minio/kustomization.yaml
+++ b/cluster-scope/bundles/minio/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: minio
 resources:
-- ../../base/core/namespaces/minio
+  - ../../base/core/namespaces/minio
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: minio

--- a/cluster-scope/bundles/moc-metrics-collector/kustomization.yaml
+++ b/cluster-scope/bundles/moc-metrics-collector/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: moc-metrics-collector
-commonLabels:
-  nerc.mghpcc.org/bundle: moc-metrics-collector
 resources:
 - ../../base/core/namespaces/moc-metrics-collector/
 - ../../base/core/serviceaccounts/moc-metrics-collector
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-metrics-collector-binding/
 - ../../base/rbac.authorization.k8s.io/clusterroles/moc-metrics-collector/
 - ../../base/core/secrets/moc-metrics-collector-token
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: moc-metrics-collector

--- a/cluster-scope/bundles/moc-metrics-collector/kustomization.yaml
+++ b/cluster-scope/bundles/moc-metrics-collector/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: moc-metrics-collector
-commonLabels:
-  nerc.mghpcc.org/bundle: moc-metrics-collector
 resources:
-- ../../base/core/namespaces/moc-metrics-collector/
-- ../../base/core/serviceaccounts/moc-metrics-collector
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-metrics-collector-binding/
-- ../../base/rbac.authorization.k8s.io/clusterroles/moc-metrics-collector/
-- ../../base/core/secrets/moc-metrics-collector-token
+  - ../../base/core/namespaces/moc-metrics-collector/
+  - ../../base/core/serviceaccounts/moc-metrics-collector
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-metrics-collector-binding/
+  - ../../base/rbac.authorization.k8s.io/clusterroles/moc-metrics-collector/
+  - ../../base/core/secrets/moc-metrics-collector-token
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: moc-metrics-collector

--- a/cluster-scope/bundles/mongodb-operator/kustomization.yaml
+++ b/cluster-scope/bundles/mongodb-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: mongodb-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/mongodb-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: mongodb-operator

--- a/cluster-scope/bundles/mongodb-operator/kustomization.yaml
+++ b/cluster-scope/bundles/mongodb-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: mongodb-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/mongodb-operator
+  - ../../base/operators.coreos.com/subscriptions/mongodb-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: mongodb-operator

--- a/cluster-scope/bundles/multicluster-engine-operator/kustomization.yaml
+++ b/cluster-scope/bundles/multicluster-engine-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: multicluster-engine-operator
 resources:
 - ../../base/core/namespaces/multicluster-engine-operator
 - ../../base/operators.coreos.com/operatorgroups/multicluster-engine-operator
 - ../../base/operators.coreos.com/subscriptions/multicluster-engine-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: multicluster-engine-operator

--- a/cluster-scope/bundles/multicluster-engine-operator/kustomization.yaml
+++ b/cluster-scope/bundles/multicluster-engine-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: multicluster-engine-operator
 resources:
-- ../../base/core/namespaces/multicluster-engine-operator
-- ../../base/operators.coreos.com/operatorgroups/multicluster-engine-operator
-- ../../base/operators.coreos.com/subscriptions/multicluster-engine-operator
+  - ../../base/core/namespaces/multicluster-engine-operator
+  - ../../base/operators.coreos.com/operatorgroups/multicluster-engine-operator
+  - ../../base/operators.coreos.com/subscriptions/multicluster-engine-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: multicluster-engine-operator

--- a/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
+++ b/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nagios-monitoring
 resources:
 - ../../base/core/namespaces/nagios
 - ../../base/core/serviceaccounts/nagios-monitor
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring
 - ../../base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring
 - ../../base/core/secrets/nagios-monitor
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nagios-monitoring

--- a/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
+++ b/cluster-scope/bundles/nagios-monitoring/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nagios-monitoring
 resources:
-- ../../base/core/namespaces/nagios
-- ../../base/core/serviceaccounts/nagios-monitor
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring
-- ../../base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring
-- ../../base/core/secrets/nagios-monitor
+  - ../../base/core/namespaces/nagios
+  - ../../base/core/serviceaccounts/nagios-monitor
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nagios-monitoring
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nagios-monitoring
+  - ../../base/core/secrets/nagios-monitor
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nagios-monitoring

--- a/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nerc-certificate-clusterissuer
 
 resources:
 - ../../base/external-secrets.io/externalsecrets/clusterissuer-dns01
 - ../../cert-manager.io/clusterissuers/letsencrypt-production-dns01
 - ../../cert-manager.io/clusterissuers/letsencrypt-staging-dns01
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nerc-certificate-clusterissuer

--- a/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-certificate-clusterissuers/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nerc-certificate-clusterissuer
 
 resources:
-- ../../base/external-secrets.io/externalsecrets/clusterissuer-dns01
-- ../../cert-manager.io/clusterissuers/letsencrypt-production-dns01
-- ../../cert-manager.io/clusterissuers/letsencrypt-staging-dns01
+  - ../../base/external-secrets.io/externalsecrets/clusterissuer-dns01
+  - ../../cert-manager.io/clusterissuers/letsencrypt-production-dns01
+  - ../../cert-manager.io/clusterissuers/letsencrypt-staging-dns01
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nerc-certificate-clusterissuer

--- a/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nerc-ops-rbac
 
 resources:
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-ops
@@ -14,3 +12,7 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai
 - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-operators
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nerc-ops-rbac

--- a/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
+++ b/cluster-scope/bundles/nerc-ops-rbac/kustomization.yaml
@@ -1,16 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nerc-ops-rbac
 
 resources:
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-ops
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-pod-exec
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-portforward
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-operators
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-ops
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-pod-exec
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-portforward
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-secrets-reader
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-sudoer
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-monitoring
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-machineconfig
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-rhoai
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-ops-operators
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nerc-ops-rbac

--- a/cluster-scope/bundles/nmstate/kustomization.yaml
+++ b/cluster-scope/bundles/nmstate/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nmstate
 resources:
 - ../../base/core/namespaces/openshift-nmstate
 - ../../base/operators.coreos.com/operatorgroups/openshift-nmstate
 - ../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
 - ../../base/nmstate.io/nmstates/nmstate
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nmstate

--- a/cluster-scope/bundles/nmstate/kustomization.yaml
+++ b/cluster-scope/bundles/nmstate/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nmstate
 resources:
-- ../../base/core/namespaces/openshift-nmstate
-- ../../base/operators.coreos.com/operatorgroups/openshift-nmstate
-- ../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
-- ../../base/nmstate.io/nmstates/nmstate
+  - ../../base/core/namespaces/openshift-nmstate
+  - ../../base/operators.coreos.com/operatorgroups/openshift-nmstate
+  - ../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
+  - ../../base/nmstate.io/nmstates/nmstate
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nmstate

--- a/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: node-feature-discovery
 resources:
 - ../../base/core/namespaces/node-feature-discovery
 - ../../base/operators.coreos.com/operatorgroups/node-feature-discovery
 - ../../base/operators.coreos.com/subscriptions/node-feature-discovery
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: node-feature-discovery

--- a/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
+++ b/cluster-scope/bundles/node-feature-discovery/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: node-feature-discovery
 resources:
-- ../../base/core/namespaces/node-feature-discovery
-- ../../base/operators.coreos.com/operatorgroups/node-feature-discovery
-- ../../base/operators.coreos.com/subscriptions/node-feature-discovery
+  - ../../base/core/namespaces/node-feature-discovery
+  - ../../base/operators.coreos.com/operatorgroups/node-feature-discovery
+  - ../../base/operators.coreos.com/subscriptions/node-feature-discovery
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: node-feature-discovery

--- a/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nvidia-gpu-operator
 resources:
 - ../../base/core/namespaces/nvidia-gpu-operator
 - ../../base/operators.coreos.com/operatorgroups/nvidia-gpu-operator
 - ../../base/operators.coreos.com/subscriptions/nvidia-gpu-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nvidia-gpu-operator

--- a/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-gpu-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nvidia-gpu-operator
 resources:
-- ../../base/core/namespaces/nvidia-gpu-operator
-- ../../base/operators.coreos.com/operatorgroups/nvidia-gpu-operator
-- ../../base/operators.coreos.com/subscriptions/nvidia-gpu-operator
+  - ../../base/core/namespaces/nvidia-gpu-operator
+  - ../../base/operators.coreos.com/operatorgroups/nvidia-gpu-operator
+  - ../../base/operators.coreos.com/subscriptions/nvidia-gpu-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nvidia-gpu-operator

--- a/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nvidia-network-operator
 resources:
 - ../../base/core/namespaces/nvidia-network-operator
 - ../../base/operators.coreos.com/operatorgroups/nvidia-network-operator
 - ../../base/operators.coreos.com/subscriptions/nvidia-network-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nvidia-network-operator

--- a/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/nvidia-network-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nvidia-network-operator
 resources:
-- ../../base/core/namespaces/nvidia-network-operator
-- ../../base/operators.coreos.com/operatorgroups/nvidia-network-operator
-- ../../base/operators.coreos.com/subscriptions/nvidia-network-operator
+  - ../../base/core/namespaces/nvidia-network-operator
+  - ../../base/operators.coreos.com/operatorgroups/nvidia-network-operator
+  - ../../base/operators.coreos.com/subscriptions/nvidia-network-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nvidia-network-operator

--- a/cluster-scope/bundles/odf-external/kustomization.yaml
+++ b/cluster-scope/bundles/odf-external/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: odf-external
 resources:
 - ../odf
 - ../../base/odf.openshift.io/storagesystems/ocs-external-storagecluster-storagesystem
 - ../../base/odf.openshift.io/storageclusters/ocs-external-storagecluster
 - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: odf-external

--- a/cluster-scope/bundles/odf-external/kustomization.yaml
+++ b/cluster-scope/bundles/odf-external/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: odf-external
 resources:
-- ../odf
-- ../../base/odf.openshift.io/storagesystems/ocs-external-storagecluster-storagesystem
-- ../../base/odf.openshift.io/storageclusters/ocs-external-storagecluster
-- ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
+  - ../odf
+  - ../../base/odf.openshift.io/storagesystems/ocs-external-storagecluster-storagesystem
+  - ../../base/odf.openshift.io/storageclusters/ocs-external-storagecluster
+  - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: odf-external

--- a/cluster-scope/bundles/odf/kustomization.yaml
+++ b/cluster-scope/bundles/odf/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: odf
 resources:
 - ../../base/core/namespaces/openshift-storage
 - ../../base/core/serviceaccounts/odf-node-patcher/
@@ -9,3 +7,7 @@ resources:
 - ../../base/operators.coreos.com/subscriptions/odf-operator
 - ../../base/ocs.openshift.io/ocsinitializations/ocsinit
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/odf-node-labeler/
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: odf

--- a/cluster-scope/bundles/odf/kustomization.yaml
+++ b/cluster-scope/bundles/odf/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: odf
 resources:
-- ../../base/core/namespaces/openshift-storage
-- ../../base/core/serviceaccounts/odf-node-patcher/
-- ../../base/operators.coreos.com/operatorgroups/openshift-storage
-- ../../base/operators.coreos.com/subscriptions/odf-operator
-- ../../base/ocs.openshift.io/ocsinitializations/ocsinit
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/odf-node-labeler/
+  - ../../base/core/namespaces/openshift-storage
+  - ../../base/core/serviceaccounts/odf-node-patcher/
+  - ../../base/operators.coreos.com/operatorgroups/openshift-storage
+  - ../../base/operators.coreos.com/subscriptions/odf-operator
+  - ../../base/ocs.openshift.io/ocsinitializations/ocsinit
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/odf-node-labeler/
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: odf

--- a/cluster-scope/bundles/openshift-custom-metrics-autoscaler-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-custom-metrics-autoscaler-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-custom-metrics-autoscaler-operator
 resources:
 - ../../base/core/namespaces/openshift-keda
 - ../../base/operators.coreos.com/operatorgroups/openshift-keda
 - ../../base/operators.coreos.com/subscriptions/openshift-custom-metrics-autoscaler-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-custom-metrics-autoscaler-operator

--- a/cluster-scope/bundles/openshift-custom-metrics-autoscaler-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-custom-metrics-autoscaler-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-custom-metrics-autoscaler-operator
 resources:
-- ../../base/core/namespaces/openshift-keda
-- ../../base/operators.coreos.com/operatorgroups/openshift-keda
-- ../../base/operators.coreos.com/subscriptions/openshift-custom-metrics-autoscaler-operator
+  - ../../base/core/namespaces/openshift-keda
+  - ../../base/operators.coreos.com/operatorgroups/openshift-keda
+  - ../../base/operators.coreos.com/subscriptions/openshift-custom-metrics-autoscaler-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-custom-metrics-autoscaler-operator

--- a/cluster-scope/bundles/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-gitops/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-gitops
 resources:
 - ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-gitops

--- a/cluster-scope/bundles/openshift-gitops/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-gitops/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-gitops
 resources:
-- ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/
+  - ../../base/operators.coreos.com/subscriptions/openshift-gitops-operator
+  - ../../base/rbac.authorization.k8s.io/clusterroles/argocd-allow-all/
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/argocd-allow-all/
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-gitops

--- a/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-opentelemetry-operator
 resources:
 - ../../base/core/namespaces/openshift-opentelemetry-operator
 - ../../base/core/namespaces/openshift-distributed-tracing
@@ -11,3 +9,7 @@ resources:
 - ../../base/operators.coreos.com/operatorgroups/openshift-tempo-operator
 - ../../base/operators.coreos.com/subscriptions/opentelemetry-product
 - ../../base/operators.coreos.com/subscriptions/tempo-product
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-opentelemetry-operator

--- a/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-opentelemetry-operator/kustomization.yaml
@@ -1,13 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-opentelemetry-operator
 resources:
-- ../../base/core/namespaces/openshift-opentelemetry-operator
-- ../../base/core/namespaces/openshift-distributed-tracing
-- ../../base/core/namespaces/openshift-tempo-operator
-- ../../base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator
-- ../../base/operators.coreos.com/operatorgroups/openshift-distributed-tracing
-- ../../base/operators.coreos.com/operatorgroups/openshift-tempo-operator
-- ../../base/operators.coreos.com/subscriptions/opentelemetry-product
-- ../../base/operators.coreos.com/subscriptions/tempo-product
+  - ../../base/core/namespaces/openshift-opentelemetry-operator
+  - ../../base/core/namespaces/openshift-distributed-tracing
+  - ../../base/core/namespaces/openshift-tempo-operator
+  - ../../base/operators.coreos.com/operatorgroups/openshift-opentelemetry-operator
+  - ../../base/operators.coreos.com/operatorgroups/openshift-distributed-tracing
+  - ../../base/operators.coreos.com/operatorgroups/openshift-tempo-operator
+  - ../../base/operators.coreos.com/subscriptions/opentelemetry-product
+  - ../../base/operators.coreos.com/subscriptions/tempo-product
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-opentelemetry-operator

--- a/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-operators-redhat
 resources:
 - ../../base/core/namespaces/openshift-operators-redhat/
 - ../../base/operators.coreos.com/operatorgroups/openshift-operators-redhat
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-operators-redhat

--- a/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-operators-redhat/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-operators-redhat
 resources:
-- ../../base/core/namespaces/openshift-operators-redhat/
-- ../../base/operators.coreos.com/operatorgroups/openshift-operators-redhat
+  - ../../base/core/namespaces/openshift-operators-redhat/
+  - ../../base/operators.coreos.com/operatorgroups/openshift-operators-redhat
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-operators-redhat

--- a/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-pipelines-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-pipelines-operator

--- a/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-pipelines-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-pipelines-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
+  - ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-pipelines-operator

--- a/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-serverless-operator
 resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
 - ../../base/core/namespaces/openshift-serverless
 - ../../base/operators.coreos.com/operatorgroups/openshift-serverless
 - ../../base/operators.coreos.com/subscriptions/red-hat-camel-k
 - ../../base/operators.coreos.com/subscriptions/serverless-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-serverless-operator

--- a/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-serverless-operator/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-serverless-operator
 resources:
-- ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
-- ../../base/core/namespaces/openshift-serverless
-- ../../base/operators.coreos.com/operatorgroups/openshift-serverless
-- ../../base/operators.coreos.com/subscriptions/red-hat-camel-k
-- ../../base/operators.coreos.com/subscriptions/serverless-operator
+  - ../../base/rbac.authorization.k8s.io/clusterroles/knative-edit
+  - ../../base/core/namespaces/openshift-serverless
+  - ../../base/operators.coreos.com/operatorgroups/openshift-serverless
+  - ../../base/operators.coreos.com/subscriptions/red-hat-camel-k
+  - ../../base/operators.coreos.com/subscriptions/serverless-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-serverless-operator

--- a/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-sriov-network-operator
 resources:
 - ../../base/core/namespaces/openshift-sriov-network-operator
 - ../../base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator
 - ../../base/operators.coreos.com/subscriptions/openshift-sriov-network-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: openshift-sriov-network-operator

--- a/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-sriov-network-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: openshift-sriov-network-operator
 resources:
-- ../../base/core/namespaces/openshift-sriov-network-operator
-- ../../base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator
-- ../../base/operators.coreos.com/subscriptions/openshift-sriov-network-operator
+  - ../../base/core/namespaces/openshift-sriov-network-operator
+  - ../../base/operators.coreos.com/operatorgroups/openshift-sriov-network-operator
+  - ../../base/operators.coreos.com/subscriptions/openshift-sriov-network-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: openshift-sriov-network-operator

--- a/cluster-scope/bundles/opentelemetry/kustomization.yaml
+++ b/cluster-scope/bundles/opentelemetry/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: opentelemetry
 resources:
 - ../../base/core/namespaces/opentelemetry
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: opentelemetry

--- a/cluster-scope/bundles/opentelemetry/kustomization.yaml
+++ b/cluster-scope/bundles/opentelemetry/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: opentelemetry
 resources:
-- ../../base/core/namespaces/opentelemetry
+  - ../../base/core/namespaces/opentelemetry
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: opentelemetry

--- a/cluster-scope/bundles/patch-operator/kustomization.yaml
+++ b/cluster-scope/bundles/patch-operator/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: patch-operator
 resources:
 - ../../base/core/namespaces/patch-operator
 - ../../base/operators.coreos.com/operatorgroups/patch-operator
 - ../../base/operators.coreos.com/subscriptions/patch-operator
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator
 - ../../base/rbac.authorization.k8s.io/clusterroles/patch-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: patch-operator

--- a/cluster-scope/bundles/patch-operator/kustomization.yaml
+++ b/cluster-scope/bundles/patch-operator/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: patch-operator
 resources:
-- ../../base/core/namespaces/patch-operator
-- ../../base/operators.coreos.com/operatorgroups/patch-operator
-- ../../base/operators.coreos.com/subscriptions/patch-operator
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/patch-operator
+  - ../../base/core/namespaces/patch-operator
+  - ../../base/operators.coreos.com/operatorgroups/patch-operator
+  - ../../base/operators.coreos.com/subscriptions/patch-operator
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/patch-operator
+  - ../../base/rbac.authorization.k8s.io/clusterroles/patch-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: patch-operator

--- a/cluster-scope/bundles/postgres/kustomization.yaml
+++ b/cluster-scope/bundles/postgres/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: postgres
 resources:
 - ../../base/core/namespaces/postgres
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: postgres

--- a/cluster-scope/bundles/postgres/kustomization.yaml
+++ b/cluster-scope/bundles/postgres/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: postgres
 resources:
-- ../../base/core/namespaces/postgres
+  - ../../base/core/namespaces/postgres
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: postgres

--- a/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
+++ b/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: prom-keycloak-proxy
 resources:
 - ../../base/core/namespaces/prom-keycloak-proxy
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: prom-keycloak-proxy

--- a/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
+++ b/cluster-scope/bundles/prom-keycloak-proxy/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: prom-keycloak-proxy
 resources:
-- ../../base/core/namespaces/prom-keycloak-proxy
+  - ../../base/core/namespaces/prom-keycloak-proxy
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: prom-keycloak-proxy

--- a/cluster-scope/bundles/rhods-operator/kustomization.yaml
+++ b/cluster-scope/bundles/rhods-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: rhods-operator
 resources:
-  - ../../base/core/namespaces/redhat-ods-operator
-  - ../../base/operators.coreos.com/operatorgroups/redhat-ods-operator
-  - ../../base/operators.coreos.com/subscriptions/redhat-ods-operator
+- ../../base/core/namespaces/redhat-ods-operator
+- ../../base/operators.coreos.com/operatorgroups/redhat-ods-operator
+- ../../base/operators.coreos.com/subscriptions/redhat-ods-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: rhods-operator

--- a/cluster-scope/bundles/rhods-operator/kustomization.yaml
+++ b/cluster-scope/bundles/rhods-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: rhods-operator
 resources:
   - ../../base/core/namespaces/redhat-ods-operator
   - ../../base/operators.coreos.com/operatorgroups/redhat-ods-operator
   - ../../base/operators.coreos.com/subscriptions/redhat-ods-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: rhods-operator

--- a/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
+++ b/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: servicemesh-operator
 resources:
 - ../../base/operators.coreos.com/subscriptions/servicemesh-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: servicemesh-operator

--- a/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
+++ b/cluster-scope/bundles/servicemesh-operator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: servicemesh-operator
 resources:
-- ../../base/operators.coreos.com/subscriptions/servicemesh-operator
+  - ../../base/operators.coreos.com/subscriptions/servicemesh-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: servicemesh-operator

--- a/cluster-scope/bundles/snmp-exporter/kustomization.yaml
+++ b/cluster-scope/bundles/snmp-exporter/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: snmp-exporter
 resources:
 - ../../base/core/namespaces/snmp-exporter
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: snmp-exporter

--- a/cluster-scope/bundles/snmp-exporter/kustomization.yaml
+++ b/cluster-scope/bundles/snmp-exporter/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: snmp-exporter
 resources:
-- ../../base/core/namespaces/snmp-exporter
+  - ../../base/core/namespaces/snmp-exporter
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: snmp-exporter

--- a/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr-helm-repo
 resources:
 - ../../base/helm.openshift.io/helmchartrepositories/solr-helm-repo
 - ../../base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo
 - ../../base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit
 - ../../base/rbac.authorization.k8s.io/clusterroles/solr-edit
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: solr-helm-repo

--- a/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
+++ b/cluster-scope/bundles/solr-helm-repo/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr-helm-repo
 resources:
-- ../../base/helm.openshift.io/helmchartrepositories/solr-helm-repo
-- ../../base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo
-- ../../base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit
-- ../../base/rbac.authorization.k8s.io/clusterroles/solr-edit
+  - ../../base/helm.openshift.io/helmchartrepositories/solr-helm-repo
+  - ../../base/apiextensions.k8s.io/customresourcedefinitions/solr-helm-repo
+  - ../../base/rbac.authorization.k8s.io/clusterroles/zookeeper-edit
+  - ../../base/rbac.authorization.k8s.io/clusterroles/solr-edit
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: solr-helm-repo

--- a/cluster-scope/bundles/solr/kustomization.yaml
+++ b/cluster-scope/bundles/solr/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr
 resources:
 - ../../base/core/namespaces/solr
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: solr

--- a/cluster-scope/bundles/solr/kustomization.yaml
+++ b/cluster-scope/bundles/solr/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: solr
 resources:
-- ../../base/core/namespaces/solr
+  - ../../base/core/namespaces/solr
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: solr

--- a/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: strimzi-kafka-operator
 resources:
 - ../../base/core/namespaces/strimzi-kafka-operator
 - ../../base/operators.coreos.com/operatorgroups/strimzi-kafka-operator
 - ../../base/operators.coreos.com/subscriptions/strimzi-kafka-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: strimzi-kafka-operator

--- a/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
+++ b/cluster-scope/bundles/strimzi-kafka-operator/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: strimzi-kafka-operator
 resources:
-- ../../base/core/namespaces/strimzi-kafka-operator
-- ../../base/operators.coreos.com/operatorgroups/strimzi-kafka-operator
-- ../../base/operators.coreos.com/subscriptions/strimzi-kafka-operator
+  - ../../base/core/namespaces/strimzi-kafka-operator
+  - ../../base/operators.coreos.com/operatorgroups/strimzi-kafka-operator
+  - ../../base/operators.coreos.com/subscriptions/strimzi-kafka-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: strimzi-kafka-operator

--- a/cluster-scope/bundles/virt/kustomization.yaml
+++ b/cluster-scope/bundles/virt/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: virt
 resources:
-  - ../../base/core/namespaces/openshift-cnv
-  - ../../base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged
-  - ../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
+- ../../base/core/namespaces/openshift-cnv
+- ../../base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged
+- ../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: virt

--- a/cluster-scope/bundles/virt/kustomization.yaml
+++ b/cluster-scope/bundles/virt/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: virt
 resources:
   - ../../base/core/namespaces/openshift-cnv
   - ../../base/operators.coreos.com/operatorgroups/kubevirt-hyperconverged
   - ../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: virt

--- a/cluster-scope/bundles/zookeeper/kustomization.yaml
+++ b/cluster-scope/bundles/zookeeper/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: zookeeper
 resources:
 - ../../base/core/namespaces/zookeeper
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: zookeeper

--- a/cluster-scope/bundles/zookeeper/kustomization.yaml
+++ b/cluster-scope/bundles/zookeeper/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: zookeeper
 resources:
-- ../../base/core/namespaces/zookeeper
+  - ../../base/core/namespaces/zookeeper
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: zookeeper

--- a/cluster-scope/cert-manager.io/clusterissuers/letsencrypt-production-dns01/kustomization.yaml
+++ b/cluster-scope/cert-manager.io/clusterissuers/letsencrypt-production-dns01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterissuer.yaml
+  - clusterissuer.yaml

--- a/cluster-scope/cert-manager.io/clusterissuers/letsencrypt-staging-dns01/kustomization.yaml
+++ b/cluster-scope/cert-manager.io/clusterissuers/letsencrypt-staging-dns01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - clusterissuer.yaml
+  - clusterissuer.yaml

--- a/cluster-scope/components/argocd-skip-dryrun/kustomization.yaml
+++ b/cluster-scope/components/argocd-skip-dryrun/kustomization.yaml
@@ -2,23 +2,23 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 patches:
-- path: patches/skipdryrunonmissingresource.yaml
-  target:
-    group: metallb.io
-    name: .*
-- path: patches/skipdryrunonmissingresource.yaml
-  target:
-    group: external-secrets.io
-    name: .*
-- path: patches/skipdryrunonmissingresource.yaml
-  target:
-    group: operator.external-secrets.io
-    name: .*
-- path: patches/skipdryrunonmissingresource.yaml
-  target:
-    group: nmstate.io
-    name: .*
-- path: patches/skipdryrunonmissingresource.yaml
-  target:
-    group: redhatcop.redhat.io
-    name: .*
+  - path: patches/skipdryrunonmissingresource.yaml
+    target:
+      group: metallb.io
+      name: .*
+  - path: patches/skipdryrunonmissingresource.yaml
+    target:
+      group: external-secrets.io
+      name: .*
+  - path: patches/skipdryrunonmissingresource.yaml
+    target:
+      group: operator.external-secrets.io
+      name: .*
+  - path: patches/skipdryrunonmissingresource.yaml
+    target:
+      group: nmstate.io
+      name: .*
+  - path: patches/skipdryrunonmissingresource.yaml
+    target:
+      group: redhatcop.redhat.io
+      name: .*

--- a/cluster-scope/components/custom-certificates/kustomization.yaml
+++ b/cluster-scope/components/custom-certificates/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-- ../../base/operator.openshift.io/ingresscontrollers/default
-- ../../base/config.openshift.io/apiservers/cluster
+  - ../../base/operator.openshift.io/ingresscontrollers/default
+  - ../../base/config.openshift.io/apiservers/cluster
 
 patches:
-- path: patches/custom_ingress_certificate.yaml
-- path: patches/custom_apiserver_certificate.yaml
+  - path: patches/custom_ingress_certificate.yaml
+  - path: patches/custom_apiserver_certificate.yaml

--- a/cluster-scope/components/nerc-certificate-issuer/kustomization.yaml
+++ b/cluster-scope/components/nerc-certificate-issuer/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-- issuer-dns01-prod.yaml
-- issuer-dns01-staging.yaml
-- aws-route53-credentials.yaml
+  - issuer-dns01-prod.yaml
+  - issuer-dns01-staging.yaml
+  - aws-route53-credentials.yaml

--- a/cluster-scope/components/nerc-secret-store/kustomization.yaml
+++ b/cluster-scope/components/nerc-secret-store/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-- secretstore.yaml
-- serviceaccount.yaml
-- token.yaml
+  - secretstore.yaml
+  - serviceaccount.yaml
+  - token.yaml

--- a/cluster-scope/components/resourcequotas/ope-course-quota/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/ope-course-quota/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-- resourcequota.yaml
+  - resourcequota.yaml

--- a/cluster-scope/overlays/albany/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/albany/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/albany/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/albany/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/albany/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/albany/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/albany/kustomization.yaml
+++ b/cluster-scope/overlays/albany/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
@@ -16,18 +14,16 @@ resources:
 - certificates
 - secretstores
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-github
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-github
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -38,39 +34,42 @@ patches:
       - name: github
         github:
           clientID: Ov23liezggam3Edgcsfs
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/albany/openshift-config/github-client-secret
-
-- target:
-    kind: SecretStore
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/albany
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+  target:
+    kind: SecretStore
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/albany/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.albany.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - albany.nerc.mghpcc.org
+  target:
+    kind: Issuer
+    name: letsencrypt-.*-dns01
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/albany/kustomization.yaml
+++ b/cluster-scope/overlays/albany/kustomization.yaml
@@ -1,20 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/node-feature-discovery
-- ../../bundles/patch-operator
-- ../../bundles/clusterissuer-http01
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/core/namespaces/openshift-gitops
-- externalsecrets
-- issuers
-- feature/odf
-- certificates
-- secretstores
+  - ../common
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/patch-operator
+  - ../../bundles/clusterissuer-http01
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/core/namespaces/openshift-gitops
+  - externalsecrets
+  - issuers
+  - feature/odf
+  - certificates
+  - secretstores
 
 components:
   - ../../components/nerc-oauth-github
@@ -27,50 +29,48 @@ generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liezggam3Edgcsfs
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/albany/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/albany
+    target:
+      kind: SecretStore
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/albany/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.albany.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liezggam3Edgcsfs
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/albany/openshift-config/github-client-secret
-
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/albany
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/albany/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.albany.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - albany.nerc.mghpcc.org
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - albany.nerc.mghpcc.org
+    target:
+      kind: Issuer
+      name: letsencrypt-.*-dns01

--- a/cluster-scope/overlays/albany/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/albany/secretstores/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -2,24 +2,24 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/openapi
-- ../../base/core/configmaps/admin-acks/
-- ../../base/machineconfiguration.openshift.io/kubeletconfigs/system-reserved
-- ../../base/machineconfiguration.openshift.io/machineconfigs/sysctl-ip-forward/
-- ../../base/config.openshift.io/oauths/cluster
-- ../../base/rbac.authorization.k8s.io/clusterroles/node-labeler/
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
-- ../../bundles/cert-manager
-- ../../bundles/openshift-operators-redhat
-- ../../bundles/external-secrets
-- ../../bundles/nmstate
-- ../../bundles/console
-- ../../bundles/image-registry
-- ../../bundles/logging
-- ../../bundles/group-sync-github
-- ../../bundles/nerc-ops-rbac
-- ../../base/operator.openshift.io/networks/cluster
-- machineconfigs
+  - ../../base/openapi
+  - ../../base/core/configmaps/admin-acks/
+  - ../../base/machineconfiguration.openshift.io/kubeletconfigs/system-reserved
+  - ../../base/machineconfiguration.openshift.io/machineconfigs/sysctl-ip-forward/
+  - ../../base/config.openshift.io/oauths/cluster
+  - ../../base/rbac.authorization.k8s.io/clusterroles/node-labeler/
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
+  - ../../bundles/cert-manager
+  - ../../bundles/openshift-operators-redhat
+  - ../../bundles/external-secrets
+  - ../../bundles/nmstate
+  - ../../bundles/console
+  - ../../bundles/image-registry
+  - ../../bundles/logging
+  - ../../bundles/group-sync-github
+  - ../../bundles/nerc-ops-rbac
+  - ../../base/operator.openshift.io/networks/cluster
+  - machineconfigs
 
 components:
-- ../../components/custom-certificates
+  - ../../components/custom-certificates

--- a/cluster-scope/overlays/common/machineconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/common/machineconfigs/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- 99-master-ssh.yaml
-- 99-worker-ssh.yaml
+  - 99-master-ssh.yaml
+  - 99-worker-ssh.yaml

--- a/cluster-scope/overlays/hypershift1/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - clusterversion.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/hypershift1/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- clusterversion.yaml
+  - clusterversion.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/hypershift2/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/certificates/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
-- console-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml
+  - console-certificate.yaml

--- a/cluster-scope/overlays/hypershift2/clusterrolebindings/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/clusterrolebindings/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-ops-cluster-admin.yaml
+  - nerc-ops-cluster-admin.yaml

--- a/cluster-scope/overlays/hypershift2/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/hypershift2/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/feature/odf/kustomization.yaml
@@ -2,12 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
 
 resources:
-  - ../../../../bundles/odf-external
-  - externalsecrets/rook-ceph-external-cluster-details.yaml
+- ../../../../bundles/odf-external
+- externalsecrets/rook-ceph-external-cluster-details.yaml
 
 patches:
-  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/hypershift2/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/feature/odf/kustomization.yaml
@@ -2,12 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
-
 resources:
   - ../../../../bundles/odf-external
   - externalsecrets/rook-ceph-external-cluster-details.yaml
 
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/hypershift2/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/kustomization.yaml
@@ -1,11 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
-
 - certificates
 - console
 - clusterrolebindings
@@ -15,7 +12,6 @@ resources:
 - externalsecrets
 - metallb-config
 - lvmcluster
-
 - ../../bundles/external-secrets-clustersecretstore
 - ../../bundles/metallb
 - ../../bundles/nerc-certificate-clusterissuers
@@ -26,24 +22,29 @@ resources:
 - ../../bundles/acm-observability
 
 components:
-  - ../../components/nerc-oauth-github
+- ../../components/nerc-oauth-github
 
 configMapGenerator:
-- name: cluster-monitoring-config
+- files:
+  - config.yaml=configmaps/cluster-monitoring-config.yaml
+  name: cluster-monitoring-config
   namespace: openshift-monitoring
   options:
     disableNameSuffixHash: true
-  files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
 
+# per: https://docs.openshift.com/container-platform/4.17/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html
+# delete sysctl ip-forward patch (this is handled via the network.operator config)
+
+# enable http/2 in ingresscontroller
+# (https://www.redhat.com/en/blog/grpc-or-http/2-ingress-connectivity-in-openshift)
 patches:
-- target:
-    kind: ClusterIssuer
-    name: letsencrypt-.*-dns01
-  patch: |
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones/0
       value: hypershift2.nerc.mghpcc.org
+  target:
+    kind: ClusterIssuer
+    name: letsencrypt-.*-dns01
 - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1
@@ -55,106 +56,99 @@ patches:
       - name: github
         github:
           clientID: Ov23liFL7hFi2qkzUlIQ
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/hypershift2/openshift-config/github-client-secret
-- target:
+  target:
     kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/hypershift2/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.hypershift2.nerc.mghpcc.org
-- target:
-    kind: ExternalSecret
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/secretStoreRef
       value:
         kind: ClusterSecretStore
         name: nerc-cluster-secrets
-- target:
+  target:
     kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+- patch: |
     - op: add
       path: /metadata/namespace
       value: openshift-operators
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/hypershift2/openshift-operators/aws-route53-credentials
-- target:
-    kind: Subscription
-    name: odf-operator
-    namespace: openshift-storage
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-4.18
-- target:
+  target:
     kind: Subscription
-    name: acm
-    namespace: open-cluster-management
-  patch: |
+    name: odf-operator
+    namespace: openshift-storage
+- patch: |
     - op: replace
       path: /spec/channel
       value: release-2.13
-- target:
+  target:
     kind: Subscription
-    name: openshift-gitops-operator
-  patch: |
+    name: acm
+    namespace: open-cluster-management
+- patch: |
     - op: replace
       path: /spec/channel
       value: gitops-1.17
-
-# per: https://docs.openshift.com/container-platform/4.17/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html
-- target:
-    kind: IngressController
-    name: default
-    namespace: openshift-ingress-operator
-  patch: |
+  target:
+    kind: Subscription
+    name: openshift-gitops-operator
+- patch: |
     - op: add
       path: /spec/routeAdmission
       value:
         wildcardPolicy: WildcardsAllowed
-
-- target:
-    kind: Network
-    group: operator.openshift.io
-    name: cluster
-  patch: |
+  target:
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+- patch: |
     - op: add
       path: /spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding
       value: Global
-
-# delete sysctl ip-forward patch (this is handled via the network.operator config)
+  target:
+    group: operator.openshift.io
+    kind: Network
+    name: cluster
 - patch: |
     apiVersion: machineconfiguration.openshift.io/v1
     kind: MachineConfig
     metadata:
       name: configure-sysctl-ip-forward
     $patch: delete
-
-- target:
-    kind: Subscription
-    name: ansible-automation-platform-operator
-    namespace: aap
-  patch: |
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-2.5
-
+  target:
+    kind: Subscription
+    name: ansible-automation-platform-operator
+    namespace: aap
 - patch: |
     apiVersion: operators.coreos.com/v1
     kind: OperatorGroup
@@ -165,9 +159,6 @@ patches:
       targetNamespaces:
       - aap
       - innabox
-
-# enable http/2 in ingresscontroller
-# (https://www.redhat.com/en/blog/grpc-or-http/2-ingress-connectivity-in-openshift)
 - patch: |
     apiVersion: operator.openshift.io/v1
     kind: IngressController
@@ -176,3 +167,7 @@ patches:
       name: default
       annotations:
         ingress.operator.openshift.io/default-enable-http2: 'true'
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/hypershift2/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/kustomization.yaml
@@ -1,178 +1,171 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-
-- certificates
-- console
-- clusterrolebindings
-- machineconfigs
-- nodenetworkconfigurationpolicies
-- feature/odf
-- externalsecrets
-- metallb-config
-- lvmcluster
-
-- ../../bundles/external-secrets-clustersecretstore
-- ../../bundles/metallb
-- ../../bundles/nerc-certificate-clusterissuers
-- ../../bundles/virt
-- ../../bundles/acm-cim
-- ../../bundles/openshift-gitops
-- ../../bundles/ansible-automation-platform-operator
-- ../../bundles/acm-observability
+  - ../common
+  - certificates
+  - console
+  - clusterrolebindings
+  - machineconfigs
+  - nodenetworkconfigurationpolicies
+  - feature/odf
+  - externalsecrets
+  - metallb-config
+  - lvmcluster
+  - ../../bundles/external-secrets-clustersecretstore
+  - ../../bundles/metallb
+  - ../../bundles/nerc-certificate-clusterissuers
+  - ../../bundles/virt
+  - ../../bundles/acm-cim
+  - ../../bundles/openshift-gitops
+  - ../../bundles/ansible-automation-platform-operator
+  - ../../bundles/acm-observability
 
 components:
   - ../../components/nerc-oauth-github
 
 configMapGenerator:
-- name: cluster-monitoring-config
-  namespace: openshift-monitoring
-  options:
-    disableNameSuffixHash: true
-  files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
+    options:
+      disableNameSuffixHash: true
 
 patches:
-- target:
-    kind: ClusterIssuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones/0
-      value: hypershift2.nerc.mghpcc.org
-- path: clustersecretstores/nerc-cluster-secrets_patch.yaml
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones/0
+        value: hypershift2.nerc.mghpcc.org
+    target:
+      kind: ClusterIssuer
+      name: letsencrypt-.*-dns01
+  - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liFL7hFi2qkzUlIQ
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/hypershift2/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/hypershift2/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.hypershift2.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liFL7hFi2qkzUlIQ
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/hypershift2/openshift-config/github-client-secret
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/hypershift2/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.hypershift2.nerc.mghpcc.org
-- target:
-    kind: ExternalSecret
-  patch: |
-    - op: replace
-      path: /spec/secretStoreRef
-      value:
-        kind: ClusterSecretStore
-        name: nerc-cluster-secrets
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: add
-      path: /metadata/namespace
-      value: openshift-operators
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/hypershift2/openshift-operators/aws-route53-credentials
-- target:
-    kind: Subscription
-    name: odf-operator
-    namespace: openshift-storage
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-4.18
-- target:
-    kind: Subscription
-    name: acm
-    namespace: open-cluster-management
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: release-2.13
-- target:
-    kind: Subscription
-    name: openshift-gitops-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: gitops-1.17
-
-# per: https://docs.openshift.com/container-platform/4.17/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html
-- target:
-    kind: IngressController
-    name: default
-    namespace: openshift-ingress-operator
-  patch: |
-    - op: add
-      path: /spec/routeAdmission
-      value:
-        wildcardPolicy: WildcardsAllowed
-
-- target:
-    kind: Network
-    group: operator.openshift.io
-    name: cluster
-  patch: |
-    - op: add
-      path: /spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding
-      value: Global
-
-# delete sysctl ip-forward patch (this is handled via the network.operator config)
-- patch: |
-    apiVersion: machineconfiguration.openshift.io/v1
-    kind: MachineConfig
-    metadata:
-      name: configure-sysctl-ip-forward
-    $patch: delete
-
-- target:
-    kind: Subscription
-    name: ansible-automation-platform-operator
-    namespace: aap
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-2.5
-
-- patch: |
-    apiVersion: operators.coreos.com/v1
-    kind: OperatorGroup
-    metadata:
+  - patch: |
+      - op: replace
+        path: /spec/secretStoreRef
+        value:
+          kind: ClusterSecretStore
+          name: nerc-cluster-secrets
+    target:
+      kind: ExternalSecret
+  - patch: |
+      - op: add
+        path: /metadata/namespace
+        value: openshift-operators
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/hypershift2/openshift-operators/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-4.18
+    target:
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: release-2.13
+    target:
+      kind: Subscription
+      name: acm
+      namespace: open-cluster-management
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: gitops-1.17
+    target:
+      kind: Subscription
+      name: openshift-gitops-operator
+  - patch: |
+      - op: add
+        path: /spec/routeAdmission
+        value:
+          wildcardPolicy: WildcardsAllowed
+    target:
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+  - patch: |
+      - op: add
+        path: /spec/defaultNetwork/ovnKubernetesConfig/gatewayConfig/ipForwarding
+        value: Global
+    target:
+      group: operator.openshift.io
+      kind: Network
+      name: cluster
+  # delete sysctl ip-forward patch (this is handled via the network.operator config)
+  - patch: |
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        name: configure-sysctl-ip-forward
+      $patch: delete
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-2.5
+    target:
+      kind: Subscription
       name: ansible-automation-platform-operator
       namespace: aap
-    spec:
-      targetNamespaces:
-      - aap
-      - innabox
-
-# enable http/2 in ingresscontroller
-# (https://www.redhat.com/en/blog/grpc-or-http/2-ingress-connectivity-in-openshift)
-- patch: |
-    apiVersion: operator.openshift.io/v1
-    kind: IngressController
-    metadata:
-      namespace: openshift-ingress-operator
-      name: default
-      annotations:
-        ingress.operator.openshift.io/default-enable-http2: 'true'
+  - patch: |
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: ansible-automation-platform-operator
+        namespace: aap
+      spec:
+        targetNamespaces:
+        - aap
+        - innabox
+  # enable http/2 in ingresscontroller
+  # (https://www.redhat.com/en/blog/grpc-or-http/2-ingress-connectivity-in-openshift)
+  - patch: |
+      apiVersion: operator.openshift.io/v1
+      kind: IngressController
+      metadata:
+        namespace: openshift-ingress-operator
+        name: default
+        annotations:
+          ingress.operator.openshift.io/default-enable-http2: 'true'
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/hypershift2/lvmcluster/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/lvmcluster/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- lvmcluster.yaml
-- subscription.yaml
+  - lvmcluster.yaml
+  - subscription.yaml

--- a/cluster-scope/overlays/hypershift2/machineconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/machineconfigs/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- udev-rules
+  - udev-rules

--- a/cluster-scope/overlays/hypershift2/metallb-config/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/metallb-config/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metallb-system
 resources:
-- ipaddresspool.yaml
-- l2advertisement.yaml
+  - ipaddresspool.yaml
+  - l2advertisement.yaml

--- a/cluster-scope/overlays/hypershift2/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift2/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-infra-routed.yaml
+  - nerc-infra-routed.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-beta-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/kustomization.yaml
@@ -1,18 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
-
 - ../../bundles/node-feature-discovery
 - ../../bundles/patch-operator
 - ../../bundles/clusterissuer-http01
 - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/rbac.authorization.k8s.io/clusterrolebindings/instructlab-admins
-
 - externalsecrets
 - issuers
 - feature/odf
@@ -21,18 +17,16 @@ resources:
 - secretstores
 - nodenetworkconfigurationpolicies
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-github
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-github
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -43,39 +37,42 @@ patches:
       - name: github
         github:
           clientID: Ov23liVTVUlKJYCJjWhF
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-beta-test/openshift-config/github-client-secret
-
-- target:
-    kind: SecretStore
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/nerc-ocp-beta-test
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+  target:
+    kind: SecretStore
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/nerc-ocp-beta-test/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.ocp-beta-test.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - ocp-beta-test.nerc.mghpcc.org
+  target:
+    kind: Issuer
+    name: letsencrypt-.*-dns01
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-beta-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/kustomization.yaml
@@ -1,29 +1,24 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-
-- ../../bundles/node-feature-discovery
-- ../../bundles/patch-operator
-- ../../bundles/clusterissuer-http01
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/core/namespaces/openshift-gitops
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/instructlab-admins
-
-- externalsecrets
-- issuers
-- feature/odf
-- machineconfigs
-- certificates
-- secretstores
-- nodenetworkconfigurationpolicies
+  - ../common
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/patch-operator
+  - ../../bundles/clusterissuer-http01
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/core/namespaces/openshift-gitops
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/instructlab-admins
+  - externalsecrets
+  - issuers
+  - feature/odf
+  - machineconfigs
+  - certificates
+  - secretstores
+  - nodenetworkconfigurationpolicies
 
 components:
   - ../../components/nerc-oauth-github
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
@@ -32,50 +27,52 @@ generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liVTVUlKJYCJjWhF
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-beta-test/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/nerc-ocp-beta-test
+    target:
+      kind: SecretStore
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-beta-test/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.ocp-beta-test.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liVTVUlKJYCJjWhF
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-beta-test/openshift-config/github-client-secret
-
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/nerc-ocp-beta-test
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-beta-test/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.ocp-beta-test.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - ocp-beta-test.nerc.mghpcc.org
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - ocp-beta-test.nerc.mghpcc.org
+    target:
+      kind: Issuer
+      name: letsencrypt-.*-dns01
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/block-public-ssh/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- machineconfig-controller.yaml
-- machineconfig-worker.yaml
+  - machineconfig-controller.yaml
+  - machineconfig-worker.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/machineconfigs/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- udev-rules/
-- block-public-ssh/
+  - udev-rules/
+  - block-public-ssh/

--- a/cluster-scope/overlays/nerc-ocp-beta-test/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- eth-nese.yaml
-- vlan-211.yaml
+  - eth-nese.yaml
+  - vlan-211.yaml

--- a/cluster-scope/overlays/nerc-ocp-beta-test/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-beta-test/secretstores/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator

--- a/cluster-scope/overlays/nerc-ocp-edu/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/consolelinks/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/consolelinks/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-helpdesk.yaml
+  - nerc-helpdesk.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/feature/custom-routes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/feature/custom-routes/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cluster-ingress.yaml
+  - cluster-ingress.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-edu/kueue-config/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/kueue-config/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- kueue-clusterqueue.yaml
-- kueue-resource-flavor.yaml
+  - kueue-clusterqueue.yaml
+  - kueue-resource-flavor.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
+# - object-storage
 resources:
 - ../common
 - ../../bundles/acct-mgt
@@ -45,27 +44,25 @@ resources:
 - certificates
 - consolelinks
 - rhoai
-# - object-storage
 - rbac
 - kueue-config
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-keycloak
-  - ../../components/nerc-oauth-github
-  - ../../components/resourcequotas/ope-course-quota
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-keycloak
+- ../../components/nerc-oauth-github
+- ../../components/resourcequotas/ope-course-quota
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
 
-configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
   # literals:
+configMapGenerator:
+- behavior: merge
+  name: admin-acks
+  namespace: openshift-config
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config
@@ -73,12 +70,12 @@ configMapGenerator:
 
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/nerc-ocp-edu
+  target:
+    kind: SecretStore
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -99,84 +96,88 @@ patches:
       - name: github
         github:
           clientID: Ov23liod1RxViSyoQ5FW
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-edu/openshift-config/oauths-clientsecret-nerc
-- target:
+  target:
     kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+    name: oauths-clientsecret-nerc
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/nerc-ocp-edu/aws-route53-credentials
-- target:
+  target:
     kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-edu/openshift-config/github-client-secret
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.edu.nerc.mghpcc.org
-- target:
-    kind: PersistentVolumeClaim
-    name: image-registry-storage
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/resources/requests/storage
       value: 750Gi
-- target:
-    kind: Subscription
-    name: cluster-logging
-  patch: |
+  target:
+    kind: PersistentVolumeClaim
+    name: image-registry-storage
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-6.3
-- target:
+  target:
     kind: Subscription
-    name: rhods-operator
-  patch: |
+    name: cluster-logging
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-2.22
     - op: replace
       path: /spec/startingCSV
       value: rhods-operator.2.22.3
-- target:
+  target:
     kind: Subscription
-    name: gpu-operator-certified
-  patch: |
+    name: rhods-operator
+- patch: |
     - op: replace
       path: /spec/channel
       value: v25.3
-- target:
+  target:
     kind: Subscription
-    name: ansible-automation-platform-operator
-  patch: |
+    name: gpu-operator-certified
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-2.5-cluster-scoped
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: Subscription
+    name: ansible-automation-platform-operator
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - edu.nerc.mghpcc.org
-- target:
-    kind: Subscription
-    name: strimzi-kafka-operator
-  patch: |
+  target:
+    kind: Issuer
+    name: letsencrypt-.*-dns01
+- patch: |
     - op: replace
       path: /spec/channel
       value: strimzi-0.50.x
+  target:
+    kind: Subscription
+    name: strimzi-kafka-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/kustomization.yaml
@@ -1,59 +1,55 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/acct-mgt
-- ../../bundles/patch-operator
-- ../../bundles/solr-helm-repo
-- ../../bundles/ansible-automation-platform-operator
-- ../../bundles/openshift-serverless-operator
-- ../../bundles/authorino-operator
-- ../../bundles/servicemesh-operator
-- ../../bundles/amq-broker-rhel8-operator
-- ../../bundles/crunchy-postgres-operator
-- ../../bundles/amq-streams-operator
-- ../../bundles/openshift-pipelines-operator
-- ../../bundles/openshift-opentelemetry-operator
-- ../../bundles/rhods-operator
-- ../../bundles/node-feature-discovery
-- ../../bundles/nvidia-gpu-operator
-- ../../bundles/openshift-custom-metrics-autoscaler-operator
-- ../../bundles/clusterissuer-http01
-- ../../bundles/koku-metrics-operator
-- ../../bundles/autopilot
-- ../../bundles/mongodb-operator
-- ../../bundles/nagios-monitoring
-- ../../bundles/moc-metrics-collector
-- ../../bundles/strimzi-kafka-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
-- ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader
-- feature/odf
-- feature/custom-routes
-- ../../base/core/namespaces/openshift-gitops
-- externalsecrets
-- secretstores
-- issuers
-- machineconfigs
-- nodenetworkconfigurationpolicies
-- clusterversion.yaml
-- certificates
-- consolelinks
-- rhoai
-# - object-storage
-- rbac
-- kueue-config
+  - ../common
+  - ../../bundles/acct-mgt
+  - ../../bundles/patch-operator
+  - ../../bundles/solr-helm-repo
+  - ../../bundles/ansible-automation-platform-operator
+  - ../../bundles/openshift-serverless-operator
+  - ../../bundles/authorino-operator
+  - ../../bundles/servicemesh-operator
+  - ../../bundles/amq-broker-rhel8-operator
+  - ../../bundles/crunchy-postgres-operator
+  - ../../bundles/amq-streams-operator
+  - ../../bundles/openshift-pipelines-operator
+  - ../../bundles/openshift-opentelemetry-operator
+  - ../../bundles/rhods-operator
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/nvidia-gpu-operator
+  - ../../bundles/openshift-custom-metrics-autoscaler-operator
+  - ../../bundles/clusterissuer-http01
+  - ../../bundles/koku-metrics-operator
+  - ../../bundles/autopilot
+  - ../../bundles/mongodb-operator
+  - ../../bundles/nagios-monitoring
+  - ../../bundles/moc-metrics-collector
+  - ../../bundles/strimzi-kafka-operator
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
+  - ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader
+  - feature/odf
+  - feature/custom-routes
+  - ../../base/core/namespaces/openshift-gitops
+  - externalsecrets
+  - secretstores
+  - issuers
+  - machineconfigs
+  - nodenetworkconfigurationpolicies
+  - clusterversion.yaml
+  - certificates
+  - consolelinks
+  - rhoai
+  - rbac
+  - kueue-config
 
 components:
   - ../../components/nerc-oauth-keycloak
   - ../../components/nerc-oauth-github
   - ../../components/resourcequotas/ope-course-quota
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
@@ -61,122 +57,126 @@ components:
 generatorOptions:
   disableNameSuffixHash: true
 
-configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
   # literals:
-- files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+configMapGenerator:
+  - behavior: merge
+    name: admin-acks
+    namespace: openshift-config
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 
 patches:
-- path: kubeletconfigs/system-reserved-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/nerc-ocp-edu
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - path: kubeletconfigs/system-reserved-patch.yaml
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/nerc-ocp-edu
+    target:
+      kind: SecretStore
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: mss-keycloak
+          openID:
+            clientID: ocp-edu
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liod1RxViSyoQ5FW
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-edu/openshift-config/oauths-clientsecret-nerc
+    target:
+      kind: ExternalSecret
+      name: oauths-clientsecret-nerc
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-edu/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-edu/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.edu.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: mss-keycloak
-        openID:
-          clientID: ocp-edu
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
-      name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liod1RxViSyoQ5FW
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-edu/openshift-config/oauths-clientsecret-nerc
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-edu/aws-route53-credentials
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-edu/openshift-config/github-client-secret
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.edu.nerc.mghpcc.org
-- target:
-    kind: PersistentVolumeClaim
-    name: image-registry-storage
-  patch: |
-    - op: replace
-      path: /spec/resources/requests/storage
-      value: 750Gi
-- target:
-    kind: Subscription
-    name: cluster-logging
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-6.3
-- target:
-    kind: Subscription
-    name: rhods-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-2.22
-    - op: replace
-      path: /spec/startingCSV
-      value: rhods-operator.2.22.3
-- target:
-    kind: Subscription
-    name: gpu-operator-certified
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: v25.3
-- target:
-    kind: Subscription
-    name: ansible-automation-platform-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-2.5-cluster-scoped
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - edu.nerc.mghpcc.org
-- target:
-    kind: Subscription
-    name: strimzi-kafka-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: strimzi-0.50.x
+  - patch: |
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 750Gi
+    target:
+      kind: PersistentVolumeClaim
+      name: image-registry-storage
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-6.3
+    target:
+      kind: Subscription
+      name: cluster-logging
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-2.22
+      - op: replace
+        path: /spec/startingCSV
+        value: rhods-operator.2.22.3
+    target:
+      kind: Subscription
+      name: rhods-operator
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: v25.3
+    target:
+      kind: Subscription
+      name: gpu-operator-certified
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-2.5-cluster-scoped
+    target:
+      kind: Subscription
+      name: ansible-automation-platform-operator
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - edu.nerc.mghpcc.org
+    target:
+      kind: Issuer
+      name: letsencrypt-.*-dns01
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: strimzi-0.50.x
+    target:
+      kind: Subscription
+      name: strimzi-kafka-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-edu/object-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/object-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
 - backingstore.yaml
 - bucketclass.yaml
 - storageclass.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-edu/object-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/object-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
-- backingstore.yaml
-- bucketclass.yaml
-- storageclass.yaml
+  - backingstore.yaml
+  - bucketclass.yaml
+  - storageclass.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-edu/rbac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rbac/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- jschless-node-reader.yaml
-- autopilot-service-acc-node-reader.yaml
-- gpu-class-clusterroles.yaml
+  - jschless-node-reader.yaml
+  - autopilot-service-acc-node-reader.yaml
+  - gpu-class-clusterroles.yaml

--- a/cluster-scope/overlays/nerc-ocp-edu/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/rhoai/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- datasciencecluster.yaml
-- odhdashboardconfigs/odh-dashboard-config.yaml
-- imagestreams/ucsls-f24-imagestream.yaml
-- imagestreams/oauth-proxy.yaml
-- acceleratorprofiles
+  - datasciencecluster.yaml
+  - odhdashboardconfigs/odh-dashboard-config.yaml
+  - imagestreams/ucsls-f24-imagestream.yaml
+  - imagestreams/oauth-proxy.yaml
+  - acceleratorprofiles

--- a/cluster-scope/overlays/nerc-ocp-edu/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-edu/secretstores/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator

--- a/cluster-scope/overlays/nerc-ocp-infra/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- rook-ceph-external-cluster-details.yaml
-- github-group-sync.yaml
+  - rook-ceph-external-cluster-details.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/feature/custom-routes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/custom-routes/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cluster-ingress.yaml
+  - cluster-ingress.yaml

--- a/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
@@ -2,11 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
 
 resources:
-  - ../../../../bundles/odf-external
+- ../../../../bundles/odf-external
 
 patches:
-  - path: subscriptions/subscription-patch.yaml
+- path: subscriptions/subscription-patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/feature/odf/kustomization.yaml
@@ -2,11 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
-
 resources:
   - ../../../../bundles/odf-external
 
 patches:
   - path: subscriptions/subscription-patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-infra/grafana-dashboards/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/grafana-dashboards/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - grafana-dev-dashboard.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/cluster-scope/overlays/nerc-ocp-infra/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
@@ -35,20 +33,20 @@ resources:
 - persistentvolumeclaims
 - nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
 components:
-  - ../../components/nerc-oauth-github
+- ../../components/nerc-oauth-github
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
+- behavior: merge
   literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
-    - ack-4.13-kube-1.27-api-removals-in-4.14=true
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
+  - ack-4.11-kube-1.25-api-removals-in-4.12=true
+  - ack-4.12-kube-1.26-api-removals-in-4.13=true
+  - ack-4.13-kube-1.27-api-removals-in-4.14=true
+  - ack-4.18-kube-1.32-api-removals-in-4.19=true
+  name: admin-acks
+  namespace: openshift-config
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config
@@ -71,46 +69,50 @@ patches:
           teams:
             - ocp-on-nerc/nerc-ops
             - ocp-on-nerc/nerc-logs-metrics
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-infra/openshift-config/github-client-secret
-- target:
+  target:
     kind: ExternalSecret
-  patch: |
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/secretStoreRef
       value:
         kind: ClusterSecretStore
         name: nerc-cluster-secrets
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.infra.nerc.mghpcc.org
-- target:
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
+    - op: replace
+      path: /spec/channel
+      value: stable-6.3
+  target:
     kind: Subscription
     name: cluster-logging
-  patch: |
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-6.3
-- target:
+  target:
     kind: Subscription
     name: loki-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-6.3
-- target:
-    kind: Issuer
-  patch: |
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - infra.nerc.mghpcc.org
+  target:
+    kind: Issuer
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,39 +1,37 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/openshift-gitops
-- ../../bundles/acm
-- ../../bundles/acm-observability
-- ../../bundles/hostpath-provisioner
-- ../../bundles/patch-operator
-- ../../bundles/external-secrets-clustersecretstore
-- ../../bundles/multicluster-engine-operator
-- ../../bundles/grafana
-- ../../bundles/nagios-monitoring
-- ../../base/core/namespaces/dex
-- ../../base/core/namespaces/nerc-ocp-prod
-- ../../base/core/namespaces/nerc-ocp-obs
-- ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
-- ../../base/operators.coreos.com/subscriptions/loki-operator
-- issuers
-- certificates
-- feature/custom-routes
-- feature/odf
-- clusterversion.yaml
-- machineconfigs/disable-net-ifnames.yaml
-- machineconfigs/refresh-storage-interface.yaml
-- machineconfigs/udev-rules
-- machineconfigs/configure-bond0
-- nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
-- externalsecrets
-- redhatcop.redhat.io/odf-node-patcher.yaml
-- grafana-dashboards
-- persistentvolumeclaims
-- nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
+  - ../common
+  - ../../bundles/openshift-gitops
+  - ../../bundles/acm
+  - ../../bundles/acm-observability
+  - ../../bundles/hostpath-provisioner
+  - ../../bundles/patch-operator
+  - ../../bundles/external-secrets-clustersecretstore
+  - ../../bundles/multicluster-engine-operator
+  - ../../bundles/grafana
+  - ../../bundles/nagios-monitoring
+  - ../../base/core/namespaces/dex
+  - ../../base/core/namespaces/nerc-ocp-prod
+  - ../../base/core/namespaces/nerc-ocp-obs
+  - ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator
+  - ../../base/operators.coreos.com/subscriptions/loki-operator
+  - issuers
+  - certificates
+  - feature/custom-routes
+  - feature/odf
+  - clusterversion.yaml
+  - machineconfigs/disable-net-ifnames.yaml
+  - machineconfigs/refresh-storage-interface.yaml
+  - machineconfigs/udev-rules
+  - machineconfigs/configure-bond0
+  - nodenetworkconfigurationpolicies/vlan-2177-nese.yaml
+  - externalsecrets
+  - redhatcop.redhat.io/odf-node-patcher.yaml
+  - grafana-dashboards
+  - persistentvolumeclaims
+  - nerc-logs-metrics-open-cluster-management-cluster-manager-admin.yaml
 components:
   - ../../components/nerc-oauth-github
 
@@ -41,76 +39,80 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
-  literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
-    - ack-4.13-kube-1.27-api-removals-in-4.14=true
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
-- files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  - behavior: merge
+    literals:
+      - ack-4.11-kube-1.25-api-removals-in-4.12=true
+      - ack-4.12-kube-1.26-api-removals-in-4.13=true
+      - ack-4.13-kube-1.27-api-removals-in-4.14=true
+      - ack-4.18-kube-1.32-api-removals-in-4.19=true
+    name: admin-acks
+    namespace: openshift-config
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 
 patches:
-- path: consoles.operator.openshift.io/cluster_patch.yaml
-- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
-- path: clustersecretstores/nerc-cluster-secrets_patch.yaml
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - path: consoles.operator.openshift.io/cluster_patch.yaml
+  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+  - path: clustersecretstores/nerc-cluster-secrets_patch.yaml
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: 77915cd4cdb5c4df7723
+            teams:
+              - ocp-on-nerc/nerc-ops
+              - ocp-on-nerc/nerc-logs-metrics
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-infra/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/secretStoreRef
+        value:
+          kind: ClusterSecretStore
+          name: nerc-cluster-secrets
+    target:
+      kind: ExternalSecret
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.infra.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: 77915cd4cdb5c4df7723
-          teams:
-            - ocp-on-nerc/nerc-ops
-            - ocp-on-nerc/nerc-logs-metrics
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-infra/openshift-config/github-client-secret
-- target:
-    kind: ExternalSecret
-  patch: |
-    - op: replace
-      path: /spec/secretStoreRef
-      value:
-        kind: ClusterSecretStore
-        name: nerc-cluster-secrets
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.infra.nerc.mghpcc.org
-- target:
-    kind: Subscription
-    name: cluster-logging
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-6.3
-- target:
-    kind: Subscription
-    name: loki-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-6.3
-- target:
-    kind: Issuer
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - infra.nerc.mghpcc.org
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-6.3
+    target:
+      kind: Subscription
+      name: cluster-logging
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-6.3
+    target:
+      kind: Subscription
+      name: loki-operator
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - infra.nerc.mghpcc.org
+    target:
+      kind: Issuer
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-infra/persistentvolumeclaims/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - openshift-storage-db-noobaa-db-pg-0.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/cluster-scope/overlays/nerc-ocp-obs/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
-
-# clean up, rook-ceph-external-cluster now under feature/odf
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
@@ -2,14 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
 
 resources:
-  - ../../../../bundles/odf-external
-  - externalsecrets/rook-ceph-external-cluster-details.yaml
-  - redhatcop.redhat.io/odf-node-patcher.yaml
+- ../../../../bundles/odf-external
+- externalsecrets/rook-ceph-external-cluster-details.yaml
+- redhatcop.redhat.io/odf-node-patcher.yaml
 
 patches:
-  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
-  - path: subscriptions/subscription-patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+- path: subscriptions/subscription-patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/feature/odf/kustomization.yaml
@@ -2,9 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
-
 resources:
   - ../../../../bundles/odf-external
   - externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -13,3 +10,7 @@ resources:
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
   - path: subscriptions/subscription-patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
@@ -36,23 +34,22 @@ resources:
 - machineconfigs
 - nodenetworkconfigurationpolicies
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-github
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-github
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
+- behavior: merge
   literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
+  - ack-4.11-kube-1.25-api-removals-in-4.12=true
+  - ack-4.12-kube-1.26-api-removals-in-4.13=true
+  name: admin-acks
+  namespace: openshift-config
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config
@@ -61,12 +58,12 @@ configMapGenerator:
 patches:
 - path: configmaps/nerc-logo_patch.yaml
 - path: kubeletconfigs/system-reserved-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/nerc-ocp-obs
+  target:
+    kind: SecretStore
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -81,17 +78,14 @@ patches:
             - ocp-on-nerc/nerc-ops
             - ocp-on-nerc/nerc-logs-metrics
             - ocp-on-nerc/nerc-obs-admins
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/nerc-ocp-obs/aws-route53-credentials
-- target:
+  target:
     kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-obs/openshift-config/github-client-secret
@@ -100,21 +94,24 @@ patches:
       value:
         kind: ClusterSecretStore
         name: nerc-cluster-secrets
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.obs.nerc.mghpcc.org
-- target:
-    kind: ClusterIssuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - obs.nerc.mghpcc.org
+  target:
+    kind: ClusterIssuer
+    name: letsencrypt-.*-dns01
 - patch: |
     apiVersion: external-secrets.io/v1beta1
     kind: ClusterSecretStore
@@ -127,3 +124,7 @@ patches:
             kubernetes:
               mountPath: kubernetes/nerc-ocp-obs
           server: https://vault-ui-vault.apps.infra.nerc.mghpcc.org/
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,44 +1,41 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/node-feature-discovery
-- ../../bundles/clusterissuer-http01
-- ../../bundles/nerc-certificate-clusterissuers
-- ../../bundles/external-secrets-clustersecretstore
-- ../../bundles/grafana
-- ../../bundles/crunchy-postgres-operator
-- ../../bundles/keycloak
-- ../../bundles/prom-keycloak-proxy
-- ../../bundles/zookeeper
-- ../../bundles/solr
-- ../../bundles/postgres
-- ../../bundles/minio
-- ../../bundles/opentelemetry
-- ../../bundles/snmp-exporter
-- ../../bundles/cluster-observability-operator
-- ../../bundles/solr-helm-repo
-- ../../base/core/namespaces/openshift-gitops
-- ../../base/core/namespaces/dex
-- ../../base/core/namespaces/aitelemetry
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/operators.coreos.com/subscriptions/loki-operator
-- ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-ops
-- clusterversion.yaml
-- externalsecrets
-- logs-storage
-- logsarchive-storage
-- feature/odf
-- certificates
-- machineconfigs
-- nodenetworkconfigurationpolicies
+  - ../common
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/clusterissuer-http01
+  - ../../bundles/nerc-certificate-clusterissuers
+  - ../../bundles/external-secrets-clustersecretstore
+  - ../../bundles/grafana
+  - ../../bundles/crunchy-postgres-operator
+  - ../../bundles/keycloak
+  - ../../bundles/prom-keycloak-proxy
+  - ../../bundles/zookeeper
+  - ../../bundles/solr
+  - ../../bundles/postgres
+  - ../../bundles/minio
+  - ../../bundles/opentelemetry
+  - ../../bundles/snmp-exporter
+  - ../../bundles/cluster-observability-operator
+  - ../../bundles/solr-helm-repo
+  - ../../base/core/namespaces/openshift-gitops
+  - ../../base/core/namespaces/dex
+  - ../../base/core/namespaces/aitelemetry
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/operators.coreos.com/subscriptions/loki-operator
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/nerc-obs-admins-ops
+  - clusterversion.yaml
+  - externalsecrets
+  - logs-storage
+  - logsarchive-storage
+  - feature/odf
+  - certificates
+  - machineconfigs
+  - nodenetworkconfigurationpolicies
 
 components:
   - ../../components/nerc-oauth-github
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
@@ -47,83 +44,87 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
-  literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
-- files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  - behavior: merge
+    literals:
+      - ack-4.11-kube-1.25-api-removals-in-4.12=true
+      - ack-4.12-kube-1.26-api-removals-in-4.13=true
+    name: admin-acks
+    namespace: openshift-config
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 
 patches:
-- path: configmaps/nerc-logo_patch.yaml
-- path: kubeletconfigs/system-reserved-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/nerc-ocp-obs
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - path: configmaps/nerc-logo_patch.yaml
+  - path: kubeletconfigs/system-reserved-patch.yaml
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/nerc-ocp-obs
+    target:
+      kind: SecretStore
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: de5c05238a2bf843860f
+            teams:
+              - ocp-on-nerc/nerc-ops
+              - ocp-on-nerc/nerc-logs-metrics
+              - ocp-on-nerc/nerc-obs-admins
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-obs/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-obs/openshift-config/github-client-secret
+      - op: replace
+        path: /spec/secretStoreRef
+        value:
+          kind: ClusterSecretStore
+          name: nerc-cluster-secrets
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.obs.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: de5c05238a2bf843860f
-          teams:
-            - ocp-on-nerc/nerc-ops
-            - ocp-on-nerc/nerc-logs-metrics
-            - ocp-on-nerc/nerc-obs-admins
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-obs/aws-route53-credentials
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-obs/openshift-config/github-client-secret
-    - op: replace
-      path: /spec/secretStoreRef
-      value:
-        kind: ClusterSecretStore
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - obs.nerc.mghpcc.org
+    target:
+      kind: ClusterIssuer
+      name: letsencrypt-.*-dns01
+  - patch: |
+      apiVersion: external-secrets.io/v1beta1
+      kind: ClusterSecretStore
+      metadata:
         name: nerc-cluster-secrets
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.obs.nerc.mghpcc.org
-- target:
-    kind: ClusterIssuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - obs.nerc.mghpcc.org
-- patch: |
-    apiVersion: external-secrets.io/v1beta1
-    kind: ClusterSecretStore
-    metadata:
-      name: nerc-cluster-secrets
-    spec:
-      provider:
-        vault:
-          auth:
-            kubernetes:
-              mountPath: kubernetes/nerc-ocp-obs
-          server: https://vault-ui-vault.apps.infra.nerc.mghpcc.org/
+      spec:
+        provider:
+          vault:
+            auth:
+              kubernetes:
+                mountPath: kubernetes/nerc-ocp-obs
+            server: https://vault-ui-vault.apps.infra.nerc.mghpcc.org/
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-obs/logs-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/logs-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
 - backingstore.yaml
 - bucketclass.yaml
 - storageclass.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-obs/logs-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/logs-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
-- backingstore.yaml
-- bucketclass.yaml
-- storageclass.yaml
+  - backingstore.yaml
+  - bucketclass.yaml
+  - storageclass.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-obs/logsarchive-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/logsarchive-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
 - backingstore.yaml
 - bucketclass.yaml
 - storageclass.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-obs/logsarchive-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/logsarchive-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
-- backingstore.yaml
-- bucketclass.yaml
-- storageclass.yaml
+  - backingstore.yaml
+  - bucketclass.yaml
+  - storageclass.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-obs/machineconfigs/configure-bond0/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/machineconfigs/configure-bond0/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- machineconfig.yaml
+  - machineconfig.yaml

--- a/cluster-scope/overlays/nerc-ocp-obs/machineconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/machineconfigs/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- configure-bond0/
+  - configure-bond0/

--- a/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- vlan-2177-nese.yaml
-- vlan-935-moc-swmon.yaml
+  - vlan-2177-nese.yaml
+  - vlan-935-moc-swmon.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/consolelinks/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/consolelinks/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-helpdesk.yaml
+  - nerc-helpdesk.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/custom-routes/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cluster-ingress.yaml
+  - cluster-ingress.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
@@ -2,18 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
 
 components:
-  - ../../../../components/nerc-secret-store
+- ../../../../components/nerc-secret-store
 
 resources:
-  - ../../../../bundles/odf-external
-  - externalsecrets/rook-ceph-external-cluster-details.yaml
-  - redhatcop.redhat.io/odf-node-patcher.yaml
-  - configmaps/rook-ceph-operator-config.yaml
+- ../../../../bundles/odf-external
+- externalsecrets/rook-ceph-external-cluster-details.yaml
+- redhatcop.redhat.io/odf-node-patcher.yaml
+- configmaps/rook-ceph-operator-config.yaml
 
 patches:
-  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
-  - path: subscriptions/subscription-patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+- path: subscriptions/subscription-patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/kustomization.yaml
@@ -2,9 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
-
 components:
   - ../../../../components/nerc-secret-store
 
@@ -17,3 +14,7 @@ resources:
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
   - path: subscriptions/subscription-patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-prod/groups/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/groups/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ai4dd-demo-group.yaml
+  - ai4dd-demo-group.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
@@ -55,29 +53,29 @@ resources:
 - rolebindings
 - groups
 
-components:
-  - ../../components/nerc-oauth-keycloak
-  - ../../components/nerc-oauth-github
-  - ../../components/resourcequotas/ope-course-quota
 
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+# this must come last in order to apply
+# to all resources.
+components:
+- ../../components/nerc-oauth-keycloak
+- ../../components/nerc-oauth-github
+- ../../components/resourcequotas/ope-course-quota
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
+- behavior: merge
   literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
-    - ack-4.13-kube-1.27-api-removals-in-4.14=true
-    - ack-4.15-kube-1.29-api-removals-in-4.16=true
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
-    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
+  - ack-4.11-kube-1.25-api-removals-in-4.12=true
+  - ack-4.12-kube-1.26-api-removals-in-4.13=true
+  - ack-4.13-kube-1.27-api-removals-in-4.14=true
+  - ack-4.15-kube-1.29-api-removals-in-4.16=true
+  - ack-4.18-kube-1.32-api-removals-in-4.19=true
+  - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
+  name: admin-acks
+  namespace: openshift-config
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config
@@ -86,12 +84,12 @@ configMapGenerator:
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
 - path: subscriptions/rhoai-operator-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/nerc-ocp-prod
+  target:
+    kind: SecretStore
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -112,69 +110,73 @@ patches:
       - name: github
         github:
           clientID: 771ea98004d436c6e529
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-prod/openshift-config/oauths-clientsecret-nerc
-- target:
+  target:
     kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+    name: oauths-clientsecret-nerc
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/nerc-ocp-prod/aws-route53-credentials
-- target:
+  target:
     kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-prod/openshift-config/github-client-secret
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.shift.nerc.mghpcc.org
-- target:
-    kind: PersistentVolumeClaim
-    name: image-registry-storage
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/resources/requests/storage
       value: 750Gi
-- target:
-    kind: Subscription
-    name: cluster-logging
-  patch: |
+  target:
+    kind: PersistentVolumeClaim
+    name: image-registry-storage
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-6.2
-- target:
+  target:
     kind: Subscription
-    name: rhods-operator
-  patch: |
+    name: cluster-logging
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-2.25
     - op: replace
       path: /spec/startingCSV
       value: rhods-operator.2.25.1
-- target:
+  target:
     kind: Subscription
-    name: gpu-operator-certified
-  patch: |
+    name: rhods-operator
+- patch: |
     - op: replace
       path: /spec/channel
       value: v25.10
-- target:
+  target:
     kind: Subscription
-    name: serverless-operator
-  patch: |
+    name: gpu-operator-certified
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-1.36
+  target:
+    kind: Subscription
+    name: serverless-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,67 +1,64 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/acct-mgt
-- ../../bundles/patch-operator
-- ../../bundles/moc-metrics-collector
-- ../../bundles/solr-helm-repo
-- ../../bundles/ansible-automation-platform-operator
-- ../../bundles/openshift-serverless-operator
-- ../../bundles/authorino-operator
-- ../../bundles/servicemesh-operator
-- ../../bundles/amq-broker-rhel8-operator
-- ../../bundles/crunchy-postgres-operator
-- ../../bundles/amq-streams-operator
-- ../../bundles/openshift-pipelines-operator
-- ../../bundles/openshift-opentelemetry-operator
-- ../../bundles/rhods-operator
-- ../../bundles/node-feature-discovery
-- ../../bundles/nvidia-gpu-operator
-- ../../bundles/nvidia-network-operator
-- ../../bundles/openshift-sriov-network-operator
-- ../../bundles/openshift-custom-metrics-autoscaler-operator
-- ../../bundles/clusterissuer-http01
-- ../../bundles/curator
-- ../../bundles/koku-metrics-operator
-- ../../bundles/autopilot
-- ../../bundles/mongodb-operator
-- ../../bundles/elasticsearch-eck-operator
-- ../../bundles/nagios-monitoring
-- ../../bundles/allow-list-crds
-- ../../bundles/strimzi-kafka-operator
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
-- ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
-- ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
-- ../../base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader
-- feature/odf
-- feature/custom-routes
-- ../../base/core/namespaces/openshift-gitops
-- externalsecrets
-- secretstores
-- issuers
-- machineconfigs/disable-net-ifnames
-- machineconfigs/udev-rules
-- machineconfigs/configure-bond0
-- nodenetworkconfigurationpolicies
-- clusterversion.yaml
-- certificates
-- consolelinks
-- rhoai
-- object-storage
-- rolebindings
-- groups
+  - ../common
+  - ../../bundles/acct-mgt
+  - ../../bundles/patch-operator
+  - ../../bundles/moc-metrics-collector
+  - ../../bundles/solr-helm-repo
+  - ../../bundles/ansible-automation-platform-operator
+  - ../../bundles/openshift-serverless-operator
+  - ../../bundles/authorino-operator
+  - ../../bundles/servicemesh-operator
+  - ../../bundles/amq-broker-rhel8-operator
+  - ../../bundles/crunchy-postgres-operator
+  - ../../bundles/amq-streams-operator
+  - ../../bundles/openshift-pipelines-operator
+  - ../../bundles/openshift-opentelemetry-operator
+  - ../../bundles/rhods-operator
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/nvidia-gpu-operator
+  - ../../bundles/nvidia-network-operator
+  - ../../bundles/openshift-sriov-network-operator
+  - ../../bundles/openshift-custom-metrics-autoscaler-operator
+  - ../../bundles/clusterissuer-http01
+  - ../../bundles/curator
+  - ../../bundles/koku-metrics-operator
+  - ../../bundles/autopilot
+  - ../../bundles/mongodb-operator
+  - ../../bundles/elasticsearch-eck-operator
+  - ../../bundles/nagios-monitoring
+  - ../../bundles/allow-list-crds
+  - ../../bundles/strimzi-kafka-operator
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
+  - ../../base/rbac.authorization.k8s.io/clusterroles/project-monitoring-edit
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-allow-sys-admin
+  - ../../base/security.openshift.io/securitycontextconstraints/nerc-allow-sys-admin
+  - ../../base/rbac.authorization.k8s.io/clusterroles/nerc-node-reader
+  - feature/odf
+  - feature/custom-routes
+  - ../../base/core/namespaces/openshift-gitops
+  - externalsecrets
+  - secretstores
+  - issuers
+  - machineconfigs/disable-net-ifnames
+  - machineconfigs/udev-rules
+  - machineconfigs/configure-bond0
+  - nodenetworkconfigurationpolicies
+  - clusterversion.yaml
+  - certificates
+  - consolelinks
+  - rhoai
+  - object-storage
+  - rolebindings
+  - groups
 
 components:
   - ../../components/nerc-oauth-keycloak
   - ../../components/nerc-oauth-github
   - ../../components/resourcequotas/ope-course-quota
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
@@ -70,127 +67,131 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
-  literals:
-    - ack-4.11-kube-1.25-api-removals-in-4.12=true
-    - ack-4.12-kube-1.26-api-removals-in-4.13=true
-    - ack-4.13-kube-1.27-api-removals-in-4.14=true
-    - ack-4.15-kube-1.29-api-removals-in-4.16=true
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
-    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
-    - ack-4.20-kube-1.34-api-removals-in-4.21=true
-- files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  - behavior: merge
+    literals:
+      - ack-4.11-kube-1.25-api-removals-in-4.12=true
+      - ack-4.12-kube-1.26-api-removals-in-4.13=true
+      - ack-4.13-kube-1.27-api-removals-in-4.14=true
+      - ack-4.15-kube-1.29-api-removals-in-4.16=true
+      - ack-4.18-kube-1.32-api-removals-in-4.19=true
+      - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
+      - ack-4.20-kube-1.34-api-removals-in-4.21=true
+    name: admin-acks
+    namespace: openshift-config
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 
 patches:
-- path: kubeletconfigs/system-reserved-patch.yaml
-- path: subscriptions/rhoai-operator-patch.yaml
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/nerc-ocp-prod
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - path: kubeletconfigs/system-reserved-patch.yaml
+  - path: subscriptions/rhoai-operator-patch.yaml
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/nerc-ocp-prod
+    target:
+      kind: SecretStore
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: mss-keycloak
+          openID:
+            clientID: ocp-prod
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: 771ea98004d436c6e529
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-prod/openshift-config/oauths-clientsecret-nerc
+    target:
+      kind: ExternalSecret
+      name: oauths-clientsecret-nerc
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-prod/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-prod/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.shift.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: mss-keycloak
-        openID:
-          clientID: ocp-prod
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
-      name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: 771ea98004d436c6e529
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-prod/openshift-config/oauths-clientsecret-nerc
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-prod/aws-route53-credentials
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-prod/openshift-config/github-client-secret
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.shift.nerc.mghpcc.org
-- target:
-    kind: PersistentVolumeClaim
-    name: image-registry-storage
-  patch: |
-    - op: replace
-      path: /spec/resources/requests/storage
-      value: 750Gi
-- target:
-    kind: Subscription
-    name: cluster-logging
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-6.5
-- target:
-    kind: Subscription
-    name: rhods-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-2.25
-    - op: replace
-      path: /spec/startingCSV
-      value: rhods-operator.2.25.1
-- target:
-    kind: Subscription
-    name: gpu-operator-certified
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: v26.3
-- target:
-    kind: Subscription
-    name: nvidia-network-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: v26.1
-    - op: replace
-      path: /spec/config/resources/limits/memory
-      value: 1.5Gi
-    - op: replace
-      path: /spec/config/resources/requests/memory
-      value: 1Gi
-- target:
-    kind: Subscription
-    name: serverless-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-1.36
+  - patch: |
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 750Gi
+    target:
+      kind: PersistentVolumeClaim
+      name: image-registry-storage
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-6.5
+    target:
+      kind: Subscription
+      name: cluster-logging
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-2.25
+      - op: replace
+        path: /spec/startingCSV
+        value: rhods-operator.2.25.1
+    target:
+      kind: Subscription
+      name: rhods-operator
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: v26.3
+    target:
+      kind: Subscription
+      name: gpu-operator-certified
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: v26.1
+      - op: replace
+        path: /spec/config/resources/limits/memory
+        value: 1.5Gi
+      - op: replace
+        path: /spec/config/resources/requests/memory
+        value: 1Gi
+    target:
+      kind: Subscription
+      name: nvidia-network-operator
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-1.36
+    target:
+      kind: Subscription
+      name: serverless-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-prod/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- vlan-2173-nese.yaml
+  - vlan-2173-nese.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
 - backingstore.yaml
 - bucketclass.yaml
 - storageclass.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/object-storage/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: noobaa
 resources:
-- backingstore.yaml
-- bucketclass.yaml
-- storageclass.yaml
+  - backingstore.yaml
+  - bucketclass.yaml
+  - storageclass.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: noobaa

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- odhdashboardconfigs/odh-dashboard-config.yaml
-- imagestreams/ucsls-f24-imagestream.yaml
-- imagestreams/oauth-proxy.yaml
-- acceleratorprofiles
-- datascienceclusters
-- servingruntimes
+  - odhdashboardconfigs/odh-dashboard-config.yaml
+  - imagestreams/ucsls-f24-imagestream.yaml
+  - imagestreams/oauth-proxy.yaml
+  - acceleratorprofiles
+  - datascienceclusters
+  - servingruntimes

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/ai4dd-06afdc/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/ai4dd-06afdc/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ai4dd-demo-edit.yaml
+  - ai4dd-demo-edit.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- project-robbie-6f75ac
-- project-robbie-8dd79e
-- project-robbie-b4784c
-- ai4dd-06afdc
+  - project-robbie-6f75ac
+  - project-robbie-8dd79e
+  - project-robbie-b4784c
+  - ai4dd-06afdc

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-6f75ac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-6f75ac/kustomization.yaml
@@ -1,16 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- project-robbie-allow-sys-admin.yaml
+  - project-robbie-allow-sys-admin.yaml
 
 transformers:
-- |-
-  apiVersion: builtin
-  kind: NamespaceTransformer
-  metadata:
-    name: notImportantHere
-    namespace: project-robbie-6f75ac
-  setRoleBindingSubjects: allServiceAccounts
-  fieldSpecs:
-  - path: metadata/namespace
-    create: true
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: notImportantHere
+      namespace: project-robbie-6f75ac
+    setRoleBindingSubjects: allServiceAccounts
+    fieldSpecs:
+    - path: metadata/namespace
+      create: true

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-8dd79e/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-8dd79e/kustomization.yaml
@@ -1,16 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- project-robbie-allow-sys-admin.yaml
+  - project-robbie-allow-sys-admin.yaml
 
 transformers:
-- |-
-  apiVersion: builtin
-  kind: NamespaceTransformer
-  metadata:
-    name: notImportantHere
-    namespace: project-robbie-8dd79e
-  setRoleBindingSubjects: allServiceAccounts
-  fieldSpecs:
-  - path: metadata/namespace
-    create: true
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: notImportantHere
+      namespace: project-robbie-8dd79e
+    setRoleBindingSubjects: allServiceAccounts
+    fieldSpecs:
+    - path: metadata/namespace
+      create: true

--- a/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rolebindings/project-robbie-b4784c/kustomization.yaml
@@ -1,16 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- project-robbie-allow-sys-admin.yaml
+  - project-robbie-allow-sys-admin.yaml
 
 transformers:
-- |-
-  apiVersion: builtin
-  kind: NamespaceTransformer
-  metadata:
-    name: notImportantHere
-    namespace: project-robbie-b4784c
-  setRoleBindingSubjects: allServiceAccounts
-  fieldSpecs:
-  - path: metadata/namespace
-    create: true
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: notImportantHere
+      namespace: project-robbie-b4784c
+    setRoleBindingSubjects: allServiceAccounts
+    fieldSpecs:
+    - path: metadata/namespace
+      create: true

--- a/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/secretstores/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- acct-mgt
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
-- ece440spring2024-619f12
-- rhods-notebooks
+  - acct-mgt
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator
+  - ece440spring2024-619f12
+  - rhods-notebooks

--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- restrict-suhruth-test-egress.yaml
+  - restrict-suhruth-test-egress.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/coo/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/coo/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  nerc.mghpcc.org/feature: coo
 
 resources:
-  - uiplugin.yaml
+- uiplugin.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: coo

--- a/cluster-scope/overlays/nerc-ocp-test/feature/coo/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/coo/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  nerc.mghpcc.org/feature: coo
-
 resources:
   - uiplugin.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: coo

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
@@ -2,18 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
 
 components:
-  - ../../../../components/nerc-secret-store
+- ../../../../components/nerc-secret-store
 
 resources:
-  - ../../../../bundles/odf-external
-  - externalsecrets/rook-ceph-external-cluster-details.yaml
-  - redhatcop.redhat.io/odf-node-patcher.yaml
-  - configmaps/rook-ceph-operator-config.yaml
+- ../../../../bundles/odf-external
+- externalsecrets/rook-ceph-external-cluster-details.yaml
+- redhatcop.redhat.io/odf-node-patcher.yaml
+- configmaps/rook-ceph-operator-config.yaml
 
 patches:
-  - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
-  - path: subscriptions/subscription-patch.yaml
+- path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+- path: subscriptions/subscription-patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/kustomization.yaml
@@ -2,9 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 
-commonLabels:
-  nerc.mghpcc.org/feature: odf
-
 components:
   - ../../../../components/nerc-secret-store
 
@@ -17,3 +14,7 @@ resources:
 patches:
   - path: storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
   - path: subscriptions/subscription-patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: odf

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -1,16 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  nerc.mghpcc.org/feature: rhoai
 
 resources:
-  - ../../../../bundles/rhods-operator
-  - datascienceclusters
-  - odhdashboardconfigs
-  - imagestreams/ucsls-f24-imagestream.yaml
-  - hardwareprofiles
-  - configmaps
+- ../../../../bundles/rhods-operator
+- datascienceclusters
+- odhdashboardconfigs
+- imagestreams/ucsls-f24-imagestream.yaml
+- hardwareprofiles
+- configmaps
 
 patches:
-  - path: subscriptions/subscription-patch.yaml
+- path: subscriptions/subscription-patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/feature: rhoai

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  nerc.mghpcc.org/feature: rhoai
-
 resources:
   - ../../../../bundles/rhods-operator
   - datascienceclusters
@@ -15,3 +12,7 @@ resources:
 
 patches:
   - path: subscriptions/subscription-patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/feature: rhoai

--- a/cluster-scope/overlays/nerc-ocp-test/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - clusterversion.yaml
@@ -47,22 +45,21 @@ resources:
 - ../../bundles/cluster-observability-operator
 - ../../bundles/strimzi-kafka-operator
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-github
-  - ../../components/nerc-oauth-htpasswd
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-github
+- ../../components/nerc-oauth-htpasswd
+- ../../components/argocd-skip-dryrun
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
+- behavior: merge
   literals:
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
-    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
-    - ack-4.20-kube-1.34-api-removals-in-4.21=true
+  - ack-4.18-kube-1.32-api-removals-in-4.19=true
+  - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
+  - ack-4.20-kube-1.34-api-removals-in-4.21=true
+  name: admin-acks
+  namespace: openshift-config
 - files:
   - config.yaml=configmaps/cluster-monitoring-config.yaml
   name: cluster-monitoring-config
@@ -70,6 +67,7 @@ configMapGenerator:
 
 generatorOptions:
   disableNameSuffixHash: true
+
 
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
@@ -90,67 +88,70 @@ patches:
             - ocp-on-nerc/nerc-rhods
             - ocp-on-nerc/nerc-test-people
             - ocp-on-nerc/griot-grits
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-test/openshift-config/github-client-secret
-- target:
+  target:
     kind: ExternalSecret
-    name: oauth-htpasswd
-  patch: |
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/nerc-ocp-test/openshift-config/oauth-htpasswd
-
-- target:
-    kind: SecretStore
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: oauth-htpasswd
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/nerc-ocp-test
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+  target:
+    kind: SecretStore
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/nerc-ocp-test/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.ocp-test.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - ocp-test.nerc.mghpcc.org
-- target:
-    kind: Subscription
-    name: serverless-operator
-  patch: |
+  target:
+    kind: Issuer
+    name: letsencrypt-.*-dns01
+- patch: |
     - op: replace
       path: /spec/channel
       value: stable-1.36
-- target:
+  target:
     kind: Subscription
-    name: gpu-operator-certified
-  patch: |
+    name: serverless-operator
+- patch: |
     - op: replace
       path: /spec/channel
       value: v25.10
-- target:
+  target:
     kind: Subscription
-    name: strimzi-kafka-operator
-  patch: |
+    name: gpu-operator-certified
+- patch: |
     - op: replace
       path: /spec/channel
       value: strimzi-0.50.x
+  target:
+    kind: Subscription
+    name: strimzi-kafka-operator
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,156 +1,156 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- clusterversion.yaml
-- ../common
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
-- ../../base/core/namespaces/openshift-gitops
-- ../../base/core/namespaces/dex
-- externalsecrets
-- secretstores
-- issuers
-- certificates
-- machineconfigs
-- nodenetworkconfigurationpolicies
-- adminnetworkpolicies
-- feature/odf
-- feature/rhoai
-- rbac
-- virt-patches
-- ../../bundles/clusterissuer-http01
-- ../../bundles/gatekeeper-operator
-- ../../bundles/hostpath-provisioner
-- ../../bundles/node-feature-discovery
-- ../../bundles/patch-operator
-- ../../bundles/nvidia-gpu-operator
-- ../../bundles/nvidia-network-operator
-- ../../bundles/openshift-sriov-network-operator
-- ../../bundles/koku-metrics-operator
-- ../../bundles/kubernetes-image-puller-operator
-- ../../bundles/curator
-- ../../bundles/ansible-automation-platform-operator
-- ../../bundles/openshift-custom-metrics-autoscaler-operator
-- ../../bundles/openshift-serverless-operator
-- ../../bundles/openshift-opentelemetry-operator
-- ../../bundles/openshift-pipelines-operator
-- ../../bundles/virt
-- ../../bundles/autopilot
-- ../../bundles/minio
-- ../../bundles/mongodb-operator
-- ../../bundles/moc-metrics-collector
-- ../../bundles/nagios-monitoring
-- ../../bundles/authorino-operator
-- ../../bundles/cluster-observability-operator
-- ../../bundles/strimzi-kafka-operator
-- ../../bundles/costmanagement-metrics-operator
+  - clusterversion.yaml
+  - ../common
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
+  - ../../base/core/namespaces/openshift-gitops
+  - ../../base/core/namespaces/dex
+  - externalsecrets
+  - secretstores
+  - issuers
+  - certificates
+  - machineconfigs
+  - nodenetworkconfigurationpolicies
+  - adminnetworkpolicies
+  - feature/odf
+  - feature/rhoai
+  - rbac
+  - virt-patches
+  - ../../bundles/clusterissuer-http01
+  - ../../bundles/gatekeeper-operator
+  - ../../bundles/hostpath-provisioner
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/patch-operator
+  - ../../bundles/nvidia-gpu-operator
+  - ../../bundles/nvidia-network-operator
+  - ../../bundles/openshift-sriov-network-operator
+  - ../../bundles/koku-metrics-operator
+  - ../../bundles/kubernetes-image-puller-operator
+  - ../../bundles/curator
+  - ../../bundles/ansible-automation-platform-operator
+  - ../../bundles/openshift-custom-metrics-autoscaler-operator
+  - ../../bundles/openshift-serverless-operator
+  - ../../bundles/openshift-opentelemetry-operator
+  - ../../bundles/openshift-pipelines-operator
+  - ../../bundles/virt
+  - ../../bundles/autopilot
+  - ../../bundles/minio
+  - ../../bundles/mongodb-operator
+  - ../../bundles/moc-metrics-collector
+  - ../../bundles/nagios-monitoring
+  - ../../bundles/authorino-operator
+  - ../../bundles/cluster-observability-operator
+  - ../../bundles/strimzi-kafka-operator
+  - ../../bundles/costmanagement-metrics-operator
 
 components:
   - ../../components/nerc-oauth-github
   - ../../components/nerc-oauth-htpasswd
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
 
 configMapGenerator:
-- name: admin-acks
-  namespace: openshift-config
-  behavior: merge
-  literals:
-    - ack-4.18-kube-1.32-api-removals-in-4.19=true
-    - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
-    - ack-4.20-kube-1.34-api-removals-in-4.21=true
-- files:
-  - config.yaml=configmaps/cluster-monitoring-config.yaml
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  - behavior: merge
+    literals:
+      - ack-4.18-kube-1.32-api-removals-in-4.19=true
+      - ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20=true
+      - ack-4.20-kube-1.34-api-removals-in-4.21=true
+    name: admin-acks
+    namespace: openshift-config
+  - files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 
 generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-- path: kubeletconfigs/system-reserved-patch.yaml
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - path: kubeletconfigs/system-reserved-patch.yaml
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liIYFewHpMri8GO1
+            teams:
+              - ocp-on-nerc/nerc-ops
+              - ocp-on-nerc/nerc-logs-metrics
+              - ocp-on-nerc/nerc-rhods
+              - ocp-on-nerc/nerc-test-people
+              - ocp-on-nerc/griot-grits
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-test/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/nerc-ocp-test/openshift-config/oauth-htpasswd
+    target:
+      kind: ExternalSecret
+      name: oauth-htpasswd
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/nerc-ocp-test
+    target:
+      kind: SecretStore
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-test/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.ocp-test.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liIYFewHpMri8GO1
-          teams:
-            - ocp-on-nerc/nerc-ops
-            - ocp-on-nerc/nerc-logs-metrics
-            - ocp-on-nerc/nerc-rhods
-            - ocp-on-nerc/nerc-test-people
-            - ocp-on-nerc/griot-grits
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-test/openshift-config/github-client-secret
-- target:
-    kind: ExternalSecret
-    name: oauth-htpasswd
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/nerc-ocp-test/openshift-config/oauth-htpasswd
-
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/nerc-ocp-test
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-test/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.ocp-test.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - ocp-test.nerc.mghpcc.org
-- target:
-    kind: Subscription
-    name: serverless-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: stable-1.36
-- target:
-    kind: Subscription
-    name: gpu-operator-certified
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: v26.3
-- target:
-    kind: Subscription
-    name: strimzi-kafka-operator
-  patch: |
-    - op: replace
-      path: /spec/channel
-      value: strimzi-0.50.x
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - ocp-test.nerc.mghpcc.org
+    target:
+      kind: Issuer
+      name: letsencrypt-.*-dns01
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: stable-1.36
+    target:
+      kind: Subscription
+      name: serverless-operator
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: v26.3
+    target:
+      kind: Subscription
+      name: gpu-operator-certified
+  - patch: |
+      - op: replace
+        path: /spec/channel
+        value: strimzi-0.50.x
+    target:
+      kind: Subscription
+      name: strimzi-kafka-operator
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/nerc-ocp-test/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- vlan-nese.yaml
+  - vlan-nese.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-test-people.yaml
-- nerc-test-perses.yaml
-- nerc-test-cost-management.yaml
+  - nerc-test-people.yaml
+  - nerc-test-perses.yaml
+  - nerc-test-cost-management.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/secretstores/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
-- curator-system
-- dex
-- minio
-- danni-ilab
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator
+  - curator-system
+  - dex
+  - minio
+  - danni-ilab

--- a/cluster-scope/overlays/nerc-ocp-test/virt-patches/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/virt-patches/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../base/core/configmaps/kubevirt
-- ../../../base/rbac.authorization.k8s.io/roles/kubevirt
-- ../../../base/rbac.authorization.k8s.io/rolebindings/kubevirt
+  - ../../../base/core/configmaps/kubevirt
+  - ../../../base/rbac.authorization.k8s.io/roles/kubevirt
+  - ../../../base/rbac.authorization.k8s.io/rolebindings/kubevirt

--- a/cluster-scope/overlays/virt/certificates/kustomization.yaml
+++ b/cluster-scope/overlays/virt/certificates/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- default-api-certificate.yaml
-- default-ingress-certificate.yaml
+  - default-api-certificate.yaml
+  - default-ingress-certificate.yaml

--- a/cluster-scope/overlays/virt/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/virt/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github-group-sync.yaml
+  - github-group-sync.yaml

--- a/cluster-scope/overlays/virt/issuers/kustomization.yaml
+++ b/cluster-scope/overlays/virt/issuers/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
+  - openshift-config
+  - openshift-ingress

--- a/cluster-scope/overlays/virt/kustomization.yaml
+++ b/cluster-scope/overlays/virt/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../common
@@ -20,13 +18,12 @@ resources:
 - secretstores
 - virt-patches
 
+# this must come last in order to apply
+# to all resources.
 components:
-  - ../../components/nerc-oauth-keycloak
-  - ../../components/nerc-oauth-github
-
-  # this must come last in order to apply
-  # to all resources.
-  - ../../components/argocd-skip-dryrun
+- ../../components/nerc-oauth-keycloak
+- ../../components/nerc-oauth-github
+- ../../components/argocd-skip-dryrun
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -42,13 +39,13 @@ patches:
       - name: mss-keycloak
         openID:
           clientID: ocp-virt
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/virt/openshift-config/oauths-clientsecret-nerc
+  target:
+    kind: ExternalSecret
+    name: oauths-clientsecret-nerc
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth
@@ -59,38 +56,42 @@ patches:
       - name: github
         github:
           clientID: Ov23liw6D35035eEiLjS
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
+- patch: |
     - op: replace
       path: /spec/data/0/remoteRef/key
       value: nerc/virt/openshift-config/github-client-secret
-- target:
-    kind: SecretStore
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: github-client-secret
+- patch: |
     - op: replace
       path: /spec/provider/vault/auth/kubernetes/mountPath
       value: kubernetes/virt
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
+  target:
+    kind: SecretStore
+- patch: |
     - op: replace
       path: /spec/dataFrom/0/extract/key
       value: nerc/virt/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
+  target:
+    kind: ExternalSecret
+    name: aws-route53-credentials
+- patch: |
     - op: replace
       path: /spec/servingCerts/namedCertificates/0/names/0
       value: api.virt.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
+  target:
+    kind: APIServer
+    name: cluster
+- patch: |
     - op: replace
       path: /spec/acme/solvers/0/selector/dnsZones
       value:
         - virt.nerc.mghpcc.org
+  target:
+    kind: Issuer
+    name: letsencrypt-.*-dns01
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/virt/kustomization.yaml
+++ b/cluster-scope/overlays/virt/kustomization.yaml
@@ -1,29 +1,26 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../common
-- ../../bundles/node-feature-discovery
-- ../../bundles/patch-operator
-- ../../bundles/clusterissuer-http01
-- ../../bundles/virt
-- ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
-- ../../base/core/namespaces/openshift-gitops
-- externalsecrets
-- issuers
-- feature/odf
-- machineconfigs
-- nodenetworkconfigurationpolicies
-- certificates
-- secretstores
-- virt-patches
+  - ../common
+  - ../../bundles/node-feature-discovery
+  - ../../bundles/patch-operator
+  - ../../bundles/clusterissuer-http01
+  - ../../bundles/virt
+  - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
+  - ../../base/core/namespaces/openshift-gitops
+  - externalsecrets
+  - issuers
+  - feature/odf
+  - machineconfigs
+  - nodenetworkconfigurationpolicies
+  - certificates
+  - secretstores
+  - virt-patches
 
 components:
   - ../../components/nerc-oauth-keycloak
   - ../../components/nerc-oauth-github
-
   # this must come last in order to apply
   # to all resources.
   - ../../components/argocd-skip-dryrun
@@ -32,65 +29,69 @@ generatorOptions:
   disableNameSuffixHash: true
 
 patches:
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: mss-keycloak
+          openID:
+            clientID: ocp-virt
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/virt/openshift-config/oauths-clientsecret-nerc
+    target:
+      kind: ExternalSecret
+      name: oauths-clientsecret-nerc
+  - patch: |
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: github
+          github:
+            clientID: Ov23liw6D35035eEiLjS
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/virt/openshift-config/github-client-secret
+    target:
+      kind: ExternalSecret
+      name: github-client-secret
+  - patch: |
+      - op: replace
+        path: /spec/provider/vault/auth/kubernetes/mountPath
+        value: kubernetes/virt
+    target:
+      kind: SecretStore
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/virt/aws-route53-credentials
+    target:
+      kind: ExternalSecret
+      name: aws-route53-credentials
+  - patch: |
+      - op: replace
+        path: /spec/servingCerts/namedCertificates/0/names/0
+        value: api.virt.nerc.mghpcc.org
+    target:
+      kind: APIServer
       name: cluster
-    spec:
-      identityProviders:
-      - name: mss-keycloak
-        openID:
-          clientID: ocp-virt
-- target:
-    kind: ExternalSecret
-    name: oauths-clientsecret-nerc
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/virt/openshift-config/oauths-clientsecret-nerc
-- patch: |
-    apiVersion: config.openshift.io/v1
-    kind: OAuth
-    metadata:
-      name: cluster
-    spec:
-      identityProviders:
-      - name: github
-        github:
-          clientID: Ov23liw6D35035eEiLjS
-- target:
-    kind: ExternalSecret
-    name: github-client-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/virt/openshift-config/github-client-secret
-- target:
-    kind: SecretStore
-  patch: |
-    - op: replace
-      path: /spec/provider/vault/auth/kubernetes/mountPath
-      value: kubernetes/virt
-- target:
-    kind: ExternalSecret
-    name: aws-route53-credentials
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/virt/aws-route53-credentials
-- target:
-    kind: APIServer
-    name: cluster
-  patch: |
-    - op: replace
-      path: /spec/servingCerts/namedCertificates/0/names/0
-      value: api.virt.nerc.mghpcc.org
-- target:
-    kind: Issuer
-    name: letsencrypt-.*-dns01
-  patch: |
-    - op: replace
-      path: /spec/acme/solvers/0/selector/dnsZones
-      value:
-        - virt.nerc.mghpcc.org
+  - patch: |
+      - op: replace
+        path: /spec/acme/solvers/0/selector/dnsZones
+        value:
+          - virt.nerc.mghpcc.org
+    target:
+      kind: Issuer
+      name: letsencrypt-.*-dns01
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/cluster-scope/overlays/virt/machineconfigs/kustomization.yaml
+++ b/cluster-scope/overlays/virt/machineconfigs/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- udev-rules/
-- pci-passthrough/
+  - udev-rules/
+  - pci-passthrough/

--- a/cluster-scope/overlays/virt/nodenetworkconfigurationpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/virt/nodenetworkconfigurationpolicies/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- nerc-infra-routed.yaml
-- mlx1-mtu.yaml
+  - nerc-infra-routed.yaml
+  - mlx1-mtu.yaml

--- a/cluster-scope/overlays/virt/secretstores/kustomization.yaml
+++ b/cluster-scope/overlays/virt/secretstores/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-config
-- openshift-ingress
-- openshift-logging
-- group-sync-operator
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - group-sync-operator

--- a/cluster-scope/overlays/virt/virt-patches/kustomization.yaml
+++ b/cluster-scope/overlays/virt/virt-patches/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../base/core/configmaps/kubevirt
-- ../../../base/rbac.authorization.k8s.io/roles/kubevirt
-- ../../../base/rbac.authorization.k8s.io/rolebindings/kubevirt
+  - ../../../base/core/configmaps/kubevirt
+  - ../../../base/rbac.authorization.k8s.io/roles/kubevirt
+  - ../../../base/rbac.authorization.k8s.io/rolebindings/kubevirt

--- a/csi-driver-nfs/base/kustomization.yaml
+++ b/csi-driver-nfs/base/kustomization.yaml
@@ -1,14 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: csi-driver-nfs
 resources:
-  - core/namespaces
-  - rbac.authorization.k8s.io/clusterroles
-  - rbac.authorization.k8s.io/clusterrolebindings
-  - rbac.authorization.k8s.io/rolebindings
-  - core/serviceaccounts
-  - core/daemonsets
-  - core/deployments
-  - storage.k8s.io/csidrivers
-  - storage.k8s.io/storageclasses
+- core/namespaces
+- rbac.authorization.k8s.io/clusterroles
+- rbac.authorization.k8s.io/clusterrolebindings
+- rbac.authorization.k8s.io/rolebindings
+- core/serviceaccounts
+- core/daemonsets
+- core/deployments
+- storage.k8s.io/csidrivers
+- storage.k8s.io/storageclasses
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: csi-driver-nfs

--- a/csi-driver-nfs/base/kustomization.yaml
+++ b/csi-driver-nfs/base/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: csi-driver-nfs
 resources:
   - core/namespaces
   - rbac.authorization.k8s.io/clusterroles
@@ -12,3 +10,7 @@ resources:
   - core/deployments
   - storage.k8s.io/csidrivers
   - storage.k8s.io/storageclasses
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: csi-driver-nfs

--- a/csi-driver-nfs/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/csi-driver-nfs/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../../base
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/csi-driver-nfs/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/csi-driver-nfs/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../../base
+  - ../../base
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../../base
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/csi-driver-nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../../base
+  - ../../base
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/curator/base/kustomization.yaml
+++ b/curator/base/kustomization.yaml
@@ -2,12 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: curator-system
 resources:
-  - deployments
-  - postgrescluster
-  - pvcs
-  - rolebindings
-  - roles
-  - serviceaccounts
-  - services
-commonLabels:
-  app.kubernetes.io/name: curator
+- deployments
+- postgrescluster
+- pvcs
+- rolebindings
+- roles
+- serviceaccounts
+- services
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: curator

--- a/curator/base/kustomization.yaml
+++ b/curator/base/kustomization.yaml
@@ -9,5 +9,7 @@ resources:
   - roles
   - serviceaccounts
   - services
-commonLabels:
-  app.kubernetes.io/name: curator
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: curator

--- a/curator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/curator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
-  - ../../base
+- ../../base
 namespace: curator-system
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: curator

--- a/curator/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/curator/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: curator
 resources:
   - ../../base
 namespace: curator-system
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: curator

--- a/custom-dns/base/kustomization.yaml
+++ b/custom-dns/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: custom-dns
 resources:
 - namespace.yaml
 - configmap.yaml
 - deployment.yaml
 - service.yaml
 patches:
-  - path: dns-operator_patch.yaml
+- path: dns-operator_patch.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: custom-dns

--- a/custom-dns/base/kustomization.yaml
+++ b/custom-dns/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: custom-dns
 resources:
-- namespace.yaml
-- configmap.yaml
-- deployment.yaml
-- service.yaml
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
 patches:
   - path: dns-operator_patch.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: custom-dns

--- a/dex/base/deployments/kustomization.yaml
+++ b/dex/base/deployments/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  deployment: dex
 resources:
-  - dex.yaml
+- dex.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    deployment: dex

--- a/dex/base/deployments/kustomization.yaml
+++ b/dex/base/deployments/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  deployment: dex
 resources:
   - dex.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      deployment: dex

--- a/dex/base/kustomization.yaml
+++ b/dex/base/kustomization.yaml
@@ -8,7 +8,9 @@ resources:
 - secrets
 - serviceaccounts
 - services
-commonLabels:
-  app.kubernetes.io/name: dex
-  app.kubernetes.io/component: dex-server
-  app.kubernetes.io/part-of: auth
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: dex
+    app.kubernetes.io/part-of: auth

--- a/dex/base/kustomization.yaml
+++ b/dex/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: dex
 resources:
-- deployments
-- externalsecrets
-- routes
-- secrets
-- serviceaccounts
-- services
-commonLabels:
-  app.kubernetes.io/name: dex
-  app.kubernetes.io/component: dex-server
-  app.kubernetes.io/part-of: auth
+  - deployments
+  - externalsecrets
+  - routes
+  - secrets
+  - serviceaccounts
+  - services
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: dex-server
+      app.kubernetes.io/name: dex
+      app.kubernetes.io/part-of: auth

--- a/fake-metrics-server/base/kustomization.yaml
+++ b/fake-metrics-server/base/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
-commonLabels:
-  app: fake-metrics-server
 resources:
 - deploy.yaml
 - service.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: fake-metrics-server

--- a/fake-metrics-server/base/kustomization.yaml
+++ b/fake-metrics-server/base/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
-commonLabels:
-  app: fake-metrics-server
 resources:
-- deploy.yaml
-- service.yaml
+  - deploy.yaml
+  - service.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: fake-metrics-server

--- a/fake-metrics-server/overlays/albany/kustomization.yaml
+++ b/fake-metrics-server/overlays/albany/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/nerc-ocp-beta-test/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-beta-test/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-edu/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-infra/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../../base/
+  - ../../base/
 
 patches:
   - path: deploy_patch.yaml
 
 configMapGenerator:
-  - name: fake-metrics
-    files:
+  - files:
       - metrics.json
+    name: fake-metrics

--- a/fake-metrics-server/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-obs/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-prod/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/nerc-ocp-test/kustomization.yaml
+++ b/fake-metrics-server/overlays/nerc-ocp-test/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/fake-metrics-server/overlays/rhoai-test/kustomization.yaml
+++ b/fake-metrics-server/overlays/rhoai-test/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-storage
 resources:
-- ../nerc-ocp-infra
+  - ../nerc-ocp-infra

--- a/grafana/base/kustomization.yaml
+++ b/grafana/base/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - routes
-  - clusterrolebindings
-commonLabels:
-  app.kubernetes.io/name: grafana
-  app.kubernetes.io/component: grafana
-  app.kubernetes.io/part-of: observability
+- routes
+- clusterrolebindings
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: observability

--- a/grafana/base/kustomization.yaml
+++ b/grafana/base/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 resources:
   - routes
   - clusterrolebindings
-commonLabels:
-  app.kubernetes.io/name: grafana
-  app.kubernetes.io/component: grafana
-  app.kubernetes.io/part-of: observability
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: observability

--- a/grafana/base/routes/kustomization.yaml
+++ b/grafana/base/routes/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- route.yaml
+  - route.yaml

--- a/grafana/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-infra/externalsecrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- oauth-client-secret.yaml
+  - oauth-client-secret.yaml

--- a/grafana/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-infra/kustomization.yaml
@@ -13,8 +13,8 @@ patches:
 
 secretGenerator:
   - name: grafana-serviceaccount-token
-    type: kubernetes.io/service-account-token
     options:
-      disableNameSuffixHash: true
       annotations:
         kubernetes.io/service-account.name: grafana-serviceaccount
+      disableNameSuffixHash: true
+    type: kubernetes.io/service-account-token

--- a/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/externalsecrets/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- oauth-client-secret.yaml
-- grafana-renderer-token.yaml
-- grafana-renderer-service-account-token.yaml
+  - oauth-client-secret.yaml
+  - grafana-renderer-token.yaml
+  - grafana-renderer-service-account-token.yaml

--- a/grafana/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/kustomization.yaml
@@ -14,8 +14,8 @@ patches:
 
 secretGenerator:
   - name: grafana-sa-token
-    type: kubernetes.io/service-account-token
     options:
-      disableNameSuffixHash: true
       annotations:
         kubernetes.io/service-account.name: grafana-sa
+      disableNameSuffixHash: true
+    type: kubernetes.io/service-account-token

--- a/hardware-inventory/base/kustomization.yaml
+++ b/hardware-inventory/base/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: hardware-inventory
 resources:
-- namespace.yaml
-- infraenv.yaml
-- pull-secret.yaml
+  - namespace.yaml
+  - infraenv.yaml
+  - pull-secret.yaml

--- a/hardware-inventory/overlays/hypershift2/kustomization.yaml
+++ b/hardware-inventory/overlays/hypershift2/kustomization.yaml
@@ -1,22 +1,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
 
 patches:
-- target:
-    kind: InfraEnv
-    name: hardware-inventory
-  patch: |
-    - op: replace
-      path: /spec/sshAuthorizedKey
-      value: |-
-        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJw3PLQmEv+2d9+yxSXIc+LgF+OerNWtjj/YSutTgjVR
-
-- target:
-    kind: ExternalSecret
-    name: pull-secret
-  patch: |
-    - op: replace
-      path: /spec/data/0/remoteRef/key
-      value: nerc/hypershift2/hardware-inventory/pull-secret
+  - patch: |
+      - op: replace
+        path: /spec/sshAuthorizedKey
+        value: |-
+          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJw3PLQmEv+2d9+yxSXIc+LgF+OerNWtjj/YSutTgjVR
+    target:
+      kind: InfraEnv
+      name: hardware-inventory
+  - patch: |
+      - op: replace
+        path: /spec/data/0/remoteRef/key
+        value: nerc/hypershift2/hardware-inventory/pull-secret
+    target:
+      kind: ExternalSecret
+      name: pull-secret

--- a/hostpath-provisioner/base/kustomization.yaml
+++ b/hostpath-provisioner/base/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: hostpath-provisioner
 resources:
 - daemonset.yaml
 - serviceaccount.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: hostpath-provisioner

--- a/hostpath-provisioner/base/kustomization.yaml
+++ b/hostpath-provisioner/base/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: hostpath-provisioner
 resources:
-- daemonset.yaml
-- serviceaccount.yaml
+  - daemonset.yaml
+  - serviceaccount.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: hostpath-provisioner

--- a/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 resources:
 - ../../base
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/hostpath-provisioner/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 resources:
-- ../../base
+  - ../../base
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/keycloak/overlays/nerc-ocp-obs/certificates/keycloak-certificate/kustomization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/certificates/keycloak-certificate/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- certificate.yaml
+  - certificate.yaml

--- a/keycloak/overlays/nerc-ocp-obs/certificates/kustomization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/certificates/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- keycloak-certificate/
+  - keycloak-certificate/

--- a/keycloak/overlays/nerc-ocp-obs/postgresclusters/postgresclusters/kustomization.yaml
+++ b/keycloak/overlays/nerc-ocp-obs/postgresclusters/postgresclusters/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- postgres.yaml
+  - postgres.yaml

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - clusterloggings
-  - clusterlogforwarders
-  - externalsecrets
-  - clusterrolebindings
-commonLabels:
-  app.kubernetes.io/name: logging
-  app.kubernetes.io/component: logging
-  app.kubernetes.io/part-of: cluster-logging
+- clusterloggings
+- clusterlogforwarders
+- externalsecrets
+- clusterrolebindings
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: logging
+    app.kubernetes.io/part-of: cluster-logging

--- a/logging/base/kustomization.yaml
+++ b/logging/base/kustomization.yaml
@@ -5,7 +5,9 @@ resources:
   - clusterlogforwarders
   - externalsecrets
   - clusterrolebindings
-commonLabels:
-  app.kubernetes.io/name: logging
-  app.kubernetes.io/component: logging
-  app.kubernetes.io/part-of: cluster-logging
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: logging
+      app.kubernetes.io/name: logging
+      app.kubernetes.io/part-of: cluster-logging

--- a/logging/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-edu/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml

--- a/logging/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-infra/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml

--- a/logging/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-obs/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
-- target:
-    kind: ExternalSecret
-    name: openshift-logging-lokistack-gateway-bearer-token
-  patch: |
-    - op: replace
-      path: /spec/dataFrom/0/extract/key
-      value: nerc/nerc-ocp-obs/lokistack-gateway-bearer-token
+  - patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: nerc/nerc-ocp-obs/lokistack-gateway-bearer-token
+    target:
+      kind: ExternalSecret
+      name: openshift-logging-lokistack-gateway-bearer-token

--- a/logging/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-prod/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml

--- a/logging/overlays/nerc-ocp-test/kustomization.yaml
+++ b/logging/overlays/nerc-ocp-test/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/openshift-logging-lokistack-gateway-bearer-token_patch.yaml

--- a/loki/base/clusterroles/kustomization.yaml
+++ b/loki/base/clusterroles/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - lokistack-tenant-logs.yaml
+  - lokistack-tenant-logs.yaml

--- a/loki/base/kustomization.yaml
+++ b/loki/base/kustomization.yaml
@@ -1,12 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - externalsecrets
-  - lokistacks
-  - clusterroles
-  - clusterrolebindings
-  - uiplugins
-commonLabels:
-  app.kubernetes.io/name: loki
-  app.kubernetes.io/component: lokistack
-  app.kubernetes.io/part-of: cluster-logging
+- externalsecrets
+- lokistacks
+- clusterroles
+- clusterrolebindings
+- uiplugins
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: lokistack
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/part-of: cluster-logging

--- a/loki/base/kustomization.yaml
+++ b/loki/base/kustomization.yaml
@@ -6,7 +6,9 @@ resources:
   - clusterroles
   - clusterrolebindings
   - uiplugins
-commonLabels:
-  app.kubernetes.io/name: loki
-  app.kubernetes.io/component: lokistack
-  app.kubernetes.io/part-of: cluster-logging
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/component: lokistack
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: cluster-logging

--- a/loki/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/loki/overlays/nerc-ocp-obs/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base
-- objectbucketclaims
+  - ../../base
+  - objectbucketclaims
 
 patches:
   - path: externalsecrets/loki-thanos-object-storage_patch.yaml

--- a/minio/base/kustomization.yaml
+++ b/minio/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: minio
-commonLabels:
-  app: minio
 
 resources:
 - externalsecret-minio-admin-credentials.yaml
@@ -12,3 +10,7 @@ resources:
 - console-route.yaml
 - object-storage-route.yaml
 - servicemonitor.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: minio

--- a/minio/base/kustomization.yaml
+++ b/minio/base/kustomization.yaml
@@ -1,14 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: minio
-commonLabels:
-  app: minio
 
 resources:
-- externalsecret-minio-admin-credentials.yaml
-- deployment.yaml
-- pvc.yaml
-- service.yaml
-- console-route.yaml
-- object-storage-route.yaml
-- servicemonitor.yaml
+  - externalsecret-minio-admin-credentials.yaml
+  - deployment.yaml
+  - pvc.yaml
+  - service.yaml
+  - console-route.yaml
+  - object-storage-route.yaml
+  - servicemonitor.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: minio

--- a/minio/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
 
 configMapGenerator:
-- name: minio-config
-  namespace: minio
-  envs:
-  - files/minio-config.env
+  - envs:
+      - files/minio-config.env
+    name: minio-config
+    namespace: minio
 
 patches:
   - path: externalsecrets/patch-minio-admin-credentials.yaml

--- a/minio/overlays/nerc-ocp-test/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- projects
+  - ../../base
+  - projects
 
 configMapGenerator:
-- name: minio-config
-  namespace: minio
-  envs:
-  - files/minio-config.env
+  - envs:
+      - files/minio-config.env
+    name: minio-config
+    namespace: minio
 
 patches:
   - path: externalsecrets/patch-minio-admin-credentials.yaml

--- a/minio/overlays/nerc-ocp-test/projects/kustomization.yaml
+++ b/minio/overlays/nerc-ocp-test/projects/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- danni-ilab.yaml
+  - danni-ilab.yaml

--- a/nfs/base/kustomization.yaml
+++ b/nfs/base/kustomization.yaml
@@ -1,11 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nfs
 resources:
-  - core/namespaces
-  - core/serviceaccounts
-  - rbac.authorization.k8s.io/rolebindings
-  - core/persistentvolumeclaims
-  - core/deployments
-  - core/services
+- core/namespaces
+- core/serviceaccounts
+- rbac.authorization.k8s.io/rolebindings
+- core/persistentvolumeclaims
+- core/deployments
+- core/services
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/bundle: nfs

--- a/nfs/base/kustomization.yaml
+++ b/nfs/base/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/bundle: nfs
 resources:
   - core/namespaces
   - core/serviceaccounts
@@ -9,3 +7,7 @@ resources:
   - core/persistentvolumeclaims
   - core/deployments
   - core/services
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/bundle: nfs

--- a/nfs/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nfs/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,16 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../../base
 
 patches:
-- target:
-    kind: PersistentVolumeClaim
-    name: nfs-server-root
-  patch: |
+- patch: |
     - op: replace
       path: /spec/resources/requests/storage
       value: 25Ti
+  target:
+    kind: PersistentVolumeClaim
+    name: nfs-server-root
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/nfs/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/nfs/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,16 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../../base
+  - ../../base
 
 patches:
-- target:
-    kind: PersistentVolumeClaim
-    name: nfs-server-root
-  patch: |
-    - op: replace
-      path: /spec/resources/requests/storage
-      value: 25Ti
+  - patch: |
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 25Ti
+    target:
+      kind: PersistentVolumeClaim
+      name: nfs-server-root
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
 - ../../base
+labels:
+- includeSelectors: true
+  pairs:
+    nerc.mghpcc.org/kustomized: "true"

--- a/nfs/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nfs/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  nerc.mghpcc.org/kustomized: "true"
 
 resources:
-- ../../base
+  - ../../base
+labels:
+  - includeSelectors: true
+    pairs:
+      nerc.mghpcc.org/kustomized: "true"

--- a/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-edu/kustomization.yaml
+++ b/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-edu/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base/keda.sh/kedacontrollers/keda/
+  - ../../base/keda.sh/kedacontrollers/keda/

--- a/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/openshift-custom-metrics-autoscaler-controller/overlays/nerc-ocp-prod/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base/keda.sh/kedacontrollers/keda/
+  - ../../base/keda.sh/kedacontrollers/keda/

--- a/openshift-gitops/overlays/nerc-ocp-infra/applicationsets/kustomization.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/applicationsets/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-gitops
 resources:
-- nerc-cluster-aoa.yaml
+  - nerc-cluster-aoa.yaml

--- a/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/openshift-gitops/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- applicationsets
+  - ../../base
+  - applicationsets
 
 patches:
-- path: patches/argocds/openshift-gitops.yaml
+  - path: patches/argocds/openshift-gitops.yaml

--- a/opentelemetry/base/kustomization.yaml
+++ b/opentelemetry/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opentelemetry
-commonLabels:
-  app: opentelemetry
 
 resources:
 - externalsecret-opentelemetry.yaml
@@ -10,3 +8,7 @@ resources:
 - opentelemetry-tempostack.yaml
 - opentelemetry-collector.yaml
 - opentelemetry-instrumentation.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: opentelemetry

--- a/opentelemetry/base/kustomization.yaml
+++ b/opentelemetry/base/kustomization.yaml
@@ -1,12 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opentelemetry
-commonLabels:
-  app: opentelemetry
 
 resources:
-- externalsecret-opentelemetry.yaml
-- opentelemetry-rbac.yaml
-- opentelemetry-tempostack.yaml
-- opentelemetry-collector.yaml
-- opentelemetry-instrumentation.yaml
+  - externalsecret-opentelemetry.yaml
+  - opentelemetry-rbac.yaml
+  - opentelemetry-tempostack.yaml
+  - opentelemetry-collector.yaml
+  - opentelemetry-instrumentation.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app: opentelemetry

--- a/opentelemetry/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/opentelemetry/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - path: externalsecrets/patch-opentelemetry.yaml

--- a/policy/avoid-literals.rego
+++ b/policy/avoid-literals.rego
@@ -1,0 +1,20 @@
+package warnings
+
+generator_has_literals(generator) if {
+    "literals" in object.keys(generator)
+  some name in generator
+  not generator.name == "admin-acks"
+}
+
+generator_types := ["configMapGenerator", "secretGenerator"]
+
+# Warn if a configMap- or secretGenerator contains literal values. It is almost
+# always better to place values in a file (using `envs:` or `files:`), because
+# this makes it easier to lint/syntax-check/etc the data.
+warn contains msg if {
+    input.kind = "Kustomization"
+    some generator_type in generator_types
+    some generator in input[generator_type]
+    generator_has_literals(generator)
+    msg = sprintf("%s '%s' contains a 'literals' stanza", [generator_type, generator.name])
+}

--- a/policy/deprecate-commonlabels.rego
+++ b/policy/deprecate-commonlabels.rego
@@ -1,0 +1,10 @@
+package main
+
+# The `commonLabels` directive has been depreacted since Kustomize v5.0.0,
+# released in 2023. Use of this directive causes kustomize to emit warnings for
+# every impacted kustomization.yaml file.
+deny contains msg if {
+    input.kind = "Kustomization"
+    "commonLabels" in object.keys(input)
+    msg = "The commonLabels directives has been deprecated. Please use the 'labels' directive."
+}

--- a/policy/helpers.rego
+++ b/policy/helpers.rego
@@ -1,0 +1,7 @@
+package main
+
+# Use this in a rule if you want people to be able to bypass it by adding the
+# `nerc.mghpcc.org/allow-policy-violation: "true"` annotation to a manifest.
+allowed_by_annotation if {
+  input.metadata.annotations["nerc.mghpcc.org/allow-policy-violation"] = "true"
+}

--- a/policy/no-secrets.rego
+++ b/policy/no-secrets.rego
@@ -1,0 +1,10 @@
+package main
+
+# Reject secrets (other than those used to create long-lived service account
+# tokens). Secrets should not be included in the repository.
+deny contains msg if {
+    input.kind = "Secret"
+  not allowed_by_annotation
+  not input.metadata.annotations["kubernetes.io/service-account.name"]
+    msg = "Do not include secrets in the repository"
+}

--- a/prom-keycloak-proxy/base/externalsecrets/prom-keycloak-proxy-certs/kustomization.yaml
+++ b/prom-keycloak-proxy/base/externalsecrets/prom-keycloak-proxy-certs/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- externalsecret.yaml
+  - externalsecret.yaml

--- a/prom-keycloak-proxy/base/externalsecrets/prom-keycloak-proxy-secrets/kustomization.yaml
+++ b/prom-keycloak-proxy/base/externalsecrets/prom-keycloak-proxy-secrets/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- externalsecret.yaml
+  - externalsecret.yaml

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/innabox-dev/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/innabox-dev/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       app: prom-keycloak-proxy
       deployment: prom-keycloak-proxy-innabox-dev
-    includeSelectors: true
 
 nameSuffix: -innabox-dev
 

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/moc/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/moc/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       app: prom-keycloak-proxy
       deployment: prom-keycloak-proxy-moc
-    includeSelectors: true
 
 nameSuffix: -moc
 

--- a/prom-keycloak-proxy/overlays/nerc-ocp-obs/open-sovereign-ai-cloud/kustomization.yaml
+++ b/prom-keycloak-proxy/overlays/nerc-ocp-obs/open-sovereign-ai-cloud/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-  - pairs:
+  - includeSelectors: true
+    pairs:
       app: prom-keycloak-proxy
       deployment: prom-keycloak-proxy-open-sovereign-ai-cloud
-    includeSelectors: true
 
 nameSuffix: -open-sovereign-ai-cloud
 

--- a/snmp-exporter/base/kustomization.yaml
+++ b/snmp-exporter/base/kustomization.yaml
@@ -1,27 +1,29 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: snmp-exporter
-commonLabels:
-  app: snmp-exporter
 
 resources:
-  - deployment-prometheus-snmp-exporter.yaml
-  - role-prometheus-snmp-exporter.yaml
-  - rolebinding-prometheus-snmp-exporter.yaml
-  - service-prometheus-snmp-exporter.yaml
-  - serviceaccount-prometheus-snmp-exporter.yaml
-  - servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
-  - servicemonitor-prometheus-snmp-exporter-pdus.yaml
+- deployment-prometheus-snmp-exporter.yaml
+- role-prometheus-snmp-exporter.yaml
+- rolebinding-prometheus-snmp-exporter.yaml
+- service-prometheus-snmp-exporter.yaml
+- serviceaccount-prometheus-snmp-exporter.yaml
+- servicemonitor-prometheus-snmp-exporter-vlan-935-moc-swmon.yaml
+- servicemonitor-prometheus-snmp-exporter-pdus.yaml
+
 
 configMapGenerator:
-- name: snmp-generator-config
-  options:
-    disableNameSuffixHash: true
-  files:
+- files:
   - files/generator.yml
-
-- name: observability-metrics-custom-allowlist
+  name: snmp-generator-config
   options:
     disableNameSuffixHash: true
-  files:
+- files:
   - files/uwl_metrics_list.yaml
+  name: observability-metrics-custom-allowlist
+  options:
+    disableNameSuffixHash: true
+labels:
+- includeSelectors: true
+  pairs:
+    app: snmp-exporter

--- a/snmp-exporter/base/kustomization.yaml
+++ b/snmp-exporter/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: snmp-exporter
-commonLabels:
-  app: snmp-exporter
 
 resources:
   - deployment-prometheus-snmp-exporter.yaml
@@ -14,14 +12,17 @@ resources:
   - servicemonitor-prometheus-snmp-exporter-pdus.yaml
 
 configMapGenerator:
-- name: snmp-generator-config
-  options:
-    disableNameSuffixHash: true
-  files:
-  - files/generator.yml
-
-- name: observability-metrics-custom-allowlist
-  options:
-    disableNameSuffixHash: true
-  files:
-  - files/uwl_metrics_list.yaml
+  - files:
+      - files/generator.yml
+    name: snmp-generator-config
+    options:
+      disableNameSuffixHash: true
+  - files:
+      - files/uwl_metrics_list.yaml
+    name: observability-metrics-custom-allowlist
+    options:
+      disableNameSuffixHash: true
+labels:
+  - includeSelectors: true
+    pairs:
+      app: snmp-exporter

--- a/snmp-exporter/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/snmp-exporter/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base

--- a/vault/backup-job/base/kustomization.yaml
+++ b/vault/backup-job/base/kustomization.yaml
@@ -1,28 +1,30 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault-backup-job
 
 resources:
-  - externalsecret.yaml
-  - pvc.yaml
-  - rolebinding.yaml
-  - serviceaccount.yaml
-  - task.yaml
-  - trigger
+- externalsecret.yaml
+- pvc.yaml
+- rolebinding.yaml
+- serviceaccount.yaml
+- task.yaml
+- trigger
+
 
 configMapGenerator:
-  - name: vault-backup-config
-    options:
-      disableNameSuffixHash: true
-    envs:
-      - vault-backup-config.env
-
-  - name: backup-scripts
-    options:
-      disableNameSuffixHash: true
-    files:
-      - scripts/create-snapshot.sh
-      - scripts/backup-to-s3.sh
-      - scripts/cleanup-taskruns.sh
+- envs:
+  - vault-backup-config.env
+  name: vault-backup-config
+  options:
+    disableNameSuffixHash: true
+- files:
+  - scripts/create-snapshot.sh
+  - scripts/backup-to-s3.sh
+  - scripts/cleanup-taskruns.sh
+  name: backup-scripts
+  options:
+    disableNameSuffixHash: true
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: vault-backup-job

--- a/vault/backup-job/base/kustomization.yaml
+++ b/vault/backup-job/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault-backup-job
 
 resources:
   - externalsecret.yaml
@@ -13,16 +11,19 @@ resources:
   - trigger
 
 configMapGenerator:
-  - name: vault-backup-config
-    options:
-      disableNameSuffixHash: true
-    envs:
+  - envs:
       - vault-backup-config.env
-
-  - name: backup-scripts
+    name: vault-backup-config
     options:
       disableNameSuffixHash: true
-    files:
+  - files:
       - scripts/create-snapshot.sh
       - scripts/backup-to-s3.sh
       - scripts/cleanup-taskruns.sh
+    name: backup-scripts
+    options:
+      disableNameSuffixHash: true
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: vault-backup-job

--- a/vault/backup-job/base/trigger/kustomization.yaml
+++ b/vault/backup-job/base/trigger/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cronjob.yaml
-- eventlistener.yaml
-- triggertemplate.yaml
-- rolebinding.yaml
-- clusterrolebinding.yaml
+  - cronjob.yaml
+  - eventlistener.yaml
+  - triggertemplate.yaml
+  - rolebinding.yaml
+  - clusterrolebinding.yaml

--- a/vault/backup-job/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/backup-job/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
 
 patches:
   - patch: |

--- a/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app: vault-config
 
 resources:
 - job.yaml
@@ -11,14 +9,13 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 
+
 configMapGenerator:
-- name: ca-certs
-  files:
+- files:
   - certs/letsencrypt.crt
   - certs/nerc-internal-root.crt
-
-- name: vault-config
-  files:
+  name: ca-certs
+- files:
   - config/backup-job.yaml
   - config/groups.yaml
   - config/hypershift1.yaml
@@ -35,3 +32,8 @@ configMapGenerator:
   - config/secrets.yaml
   - config/pki-nerc.yaml
   - config/albany.yaml
+  name: vault-config
+labels:
+- includeSelectors: true
+  pairs:
+    app: vault-config

--- a/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/config/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,37 +1,38 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app: vault-config
 
 resources:
-- job.yaml
-- cronjob.yaml
+  - job.yaml
+  - cronjob.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: ca-certs
-  files:
-  - certs/letsencrypt.crt
-  - certs/nerc-internal-root.crt
-
-- name: vault-config
-  files:
-  - config/backup-job.yaml
-  - config/groups.yaml
-  - config/hypershift1.yaml
-  - config/hypershift2.yaml
-  - config/nerc-ocp-infra.yaml
-  - config/nerc-ocp-obs.yaml
-  - config/nerc-ocp-prod.yaml
-  - config/nerc-ocp-edu.yaml
-  - config/nerc-ocp-test.yaml
-  - config/nerc-ocp-beta-test.yaml
-  - config/rhoai-test.yaml
-  - config/oidc.yaml
-  - config/policies.yaml
-  - config/secrets.yaml
-  - config/pki-nerc.yaml
-  - config/albany.yaml
+  - files:
+      - certs/letsencrypt.crt
+      - certs/nerc-internal-root.crt
+    name: ca-certs
+  - files:
+      - config/backup-job.yaml
+      - config/groups.yaml
+      - config/hypershift1.yaml
+      - config/hypershift2.yaml
+      - config/nerc-ocp-infra.yaml
+      - config/nerc-ocp-obs.yaml
+      - config/nerc-ocp-prod.yaml
+      - config/nerc-ocp-edu.yaml
+      - config/nerc-ocp-test.yaml
+      - config/nerc-ocp-beta-test.yaml
+      - config/rhoai-test.yaml
+      - config/oidc.yaml
+      - config/policies.yaml
+      - config/secrets.yaml
+      - config/pki-nerc.yaml
+      - config/albany.yaml
+    name: vault-config
+labels:
+  - includeSelectors: true
+    pairs:
+      app: vault-config

--- a/vault/instance/base/kustomization.yaml
+++ b/vault/instance/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault
 
 resources:
 - namespace.yaml
@@ -14,4 +12,8 @@ resources:
 - route.yaml
 
 configurations:
-  - namespace-transformer.yaml
+- namespace-transformer.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: vault

--- a/vault/instance/base/kustomization.yaml
+++ b/vault/instance/base/kustomization.yaml
@@ -1,17 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault
 
 resources:
-- namespace.yaml
-- serviceaccount.yaml
-- rbac.yaml
-- vault.yaml
-- vault-allow-vault-scc.yaml
-- vault-ingress-service.yaml
-- route.yaml
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - vault.yaml
+  - vault-allow-vault-scc.yaml
+  - vault-ingress-service.yaml
+  - route.yaml
 
 configurations:
   - namespace-transformer.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: vault

--- a/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault
 
 resources:
 - ../../base
 - vault-compat-route.yaml
 
+# The vault operator will create a secret with the generated
+# ca.crt in the following namespaces.
 patches:
 - patch: |
     apiVersion: route.openshift.io/v1
@@ -16,7 +16,6 @@ patches:
       name: vault
     spec:
       host: vault.apps.infra.nerc.mghpcc.org
-
 - patch: |
     apiVersion: vault.banzaicloud.com/v1alpha1
     kind: Vault
@@ -37,3 +36,7 @@ patches:
           - chmod
           - g+rw
           - /vault/config/vault.json
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: vault

--- a/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/instance/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,39 +1,40 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vault
-commonLabels:
-  app.kubernetes.io/name: vault
 
 resources:
-- ../../base
-- vault-compat-route.yaml
+  - ../../base
+  - vault-compat-route.yaml
 
 patches:
-- patch: |
-    apiVersion: route.openshift.io/v1
-    kind: Route
-    metadata:
-      name: vault
-    spec:
-      host: vault.apps.infra.nerc.mghpcc.org
-
-- patch: |
-    apiVersion: vault.banzaicloud.com/v1alpha1
-    kind: Vault
-    metadata:
-      name: vault
-    spec:
-      # The vault operator will create a secret with the generated
-      # ca.crt in the following namespaces.
-      caNamespaces:
-        - "external-secrets-operator"
-      vaultInitContainers:
-        - name: fix-permissions
-          volumeMounts:
-          - name: vault-config
-            mountPath: /vault/config
-          image: ghcr.io/bank-vaults/bank-vaults:v1.31.4
-          command:
-          - chmod
-          - g+rw
-          - /vault/config/vault.json
+  - patch: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: vault
+      spec:
+        host: vault.apps.infra.nerc.mghpcc.org
+  - patch: |
+      apiVersion: vault.banzaicloud.com/v1alpha1
+      kind: Vault
+      metadata:
+        name: vault
+      spec:
+        # The vault operator will create a secret with the generated
+        # ca.crt in the following namespaces.
+        caNamespaces:
+          - "external-secrets-operator"
+        vaultInitContainers:
+          - name: fix-permissions
+            volumeMounts:
+            - name: vault-config
+              mountPath: /vault/config
+            image: ghcr.io/bank-vaults/bank-vaults:v1.31.4
+            command:
+            - chmod
+            - g+rw
+            - /vault/config/vault.json
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: vault

--- a/vault/operator/base/src/kustomization.yaml
+++ b/vault/operator/base/src/kustomization.yaml
@@ -3,9 +3,9 @@ kind: Kustomization
 namespace: vault-operator
 
 helmCharts:
-  - name: vault-operator
+  - includeCRDs: true
+    name: vault-operator
     namespace: vault-operator
+    releaseName: vault-operator
     repo: oci://ghcr.io/bank-vaults/helm-charts
     version: 1.22.6
-    includeCRDs: true
-    releaseName: vault-operator

--- a/vault/operator/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/vault/operator/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base

--- a/virt/overlays/virt/kustomization.yaml
+++ b/virt/overlays/virt/kustomization.yaml
@@ -4,4 +4,4 @@ namespace: openshift-cnv
 resources:
   - ../../base
 patches:
-- path: hyperconverged.yaml
+  - path: hyperconverged.yaml


### PR DESCRIPTION
Running modern versions of `kustomize build` on this repository results in
many warnings of the form:

    # Warning: 'commonLabels' is deprecated. Please use 'labels' instead.
    # Run 'kustomize edit fix' to update your Kustomization automatically.

This commit is the result of running `kustomize edit fix` on all
`kustomization.yaml` files that include a `commonLabels` directive. This
replaces the `commonLabels` block with a new `labels` block, so that this:

    commonLabels:
      app: acct-mgt

Becomes:

    labels:
      - includeSelectors: true
        pairs:
          app: acct-mgt

A side effect is that it reformats the files to match kustomize's
idea of correct YAML indenting.

This commit updates our `.pre-commit-config.yaml` with a hook that will
complain about `kustomization.yaml` files containing a `commonLabels`
directive.
