### PR TITLE
feat(metering): add OpenMeter self-hosted meter engine for nerc-ocp-test [6/6]

### DIFF
--- a/metering/base/kafkausers.yaml
+++ b/metering/base/kafkausers.yaml
@@ -4,23 +4,25 @@ metadata:
   name: metering-otel-collector
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering
+    strimzi.io/cluster: metering-kafka
 spec:
   authentication:
     type: scram-sha-512
   authorization:
     type: simple
     acls:
-    - resource:
-        type: topic
-        name: billing-events
-        patternType: literal
-      operations: [Write, Describe]
-    - resource:
-        type: transactionalId
-        name: otel-collector
-        patternType: literal
-      operations: [Describe, Write]
+      - resource:
+          type: topic
+          name: billing-events
+        operations:
+          - Write
+          - Describe
+      - resource:
+          type: transactionalId
+          name: otel-collector
+        operations:
+          - Describe
+          - Write
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -28,18 +30,19 @@ metadata:
   name: metering-reconciler
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering
+    strimzi.io/cluster: metering-kafka
 spec:
   authentication:
     type: scram-sha-512
   authorization:
     type: simple
     acls:
-    - resource:
-        type: topic
-        name: billing-events
-        patternType: literal
-      operations: [Write, Describe]
+      - resource:
+          type: topic
+          name: billing-events
+        operations:
+          - Write
+          - Describe
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -47,28 +50,24 @@ metadata:
   name: metering-stream-processor
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering
+    strimzi.io/cluster: metering-kafka
 spec:
   authentication:
     type: scram-sha-512
   authorization:
     type: simple
     acls:
-    - resource:
-        type: topic
-        name: billing-events
-        patternType: literal
-      operations: [Read, Describe]
-    - resource:
-        type: topic
-        name: billing-events-dlq
-        patternType: literal
-      operations: [Write, Describe]
-    - resource:
-        type: group
-        name: metering-stream-processor
-        patternType: literal
-      operations: [Read, Describe]
+      - resource:
+          type: topic
+          name: billing-events
+        operations:
+          - Read
+          - Describe
+      - resource:
+          type: group
+          name: stream-processor
+        operations:
+          - Read
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
@@ -76,20 +75,21 @@ metadata:
   name: metering-openmeter
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering
+    strimzi.io/cluster: metering-kafka
 spec:
   authentication:
     type: scram-sha-512
   authorization:
     type: simple
     acls:
-    - resource:
-        type: topic
-        name: billing-events
-        patternType: literal
-      operations: [Read, Describe]
-    - resource:
-        type: group
-        name: metering-openmeter
-        patternType: literal
-      operations: [Read, Describe]
+      - resource:
+          type: topic
+          name: billing-events
+        operations:
+          - Read
+          - Describe
+      - resource:
+          type: group
+          name: openmeter-consumer
+        operations:
+          - Read

--- a/metering/base/kafkausers.yaml
+++ b/metering/base/kafkausers.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metering-otel-collector
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering-kafka
+    strimzi.io/cluster: metering
 spec:
   authentication:
     type: scram-sha-512
@@ -30,7 +30,7 @@ metadata:
   name: metering-reconciler
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering-kafka
+    strimzi.io/cluster: metering
 spec:
   authentication:
     type: scram-sha-512
@@ -50,7 +50,7 @@ metadata:
   name: metering-stream-processor
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering-kafka
+    strimzi.io/cluster: metering
 spec:
   authentication:
     type: scram-sha-512
@@ -64,8 +64,14 @@ spec:
           - Read
           - Describe
       - resource:
+          type: topic
+          name: billing-events-dlq
+        operations:
+          - Write
+          - Describe
+      - resource:
           type: group
-          name: stream-processor
+          name: metering-stream-processor
         operations:
           - Read
 ---
@@ -75,7 +81,7 @@ metadata:
   name: metering-openmeter
   namespace: metering-thor
   labels:
-    strimzi.io/cluster: metering-kafka
+    strimzi.io/cluster: metering
 spec:
   authentication:
     type: scram-sha-512

--- a/metering/base/kustomization.yaml
+++ b/metering/base/kustomization.yaml
@@ -15,3 +15,5 @@ resources:
 - clickhouse-schema-configmap.yaml
 - clickhouse-schema-job.yaml
 - stream-processor.yaml
+- openmeter-config.yaml
+- openmeter.yaml

--- a/metering/base/openmeter-config.yaml
+++ b/metering/base/openmeter-config.yaml
@@ -9,11 +9,12 @@ data:
 
     ingest:
       kafka:
-        broker: metering-kafka-bootstrap.metering-thor.svc:9092
-        securityProtocol: SASL_PLAINTEXT
+        broker: metering-kafka-bootstrap.metering-thor.svc:9093
+        securityProtocol: SASL_SSL
         saslMechanisms: SCRAM-SHA-512
         saslUsername: metering-openmeter
         saslPasswordFile: /mnt/kafka-secret/password
+        sslCaLocation: /mnt/kafka-ca/ca.crt
         topics:
           - billing-events
         consumerGroupID: openmeter-consumer

--- a/metering/base/openmeter-config.yaml
+++ b/metering/base/openmeter-config.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metering-openmeter-config
+  namespace: metering-thor
+data:
+  config.yaml: |
+    address: 0.0.0.0:8080
+
+    ingest:
+      kafka:
+        broker: metering-kafka-bootstrap.metering-thor.svc:9092
+        securityProtocol: SASL_PLAINTEXT
+        saslMechanisms: SCRAM-SHA-512
+        saslUsername: metering-openmeter
+        saslPasswordFile: /mnt/kafka-secret/password
+        topics:
+          - billing-events
+        consumerGroupID: openmeter-consumer
+
+    sink:
+      clickhouse:
+        address: chi-metering-clickhouse-0-0.metering-thor.svc:9000
+        username: default
+        database: billing
+        eventsTableName: billing_events
+
+    meters:
+      - slug: pod_running_seconds
+        description: "Pod running time in seconds"
+        aggregation: SUM
+        valueProperty: "$.duration_seconds"
+        groupBy:
+          namespace: "$.namespace"
+          pod: "$.pod_name"
+        eventType: POD_RUNNING
+
+      - slug: storage_request_bytes
+        description: "Persistent volume storage requested"
+        aggregation: MAX
+        valueProperty: "$.storage_bytes"
+        groupBy:
+          namespace: "$.namespace"
+          pvc: "$.pvc_name"
+        eventType: PVC_BOUND
+
+      - slug: pod_error_count
+        description: "Pod error events"
+        aggregation: COUNT
+        groupBy:
+          namespace: "$.namespace"
+          reason: "$.reason"
+        eventType: POD_ERROR

--- a/metering/base/openmeter-config.yaml
+++ b/metering/base/openmeter-config.yaml
@@ -23,6 +23,7 @@ data:
       clickhouse:
         address: chi-metering-metering-0-0.metering-thor.svc:9000
         username: default
+        passwordFile: /mnt/clickhouse-secret/password
         database: billing
         eventsTableName: billing_events
 

--- a/metering/base/openmeter-config.yaml
+++ b/metering/base/openmeter-config.yaml
@@ -20,7 +20,7 @@ data:
 
     sink:
       clickhouse:
-        address: chi-metering-clickhouse-0-0.metering-thor.svc:9000
+        address: chi-metering-metering-0-0.metering-thor.svc:9000
         username: default
         database: billing
         eventsTableName: billing_events

--- a/metering/base/openmeter.yaml
+++ b/metering/base/openmeter.yaml
@@ -27,6 +27,9 @@ spec:
             - name: kafka-secret
               mountPath: /mnt/kafka-secret
               readOnly: true
+            - name: kafka-ca
+              mountPath: /mnt/kafka-ca
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -44,6 +47,9 @@ spec:
             items:
               - key: password
                 path: password
+        - name: kafka-ca
+          secret:
+            secretName: metering-cluster-ca-cert
 ---
 apiVersion: v1
 kind: Service

--- a/metering/base/openmeter.yaml
+++ b/metering/base/openmeter.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: openmeter
-          image: ghcr.io/openmeterio/openmeter:latest
+          image: ghcr.io/openmeterio/openmeter:v1.0.0-beta.227
           args:
             - --config
             - /etc/openmeter/config.yaml

--- a/metering/base/openmeter.yaml
+++ b/metering/base/openmeter.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metering-openmeter
+  namespace: metering-thor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metering-openmeter
+  template:
+    metadata:
+      labels:
+        app: metering-openmeter
+    spec:
+      containers:
+        - name: openmeter
+          image: ghcr.io/openmeterio/openmeter:latest
+          args:
+            - --config
+            - /etc/openmeter/config.yaml
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/openmeter
+            - name: kafka-secret
+              mountPath: /mnt/kafka-secret
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: metering-openmeter-config
+        - name: kafka-secret
+          secret:
+            secretName: metering-openmeter
+            items:
+              - key: password
+                path: password
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metering-openmeter
+  namespace: metering-thor
+spec:
+  selector:
+    app: metering-openmeter
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/metering/base/openmeter.yaml
+++ b/metering/base/openmeter.yaml
@@ -30,6 +30,9 @@ spec:
             - name: kafka-ca
               mountPath: /mnt/kafka-ca
               readOnly: true
+            - name: clickhouse-secret
+              mountPath: /mnt/clickhouse-secret
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -50,6 +53,12 @@ spec:
         - name: kafka-ca
           secret:
             secretName: metering-cluster-ca-cert
+        - name: clickhouse-secret
+          secret:
+            secretName: clickhouse-billing-credentials
+            items:
+              - key: password
+                path: password
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

- Adds OpenMeter self-hosted Deployment + ClusterIP Service (port 8080)
- Adds ConfigMap with OpenMeter config: Kafka ingest from billing-events, ClickHouse sink
- Defines 3 meters: pod_running_seconds (SUM), storage_request_bytes (MAX), pod_error_count (COUNT)
- Updates KafkaUsers: cluster label `metering-kafka`, ACL format cleanup, consumer group `openmeter-consumer`

## Stack

> **This is a stacked PR chain. Merge in order, top to bottom.**

| # | PR | Description | Status |
|---|-----|-------------|--------|
| 1/6 | #912 | namespace + Kafka | merge first |
| 2/6 | #914 | OTel collector billing patch | depends on 1 |
| 3/6 | #915 | reconciler CronJob | depends on 2 |
| 4/6 | #916 | ClickHouse billing DB | depends on 3 |
| 5/6 | #917 | stream processor | depends on 4 |
| **6/6** | **#918 (this PR)** | **OpenMeter meter engine** | ← depends on #917 |

## Architectural note

OpenMeter reads billing-events directly from Kafka (independent consumer group `openmeter-consumer`), parallel to the stream-processor. Stream processor archives raw events; OpenMeter aggregates sessions.

## Test plan

- [ ] `kustomize build metering/overlays/nerc-ocp-test` builds cleanly
- [ ] OpenMeter pod reaches Running state
- [ ] OpenMeter API responds on port 8080
- [ ] Meters accumulating data from billing-events topic