### PR TITLE
feat(metering): add namespace and Kafka for nerc-ocp-test [1/6]

### DIFF
--- a/cluster-scope/base/core/namespaces/metering-thor/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metering-thor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/metering-thor/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/metering-thor/namespace.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: metering-thor
+spec: {}

--- a/cluster-scope/base/core/namespaces/metering-thor/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/metering-thor/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metering-thor

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
 - ../../base/core/namespaces/openshift-gitops
 - ../../base/core/namespaces/dex
+- ../../base/core/namespaces/metering-thor
 - externalsecrets
 - secretstores
 - issuers

--- a/metering/base/kafka.yaml
+++ b/metering/base/kafka.yaml
@@ -1,0 +1,40 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: metering
+  namespace: metering-thor
+spec:
+  kafka:
+    version: "3.7.0"
+    replicas: 1
+    listeners:
+    - name: plain
+      port: 9092
+      type: internal
+      tls: false
+    - name: tls
+      port: 9093
+      type: internal
+      tls: true
+      authentication:
+        type: scram-sha-512
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      log.retention.hours: 168
+    storage:
+      type: persistent-claim
+      size: 20Gi
+      deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 5Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/metering/base/kafka.yaml
+++ b/metering/base/kafka.yaml
@@ -8,12 +8,12 @@ spec:
     version: "3.7.0"
     replicas: 1
     listeners:
-    - name: tls
-      port: 9093
-      type: internal
-      tls: true
-      authentication:
-        type: scram-sha-512
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: scram-sha-512
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1

--- a/metering/base/kafka.yaml
+++ b/metering/base/kafka.yaml
@@ -8,10 +8,6 @@ spec:
     version: "3.7.0"
     replicas: 1
     listeners:
-    - name: plain
-      port: 9092
-      type: internal
-      tls: false
     - name: tls
       port: 9093
       type: internal

--- a/metering/base/kafka.yaml
+++ b/metering/base/kafka.yaml
@@ -27,7 +27,7 @@ spec:
       log.retention.hours: 168
     storage:
       type: persistent-claim
-      size: 20Gi
+      size: 5Gi
       deleteClaim: false
   zookeeper:
     replicas: 1

--- a/metering/base/kafkatopics.yaml
+++ b/metering/base/kafkatopics.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: billing-events
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: billing-events-dlq
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete

--- a/metering/base/kafkausers.yaml
+++ b/metering/base/kafkausers.yaml
@@ -1,0 +1,95 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: metering-otel-collector
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    - resource:
+        type: topic
+        name: billing-events
+        patternType: literal
+      operations: [Write, Describe]
+    - resource:
+        type: transactionalId
+        name: otel-collector
+        patternType: literal
+      operations: [Describe, Write]
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: metering-reconciler
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    - resource:
+        type: topic
+        name: billing-events
+        patternType: literal
+      operations: [Write, Describe]
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: metering-stream-processor
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    - resource:
+        type: topic
+        name: billing-events
+        patternType: literal
+      operations: [Read, Describe]
+    - resource:
+        type: topic
+        name: billing-events-dlq
+        patternType: literal
+      operations: [Write, Describe]
+    - resource:
+        type: group
+        name: metering-stream-processor
+        patternType: literal
+      operations: [Read, Describe]
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: metering-openmeter
+  namespace: metering-thor
+  labels:
+    strimzi.io/cluster: metering
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    - resource:
+        type: topic
+        name: billing-events
+        patternType: literal
+      operations: [Read, Describe]
+    - resource:
+        type: group
+        name: metering-openmeter
+        patternType: literal
+      operations: [Read, Describe]

--- a/metering/base/kustomization.yaml
+++ b/metering/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metering-thor
+commonLabels:
+  app.kubernetes.io/part-of: metering
+
+resources:
+- kafka.yaml
+- kafkatopics.yaml
+- kafkausers.yaml

--- a/metering/overlays/nerc-ocp-test/kustomization.yaml
+++ b/metering/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metering-thor
+resources:
+- ../../base


### PR DESCRIPTION
## Summary

- Adds `metering-thor` namespace (cluster-scope)
- Adds Strimzi Kafka single-node with SCRAM-SHA-512 auth and ~20Gi~ 5Gi storage
- Adds billing-events (7d retention) and billing-events-dlq (30d) topics
- Wires namespace into cluster-scope nerc-ocp-test overlay

## Architecture

https://docs.google.com/document/d/1yU5i8jx8VD0GuDPZ7P410M1o3sbb5D-ziAzpRT2RX2A/edit?usp=sharing

<img width="1132" height="1083" alt="image" src="https://github.com/user-attachments/assets/b1c07716-7c72-4e21-89b8-cefd68415e13" />

## Stack

> **This is a stacked PR chain. Merge in order, top to bottom.**

| # | PR | Description | Status |
|---|-----|-------------|--------|
| **1/6** | **#912 (this PR)** | **namespace + Kafka** | ← merge first |
| 2/6 | #914 | OTel collector billing patch | depends on 1 |
| 3/6 | #915 | reconciler CronJob | depends on 2 |
| 4/6 | #916 | ClickHouse billing DB | depends on 3 |
| 5/6 | #917 | stream processor | depends on 4 |
| 6/6 | #918 | OpenMeter meter engine | depends on 5 |

## Test plan

- [ ] `kustomize build cluster-scope/overlays/nerc-ocp-test` builds cleanly
- [ ] `kustomize build metering/overlays/nerc-ocp-test` builds cleanly
- [ ] Namespace `metering-thor` created on cluster
- [ ] Kafka CR reaches `Ready` state
- [ ] Topics `billing-events` and `billing-events-dlq` exist