### PR TITLE
ocp-prod: bump odf operator to v4.21

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/feature/odf/subscriptions/subscription-patch.yaml
@@ -3,4 +3,4 @@ kind: Subscription
 metadata:
     name: odf-operator
 spec:
-    channel: stable-4.20
+    channel: stable-4.21


### PR DESCRIPTION
Needed now that OCP-Prod is running on 4.21