### PR TITLE
ocp-prod: disable RDMA in clusterpolicy

### DIFF
--- a/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-prod/clusterpolicy/clusterpolicy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     repository: "nvcr.io/nvidia"
     image: "driver"
     rdma:
-      enabled: true
+      enabled: false
   daemonsets:
     tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
The current v26.3.0 of the NVIDIA operator installed on prod strictly requires RDMA hardware to be available across the cluster. This appears to be a change from v25.10.1 which was more leniant and allowed heterogeneous NIC hardware with respect to RDMA. The result is that only the A100 and H100 nodes in the cluster were able to successfully launch all required GPU pods while the V100 nodes were pending waiting for mellanox drivers from the nvidia-network-operator that will never be created due to the lack of compatible hardware (ie Mellanox/NVIDIA NICs).

The current plan is to experiment with abandoning the classic/global clusterpolicy CRD in favor of the new NVIDIADriver CRD which in theory should allow us to selectively install different versions of the NVIDIA driver (e.g. to pin older driver versions for V100s moving forward) as well as selectively enable RDMA based on nodeSelectors.