### PR TITLE
feat(metering): add ClickHouse billing DB for nerc-ocp-test [4/6]

### DIFF
--- a/cluster-scope/base/core/namespaces/clickhouse-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/clickhouse-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/clickhouse-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/clickhouse-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clickhouse-operator
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/clickhouse-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/clickhouse-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/clickhouse-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/clickhouse-operator/operatorgroup.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: clickhouse-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/clickhouse-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/clickhouse-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/clickhouse-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/clickhouse-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: clickhouse-operator
+  namespace: clickhouse-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: altinity-clickhouse-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/clickhouse-operator/kustomization.yaml
+++ b/cluster-scope/bundles/clickhouse-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  nerc.mghpcc.org/bundle: clickhouse-operator
+resources:
+- ../../base/core/namespaces/clickhouse-operator
+- ../../base/operators.coreos.com/operatorgroups/clickhouse-operator
+- ../../base/operators.coreos.com/subscriptions/clickhouse-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -48,6 +48,7 @@ resources:
 - ../../bundles/cluster-observability-operator
 - ../../bundles/strimzi-kafka-operator
 - ../../bundles/costmanagement-metrics-operator
+- ../../bundles/clickhouse-operator
 
 components:
   - ../../components/nerc-oauth-github

--- a/metering/base/clickhouse-schema-configmap.yaml
+++ b/metering/base/clickhouse-schema-configmap.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-billing-schema
+  namespace: metering-thor
+data:
+  00_create_database.sql: |
+    CREATE DATABASE IF NOT EXISTS billing;
+
+  01_billing_events.sql: |
+    CREATE TABLE IF NOT EXISTS billing.billing_events
+    (
+        event_id        UUID DEFAULT generateUUIDv4(),
+        received_at     DateTime DEFAULT now(),
+        event_time      DateTime,
+        event_reason    LowCardinality(String),
+        billing_action  LowCardinality(String),
+        namespace       String,
+        pod_name        String,
+        node_name       String,
+        nerc_tenant     String,
+        nerc_owner      String,
+        resource_type   LowCardinality(String),
+        raw_payload     String
+    )
+    ENGINE = MergeTree()
+    PARTITION BY toYYYYMM(event_time)
+    ORDER BY (nerc_tenant, namespace, event_time, event_id)
+    TTL event_time + INTERVAL 13 MONTH;
+
+  02_billing_sessions.sql: |
+    CREATE TABLE IF NOT EXISTS billing.billing_sessions
+    (
+        session_id      UUID DEFAULT generateUUIDv4(),
+        nerc_tenant     String,
+        namespace       String,
+        pod_name        String,
+        node_name       String,
+        resource_type   LowCardinality(String),
+        start_time      DateTime,
+        stop_time       Nullable(DateTime),
+        stop_reason     LowCardinality(String),
+        duration_seconds Nullable(UInt64)
+    )
+    ENGINE = MergeTree()
+    PARTITION BY toYYYYMM(start_time)
+    ORDER BY (nerc_tenant, namespace, start_time, session_id)
+    TTL start_time + INTERVAL 25 MONTH;
+
+  03_namespace_usage_daily.sql: |
+    CREATE MATERIALIZED VIEW IF NOT EXISTS billing.namespace_usage_daily
+    ENGINE = SummingMergeTree()
+    PARTITION BY toYYYYMM(usage_date)
+    ORDER BY (nerc_tenant, namespace, resource_type, usage_date)
+    AS
+    SELECT
+        nerc_tenant,
+        namespace,
+        resource_type,
+        toDate(start_time)              AS usage_date,
+        count()                         AS session_count,
+        sum(duration_seconds)           AS total_seconds
+    FROM billing.billing_sessions
+    WHERE stop_time IS NOT NULL
+    GROUP BY nerc_tenant, namespace, resource_type, usage_date;

--- a/metering/base/clickhouse-schema-job.yaml
+++ b/metering/base/clickhouse-schema-job.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
-  backoffLimit: 10
+  backoffLimit: 4
   template:
     spec:
       restartPolicy: OnFailure

--- a/metering/base/clickhouse-schema-job.yaml
+++ b/metering/base/clickhouse-schema-job.yaml
@@ -14,6 +14,12 @@ spec:
       containers:
       - name: schema-init
         image: clickhouse/clickhouse-client:24.3
+        env:
+        - name: CLICKHOUSE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-default-password
+              key: password
         command:
         - /bin/sh
         - -c
@@ -22,7 +28,8 @@ spec:
           HOST="chi-metering-metering-0-0.metering-thor.svc"
           for f in /sql/*.sql; do
             echo "applying $f"
-            clickhouse-client --host "$HOST" --multiquery < "$f"
+            clickhouse-client --host "$HOST" --user default \
+              --password "$CLICKHOUSE_PASSWORD" --multiquery < "$f"
           done
           echo "schema init complete"
         volumeMounts:

--- a/metering/base/clickhouse-schema-job.yaml
+++ b/metering/base/clickhouse-schema-job.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: clickhouse-schema-init
+  namespace: metering-thor
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: schema-init
+        image: clickhouse/clickhouse-client:24.3
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          HOST="chi-metering-metering-0-0.metering-thor.svc"
+          for f in /sql/*.sql; do
+            echo "applying $f"
+            clickhouse-client --host "$HOST" --multiquery < "$f"
+          done
+          echo "schema init complete"
+        volumeMounts:
+        - name: sql
+          mountPath: /sql
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      volumes:
+      - name: sql
+        configMap:
+          name: clickhouse-billing-schema

--- a/metering/base/clickhouse.yaml
+++ b/metering/base/clickhouse.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: metering-thor
 spec:
   configuration:
+    users:
+      default/passwordSecret/name: clickhouse-default-password
+      default/passwordSecret/key: password
     clusters:
     - name: metering
       layout:

--- a/metering/base/clickhouse.yaml
+++ b/metering/base/clickhouse.yaml
@@ -1,0 +1,37 @@
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: metering
+  namespace: metering-thor
+spec:
+  configuration:
+    clusters:
+    - name: metering
+      layout:
+        shardsCount: 1
+        replicasCount: 1
+  defaults:
+    templates:
+      podTemplate: clickhouse-pod
+      dataVolumeClaimTemplate: clickhouse-data
+  templates:
+    podTemplates:
+    - name: clickhouse-pod
+      spec:
+        containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+    volumeClaimTemplates:
+    - name: clickhouse-data
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 50Gi

--- a/metering/base/externalsecrets/clickhouse-default-password.yaml
+++ b/metering/base/externalsecrets/clickhouse-default-password.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-default-password
+  namespace: metering-thor
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: clickhouse-default-password
+    template:
+      type: Opaque
+  data:
+  - secretKey: password
+    remoteRef:
+      key: nerc/nerc-ocp-test/metering-thor/clickhouse-default-password
+      property: password

--- a/metering/base/externalsecrets/kustomization.yaml
+++ b/metering/base/externalsecrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clickhouse-default-password.yaml

--- a/metering/base/kustomization.yaml
+++ b/metering/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - kafkausers.yaml
 - rbac.yaml
 - reconciler-cronjob.yaml
+- externalsecrets
 - clickhouse.yaml
 - clickhouse-schema-configmap.yaml
 - clickhouse-schema-job.yaml

--- a/metering/base/kustomization.yaml
+++ b/metering/base/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - kafkausers.yaml
 - rbac.yaml
 - reconciler-cronjob.yaml
+- clickhouse.yaml
+- clickhouse-schema-configmap.yaml
+- clickhouse-schema-job.yaml


### PR DESCRIPTION
## Summary

- Adds ClickHouseInstallation CR (1 shard, 1 replica, 50Gi PVC)
- Adds ConfigMap with schema SQL: database, billing_events table, billing_sessions table, namespace_usage_daily materialized view
- Adds ArgoCD PostSync Job to apply schema on first deploy
- Adds ExternalSecret for ClickHouse default user password (Vault)
- Wires clickhouse-operator bundle into nerc-ocp-test cluster-scope overlay

## Stack

> **This is a stacked PR chain. Merge in order, top to bottom.**

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1/6 | #912 | namespace + Kafka | merge first |
| 2/6 | #914 | OTel collector billing patch | depends on 1 |
| 3/6 | #915 | reconciler CronJob | depends on 2 |
| **4/6** | **#916 (this PR)** | **ClickHouse billing DB** | ← depends on #915 |
| 5/6 | #917 | stream processor | depends on 4 |
| 6/6 | #918 | OpenMeter meter engine | depends on 5 |

## Test plan

- [ ] `kustomize build metering/overlays/nerc-ocp-test` builds cleanly
- [ ] ClickHouse pod reaches Running state
- [ ] PostSync job runs and billing database + tables are created