### PR TITLE
Remove servicemesh-operator from nerc-ocp-test overlay

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -44,7 +44,6 @@ resources:
 - ../../bundles/moc-metrics-collector
 - ../../bundles/nagios-monitoring
 - ../../bundles/authorino-operator
-- ../../bundles/servicemesh-operator
 - ../../bundles/cluster-observability-operator
 - ../../bundles/strimzi-kafka-operator
 - ../../bundles/costmanagement-metrics-operator

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -43,7 +43,6 @@ resources:
 - ../../bundles/moc-metrics-collector
 - ../../bundles/nagios-monitoring
 - ../../bundles/authorino-operator
-- ../../bundles/servicemesh-operator
 - ../../bundles/cluster-observability-operator
 - ../../bundles/strimzi-kafka-operator
 - ../../bundles/costmanagement-metrics-operator


### PR DESCRIPTION
Removed servicemesh-operator from test cluster kustomization.yaml
This subscription has been replaced by servicemeshoperator3 for newer version of RHOAI and was preventing the cluster from upgrading as it was causing the ingress operator to be in a degraded state.