### PR TITLE
ocp-test: bump prometheus k8s monitoring storage

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/configmaps/cluster-monitoring-config.yaml
@@ -5,7 +5,7 @@ prometheusK8s:
       storageClassName: ocs-external-storagecluster-ceph-rbd
       resources:
         requests:
-          storage: 100Gi
+          storage: 200Gi
 alertmanagerMain:
   enabled: true
   volumeClaimTemplate:


### PR DESCRIPTION
The prometheus-k8s-1 pod on the test cluster is currently out of space. This doubles the amount of storage for the prometheus k8s pods in the openshift-storage namespace.

```
[PROBLEM] service nerc-ocp-test-co is CRITICAL
CRITICAL - Operator problems: monitoring: Degraded=True
```