### PR TITLE
feat(metering): add stream processor placeholder for nerc-ocp-test [5/6]

### DIFF
--- a/metering/base/externalsecrets/clickhouse-credentials.yaml
+++ b/metering/base/externalsecrets/clickhouse-credentials.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-billing-credentials
+  namespace: metering-thor
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: clickhouse-billing-credentials
+    template:
+      type: Opaque
+  data:
+  - secretKey: password
+    remoteRef:
+      key: nerc/nerc-ocp-test/metering-thor/clickhouse-billing-credentials
+      property: password

--- a/metering/base/externalsecrets/kustomization.yaml
+++ b/metering/base/externalsecrets/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - clickhouse-default-password.yaml
+- clickhouse-credentials.yaml

--- a/metering/base/kustomization.yaml
+++ b/metering/base/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - clickhouse.yaml
 - clickhouse-schema-configmap.yaml
 - clickhouse-schema-job.yaml
+- stream-processor.yaml

--- a/metering/base/stream-processor.yaml
+++ b/metering/base/stream-processor.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metering-stream-processor
+  namespace: metering-thor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metering-stream-processor
+  template:
+    metadata:
+      labels:
+        app: metering-stream-processor
+    spec:
+      serviceAccountName: metering-reconciler
+      containers:
+      - name: stream-processor
+        image: registry.access.redhat.com/ubi9/python-311:latest
+        env:
+        - name: KAFKA_BOOTSTRAP
+          value: metering-kafka-bootstrap.metering-thor.svc:9092
+        - name: KAFKA_TOPIC
+          value: billing-events
+        - name: KAFKA_DLQ_TOPIC
+          value: billing-events-dlq
+        - name: KAFKA_GROUP_ID
+          value: metering-stream-processor
+        - name: KAFKA_USER
+          value: metering-stream-processor
+        - name: KAFKA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metering-stream-processor
+              key: password
+        - name: CLICKHOUSE_HOST
+          value: chi-metering-metering-0-0.metering-thor.svc
+        - name: CLICKHOUSE_PORT
+          value: "9000"
+        - name: CLICKHOUSE_DB
+          value: billing
+        - name: CLICKHOUSE_USER
+          value: default
+        - name: CLICKHOUSE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: clickhouse-billing-credentials
+              key: password
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "stream-processor placeholder - implement START/STOP pairing and ClickHouse writes"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "exit 0"]
+          initialDelaySeconds: 30
+          periodSeconds: 60

--- a/metering/base/stream-processor.yaml
+++ b/metering/base/stream-processor.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: metering-reconciler
       containers:
       - name: stream-processor
-        image: registry.access.redhat.com/ubi9/python-311:latest
+        image: registry.access.redhat.com/ubi9/python-311:9.7-1776963225
         env:
         - name: KAFKA_BOOTSTRAP
           value: metering-kafka-bootstrap.metering-thor.svc:9093

--- a/metering/base/stream-processor.yaml
+++ b/metering/base/stream-processor.yaml
@@ -19,7 +19,9 @@ spec:
         image: registry.access.redhat.com/ubi9/python-311:latest
         env:
         - name: KAFKA_BOOTSTRAP
-          value: metering-kafka-bootstrap.metering-thor.svc:9092
+          value: metering-kafka-bootstrap.metering-thor.svc:9093
+        - name: KAFKA_CA_CERT
+          value: /mnt/kafka-ca/ca.crt
         - name: KAFKA_TOPIC
           value: billing-events
         - name: KAFKA_DLQ_TOPIC
@@ -58,8 +60,16 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+        volumeMounts:
+        - name: kafka-ca
+          mountPath: /mnt/kafka-ca
+          readOnly: true
         livenessProbe:
           exec:
             command: ["/bin/sh", "-c", "exit 0"]
           initialDelaySeconds: 30
           periodSeconds: 60
+      volumes:
+      - name: kafka-ca
+        secret:
+          secretName: metering-cluster-ca-cert


### PR DESCRIPTION
## Summary

- Adds stream-processor Deployment placeholder
- Reads billing-events from Kafka, writes raw events to ClickHouse billing_events table
- Adds ExternalSecret for clickhouse-billing-credentials (Vault)
- Currently a shell placeholder — actual Kafka→ClickHouse logic to be implemented

## Stack

> **This is a stacked PR chain. Merge in order, top to bottom.**

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1/6 | #912 | namespace + Kafka | merge first |
| 2/6 | #914 | OTel collector billing patch | depends on 1 |
| 3/6 | #915 | reconciler CronJob | depends on 2 |
| 4/6 | #916 | ClickHouse billing DB | depends on 3 |
| **5/6** | **#917 (this PR)** | **stream processor** | ← depends on #916 |
| 6/6 | #918 | OpenMeter meter engine | depends on 5 |

## Test plan

- [ ] `kustomize build metering/overlays/nerc-ocp-test` builds cleanly
- [ ] Deployment created (pod will log placeholder message until implemented)