### PR TITLE
ocp-prod: add nvidia-network and sriov operators and udev rule updates for H100 RDMA

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
 - ../../bundles/rhods-operator
 - ../../bundles/node-feature-discovery
 - ../../bundles/nvidia-gpu-operator
+- ../../bundles/nvidia-network-operator
+- ../../bundles/openshift-sriov-network-operator
 - ../../bundles/openshift-custom-metrics-autoscaler-operator
 - ../../bundles/clusterissuer-http01
 - ../../bundles/curator

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/custom-udev-rules-worker.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/woOdQqODA5x9bW1VcpLLVHScQnyDHMNCra1VcrNqTCNT84vSlXS8XYN8nP1AQkaGBgYWBmYWRkY6Bko6Tg6h3j6+9naKiWmpCjp+Dn6utoq5WUmGypxUWCuIU5zjcg018yUNu6FmEt99yYb08a9iQTMJde9RgTMNSY3PRAw10SJCxAAAP//qtQhOcACAAA=
+            source: data:;base64,H4sIAAAAAAAC/7TSwWqEMBDG8btPEWavsYy6SWEhh22bg7RaMLbQU5Ek0IJNQEV8/FKE3tZAxOscfnx/GPX2oD5UKyshwNkJ6FNTvstGCQE//cI+tR8s0GfZ1PLl74iIeEF+QbxDoNfHtnythYDOGKD1tZIC3LfOINnhZjfdPNLl7Ji9q7u590R66/zs09FwztxcpF8ZInHe2DE5Ee2ds3paUk50N5gxbsc5P6ZvdQN9/wn3exLyYjuhiH2pgHuOdHXAZZFuF3A5JL8BAAD///WCxvKzAwAA
           mode: 420
           path: /etc/udev/rules.d/90-mlx5-core.rules
         - contents:

--- a/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
+++ b/cluster-scope/overlays/nerc-ocp-prod/machineconfigs/udev-rules/src/mlx5_core.rules
@@ -2,7 +2,12 @@ SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.0",ACTION=="add",NAME
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:06:00.1",ACTION=="add",NAME="nic2"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.0",ACTION=="add",NAME="nic1"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:65:00.1",ACTION=="add",NAME="nic2"
-SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:c3:00.0",ACTION=="add",NAME="nic1"
-SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:a3:00.0",ACTION=="add",NAME="nic2"
+# lenovo-sd665nv3-h100 nodes
+# connectx-6 cards
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:42:00.0",ACTION=="add",NAME="nic1"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:42:00.1",ACTION=="add",NAME="nic2"
+# connectx-7 cards
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:23:00.0",ACTION=="add",NAME="nic3"
 SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:03:00.0",ACTION=="add",NAME="nic4"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:c3:00.0",ACTION=="add",NAME="nic5"
+SUBSYSTEM=="net",DRIVERS=="mlx5_core",KERNELS=="0000:a3:00.0",ACTION=="add",NAME="nic6"


### PR DESCRIPTION
This PR includes 2 commits from https://github.com/OCP-on-NERC/nerc-ocp-config/pull/875 that were applied during the 20260414 maintenance. 

It includes the udev rule machine config update and the nvidia-network and sriov operator installs.

Unfortunately the OFED drivers refuse to build on the (at the time) latest stable OpenShift 4.21.8 with the following build error:

```
LD [M]  /var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-25.10/obj/default/drivers/infiniband/core/rdma_cm.o
  LD [M]  /var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-25.10/obj/default/drivers/infiniband/core/ib_cm.o
In file included from /var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-25.10/obj/default/drivers/net/ethernet/mellanox/mlx5/core/dpll.c:4:
/var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-25.10/obj/default/drivers/net/ethernet/mellanox/mlx5/core/dpll.c: In function 'mlx5_dpll_probe':
./include/linux/dpll.h:270:25: error: too few arguments to function 'dpll_device_get_rh'
  270 | #define dpll_device_get dpll_device_get_rh
      |                         ^~~~~~~~~~~~~~~~~~
./include/linux/dpll.h:270:25: note: in definition of macro 'dpll_device_get'
```

and similar using the `doca3.3.0-26.01-1.0.0.0-0` drivers which are meant for v26.1.0 of the nvidia-network-operator (currently not available to install via the OLM):

```
In file included from /var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-26.01/obj/default/drivers/net/ethernet/mellanox/mlx5/core/dpll.c:4:
/var/tmp/OFED_topdir/BUILD/mlnx-ofa_kernel-26.01/obj/default/drivers/net/ethernet/mellanox/mlx5/core/dpll.c: In function 'mlx5_dpll_probe':
./include/linux/dpll.h:270:25: error: too few arguments to function 'dpll_device_get_rh'
```

We believe this might be related to the following issue https://redhat.atlassian.net/browse/CORENET-6950

That issue suggests 4.21.10 might include a fix but we'll need to evaluate that on ocp-test before slating it for production.