### PR TITLE
Add vllm 0.15.0 servingruntime to prod and test cluster 

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - imagestreams/oauth-proxy.yaml
 - acceleratorprofiles
 - datascienceclusters
+- servingruntimes

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vllm-cuda-v0.15.0.yaml

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
@@ -1,0 +1,69 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: vLLM ServingRuntime v0.15.0+ with CUDA support (for NVIDIA GPUs) - supports Qwen3-coder-next, DeepSeek-v3.2, Minimax-m2.5
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/model-type: '["generative"]'
+    opendatahub.io/modelServingSupport: '["single"]'
+    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime,vllm-v15
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
+    template.openshift.io/long-description: This template defines resources needed
+      to deploy vLLM v0.15+ NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI.
+      Supports newer models like Qwen3-coder-next, DeepSeek-v3.2, and Minimax-m2.5.
+  labels:
+    app: odh-dashboard
+    opendatahub.io/dashboard: "true"
+  name: vllm-cuda-v15-runtime-template
+  namespace: redhat-ods-applications
+objects:
+- apiVersion: serving.kserve.io/v1alpha1
+  kind: ServingRuntime
+  metadata:
+    annotations:
+      opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      opendatahub.io/runtime-version: v0.15.0
+      openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    labels:
+      opendatahub.io/dashboard: "true"
+    name: vllm-cuda-v15-runtime
+  spec:
+    annotations:
+      opendatahub.io/kserve-runtime: vllm
+      prometheus.io/path: /metrics
+      prometheus.io/port: "8080"
+    containers:
+    - args:
+      - --port=8080
+      - --model=/mnt/models
+      - --served-model-name={{.Name}}
+      command:
+      - python3
+      - -m
+      - vllm.entrypoints.openai.api_server
+      env:
+      - name: HOME
+        value: /tmp
+      - name: HF_HOME
+        value: /tmp/hf_home
+      - name: XDG_CACHE_HOME
+        value: /tmp/.cache
+      - name: XDG_CONFIG_HOME
+        value: /tmp/.config
+      - name: FLASHINFER_WORKSPACE_DIR
+        value: /tmp/flashinfer_workspace
+      - name: VLLM_USAGE_STATS
+        value: "0"
+      # Upstream vLLM v0.15.0+
+      # Replace with Red Hat registry image when available
+      image: vllm/vllm-openai:v0.15.0
+      name: kserve-container
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+    multiModel: false
+    supportedModelFormats:
+    - autoSelect: true
+      name: vLLM

--- a/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/apiProtocol: REST
     opendatahub.io/model-type: '["generative"]'
     opendatahub.io/modelServingSupport: '["single"]'
-    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe (experimental)
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime,vllm-v15
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
@@ -25,7 +25,7 @@ objects:
     annotations:
       opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
       opendatahub.io/runtime-version: v0.15.0
-      openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+      openshift.io/display-name: vLLM v0.15.0 NVIDIA GPU ServingRuntime for KServe (experimental)
     labels:
       opendatahub.io/dashboard: "true"
     name: vllm-cuda-v15-runtime

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - imagestreams/ucsls-f24-imagestream.yaml
   - hardwareprofiles
   - configmaps
+  - servingruntimes
 
 patches:
   - path: subscriptions/subscription-patch.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vllm-cuda-v0.15.0.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
@@ -1,0 +1,69 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: vLLM ServingRuntime v0.15.0+ with CUDA support (for NVIDIA GPUs) - supports Qwen3-coder-next, DeepSeek-v3.2, Minimax-m2.5
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/model-type: '["generative"]'
+    opendatahub.io/modelServingSupport: '["single"]'
+    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime,vllm-v15
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
+    template.openshift.io/long-description: This template defines resources needed
+      to deploy vLLM v0.15+ NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI.
+      Supports newer models like Qwen3-coder-next, DeepSeek-v3.2, and Minimax-m2.5.
+  labels:
+    app: odh-dashboard
+    opendatahub.io/dashboard: "true"
+  name: vllm-cuda-v15-runtime-template
+  namespace: redhat-ods-applications
+objects:
+- apiVersion: serving.kserve.io/v1alpha1
+  kind: ServingRuntime
+  metadata:
+    annotations:
+      opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      opendatahub.io/runtime-version: v0.15.0
+      openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    labels:
+      opendatahub.io/dashboard: "true"
+    name: vllm-cuda-v15-runtime
+  spec:
+    annotations:
+      opendatahub.io/kserve-runtime: vllm
+      prometheus.io/path: /metrics
+      prometheus.io/port: "8080"
+    containers:
+    - args:
+      - --port=8080
+      - --model=/mnt/models
+      - --served-model-name={{.Name}}
+      command:
+      - python3
+      - -m
+      - vllm.entrypoints.openai.api_server
+      env:
+      - name: HOME
+        value: /tmp
+      - name: HF_HOME
+        value: /tmp/hf_home
+      - name: XDG_CACHE_HOME
+        value: /tmp/.cache
+      - name: XDG_CONFIG_HOME
+        value: /tmp/.config
+      - name: FLASHINFER_WORKSPACE_DIR
+        value: /tmp/flashinfer_workspace
+      - name: VLLM_USAGE_STATS
+        value: "0"
+      # Upstream vLLM v0.15.0+
+      # Replace with Red Hat registry image when available
+      image: vllm/vllm-openai:v0.15.0
+      name: kserve-container
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+    multiModel: false
+    supportedModelFormats:
+    - autoSelect: true
+      name: vLLM

--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/servingruntimes/vllm-cuda-v0.15.0.yaml
@@ -6,7 +6,7 @@ metadata:
     opendatahub.io/apiProtocol: REST
     opendatahub.io/model-type: '["generative"]'
     opendatahub.io/modelServingSupport: '["single"]'
-    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+    openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe (experimental)
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime,vllm-v15
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
@@ -25,7 +25,7 @@ objects:
     annotations:
       opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
       opendatahub.io/runtime-version: v0.15.0
-      openshift.io/display-name: vLLM v0.15+ NVIDIA GPU ServingRuntime for KServe
+      openshift.io/display-name: vLLM v0.15.0 NVIDIA GPU ServingRuntime for KServe (experimental)
     labels:
       opendatahub.io/dashboard: "true"
     name: vllm-cuda-v15-runtime


### PR DESCRIPTION
- Adds location for custom servingruntimes
- Adds vllm 0.15.0 servingruntime to prod and test 


Closes: https://github.com/nerc-project/operations/issues/1510