### PR TITLE
ocp-test: Upgrade RHOAI to 3.3.1

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/subscriptions/subscription-patch.yaml
@@ -4,5 +4,5 @@ metadata:
   name: rhods-operator
   namespace: redhat-ods-operator
 spec:
-  channel: stable
-  startingCSV: rhods-operator.2.23.0
+  channel: stable-3.x
+  startingCSV: rhods-operator.3.3.1

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -73,7 +73,6 @@ generatorOptions:
 
 patches:
 - path: kubeletconfigs/system-reserved-patch.yaml
-- path: subscriptions/rhoai-operator-patch.yaml
 - patch: |
     apiVersion: config.openshift.io/v1
     kind: OAuth

--- a/cluster-scope/overlays/nerc-ocp-test/subscriptions/rhoai-operator-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/subscriptions/rhoai-operator-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: rhods-operator
-  namespace: redhat-ods-operator
-spec:
-  startingCSV: rhods-operator.2.19.0


### PR DESCRIPTION
- ocp-test: Upgrade RHOAI to 3.3.1
- ocp-test: Remove old subscription patch reference for RHOAI

We had two places in nerc-ocp-config for setting the version of RHOAI to use. Removed one of them that we haven't used in a while and sticking with the one we have been using.  