### PR TITLE
ocp-prod: upgrade cluster logging operator to v6.5

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -154,7 +154,7 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: stable-6.2
+      value: stable-6.5
 - target:
     kind: Subscription
     name: rhods-operator


### PR DESCRIPTION
The 6.2 version of the operator is currently blocking the OCP upgrade to 4.21.8:

Reason: IncompatibleOperatorsInstalled
Message: Cluster operator operator-lifecycle-manager should not be upgraded between minor versions: ClusterServiceVersions blocking minor version upgrades to 4.21.0 or higher:
- maximum supported OCP version for openshift-logging/cluster-logging.v6.2.9 is 4.20