### PR TITLE
ocp-prod: bump ODF operator to v4.20

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.19
+    channel: stable-4.20


### PR DESCRIPTION
Apparently we missed this spot during last maintenance upgrade.