### PR TITLE
nvidia-network-operator: bump memory requirements

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/nvidia-network-operator/subscription.yaml
@@ -8,3 +8,11 @@ spec:
   name: nvidia-network-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 5m
+        memory: 256Mi


### PR DESCRIPTION
This updates the deployment resource requirements from the original:
```
  resources:
    limits:
      cpu: 500m
      memory: 256Mi
    requests:
      cpu: 5m
      memory: 64Mi
```