### PR TITLE
ocp-prod: upgrade NVIDIA GPU operator to v26.3

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -171,7 +171,7 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: v25.10
+      value: v26.3
 - target:
     kind: Subscription
     name: serverless-operator

--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -6,7 +6,7 @@ spec:
   driver:
     upgradePolicy:
       autoUpgrade: true
-    version: "580.105.08"
+    version: "580.126.20"
     repository: "nvcr.io/nvidia"
     image: "driver"
   daemonsets:


### PR DESCRIPTION
This is currently the latest version. The driver version pin here is the current default for v26.3 of the NVIDIA GPU operator according to the platform support docs:

https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html