### PR TITLE
feat(metering): add OTel collector billing patch for nerc-ocp-test [2/6]

### DIFF
--- a/opentelemetry/overlays/nerc-ocp-test/kustomization.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opentelemetry
+resources:
+- ../../base
+- rbac-k8sobjects.yaml
+
+patches:
+- path: patch-otelcol-billing.yaml

--- a/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
@@ -63,20 +63,15 @@ spec:
         check_interval: 1s
         limit_percentage: 50
         spike_limit_percentage: 30
-      k8sattributes:
-        auth_type: serviceAccount
-        extract:
-          metadata:
-          - k8s.namespace.name
-          - k8s.pod.name
-          - k8s.node.name
-          labels:
-          - tag_name: nerc.tenant
-            key: nerc.mghpcc.org/project
-            from: namespace
-          - tag_name: nerc.owner
-            key: nerc.mghpcc.org/owner
-            from: namespace
+      transform/billing:
+        log_statements:
+        - context: log
+          statements:
+          - set(attributes["namespace"],  body["involvedObject"]["namespace"])
+          - set(attributes["object_name"], body["involvedObject"]["name"])
+          - set(attributes["object_kind"], body["involvedObject"]["kind"])
+          - set(attributes["reason"],      body["reason"])
+          - set(attributes["event_time"],  body["lastTimestamp"])
     exporters:
       prometheus:
         endpoint: 0.0.0.0:8889
@@ -117,7 +112,7 @@ spec:
           exporters: [otlp]
         logs/billing:
           receivers: [k8sobjects]
-          processors: [memory_limiter, batch]
+          processors: [transform/billing, memory_limiter, batch]
           exporters: [kafka/billing]
   env:
   - name: KAFKA_PASSWORD

--- a/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
@@ -56,7 +56,7 @@ spec:
           X-Scope-OrgID: "dev"
       kafka/billing:
         brokers:
-        - metering-kafka-bootstrap.metering-thor.svc:9092
+        - metering-kafka-bootstrap.metering-thor.svc:9093
         topic: billing-events
         encoding: otlp_json
         auth:
@@ -64,6 +64,8 @@ spec:
             mechanism: SCRAM-SHA-512
             username: metering-otel-collector
             password: "${KAFKA_PASSWORD}"
+          tls:
+            ca_file: /mnt/kafka-ca/ca.crt
     service:
       telemetry:
         metrics:
@@ -88,3 +90,11 @@ spec:
       secretKeyRef:
         name: metering-otel-collector
         key: password
+  volumes:
+  - name: kafka-ca
+    secret:
+      secretName: metering-cluster-ca-cert
+  volumeMounts:
+  - name: kafka-ca
+    mountPath: /mnt/kafka-ca
+    readOnly: true

--- a/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
@@ -19,7 +19,42 @@ spec:
           mode: watch
           group: ""
           namespaces: []
-          field_selector: "reason=Started,reason=Killing,reason=Failed,reason=OOMKilling,reason=SuccessfulCreate,reason=SuccessfulDelete,reason=ProvisioningSucceeded,reason=Preempting,reason=BackOff"
+          field_selector: "reason=Started"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=Killing"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=Failed"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=OOMKilling"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=SuccessfulCreate"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=SuccessfulDelete"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=Preempting"
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=BackOff"
     processors:
       batch:
         timeout: 5s
@@ -58,7 +93,7 @@ spec:
         brokers:
         - metering-kafka-bootstrap.metering-thor.svc:9093
         topic: billing-events
-        encoding: otlp_json
+        encoding: json
         auth:
           sasl:
             mechanism: SCRAM-SHA-512
@@ -82,7 +117,7 @@ spec:
           exporters: [otlp]
         logs/billing:
           receivers: [k8sobjects]
-          processors: [k8sattributes, memory_limiter, batch]
+          processors: [memory_limiter, batch]
           exporters: [kafka/billing]
   env:
   - name: KAFKA_PASSWORD

--- a/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/patch-otelcol-billing.yaml
@@ -1,0 +1,90 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: opentelemetry
+  namespace: opentelemetry
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+        - name: events
+          mode: watch
+          group: ""
+          namespaces: []
+          field_selector: "reason=Started,reason=Killing,reason=Failed,reason=OOMKilling,reason=SuccessfulCreate,reason=SuccessfulDelete,reason=ProvisioningSucceeded,reason=Preempting,reason=BackOff"
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_max_size: 10000
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 50
+        spike_limit_percentage: 30
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.node.name
+          labels:
+          - tag_name: nerc.tenant
+            key: nerc.mghpcc.org/project
+            from: namespace
+          - tag_name: nerc.owner
+            key: nerc.mghpcc.org/owner
+            from: namespace
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        add_metric_suffixes: false
+        resource_to_telemetry_conversion:
+          enabled: true
+      otlp:
+        endpoint: tempo-opentelemetry-distributor.opentelemetry.svc:4317
+        tls:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        headers:
+          X-Scope-OrgID: "dev"
+      kafka/billing:
+        brokers:
+        - metering-kafka-bootstrap.metering-thor.svc:9092
+        topic: billing-events
+        encoding: otlp_json
+        auth:
+          sasl:
+            mechanism: SCRAM-SHA-512
+            username: metering-otel-collector
+            password: "${KAFKA_PASSWORD}"
+    service:
+      telemetry:
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: '0.0.0.0'
+                  port: 8888
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlp]
+        logs/billing:
+          receivers: [k8sobjects]
+          processors: [k8sattributes, memory_limiter, batch]
+          exporters: [kafka/billing]
+  env:
+  - name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: metering-otel-collector
+        key: password

--- a/opentelemetry/overlays/nerc-ocp-test/rbac-k8sobjects.yaml
+++ b/opentelemetry/overlays/nerc-ocp-test/rbac-k8sobjects.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otelcol-k8sobjects-billing
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces", "pods", "persistentvolumeclaims"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otelcol-k8sobjects-billing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otelcol-k8sobjects-billing
+subjects:
+- kind: ServiceAccount
+  name: opentelemetry-collector
+  namespace: opentelemetry


### PR DESCRIPTION
## Summary

- Patches OTel collector with k8sobjects receiver to capture Pod/PVC lifecycle events
- Adds k8sattributes processor for namespace/workload enrichment
- Adds Kafka billing exporter writing to billing-events topic
- Adds ClusterRole + binding for k8sobjects watch permissions

## Stack

> **This is a stacked PR chain. Merge in order, top to bottom.**

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1/6 | #912 | namespace + Kafka | merge first |
| **2/6** | **#914 (this PR)** | **OTel collector billing patch** | ← depends on #912 |
| 3/6 | #915 | reconciler CronJob | depends on 2 |
| 4/6 | #916 | ClickHouse billing DB | depends on 3 |
| 5/6 | #917 | stream processor | depends on 4 |
| 6/6 | #918 | OpenMeter meter engine | depends on 5 |

## Test plan

- [ ] `kustomize build opentelemetry/overlays/nerc-ocp-test` builds cleanly
- [ ] OTel collector pod restarts without error
- [ ] Events visible in billing-events Kafka topic