### PR TITLE
Add costmanagement-metrics-operator to nerc-ocp-test cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/costmanagement-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/costmanagement-metrics-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/costmanagement-metrics-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/costmanagement-metrics-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: costmanagement-metrics-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/costmanagement-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/costmanagement-metrics-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/costmanagement-metrics-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/costmanagement-metrics-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: costmanagement-metrics-operator
+spec:
+  targetNamespaces:
+    - costmanagement-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/costmanagement-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/costmanagement-metrics-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/costmanagement-metrics-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/costmanagement-metrics-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: costmanagement-metrics-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: costmanagement-metrics-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/costmanagement-metrics-operator/kustomization.yaml
+++ b/cluster-scope/bundles/costmanagement-metrics-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: costmanagement-metrics-operator
+resources:
+  - ../../base/core/namespaces/costmanagement-metrics-operator/
+  - ../../base/operators.coreos.com/operatorgroups/costmanagement-metrics-operator/
+  - ../../base/operators.coreos.com/subscriptions/costmanagement-metrics-operator/

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -46,6 +46,7 @@ resources:
 - ../../bundles/servicemesh-operator
 - ../../bundles/cluster-observability-operator
 - ../../bundles/strimzi-kafka-operator
+- ../../bundles/costmanagement-metrics-operator
 
 components:
   - ../../components/nerc-oauth-github


### PR DESCRIPTION
This will allow the Red Hat Cost Management On Prem team to test the
latest cost management solution in the test cluster.
