### PR TITLE
ocp-test: use nvidiadriver to manage drivers

### DIFF
--- a/nfd-operator/base/nodefeaturerules/kustomization.yaml
+++ b/nfd-operator/base/nodefeaturerules/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - nodefeaturediscoveries
-  - nodefeaturerules
+  - nvidia-pci-labels-and-taints.yaml

--- a/nfd-operator/base/nodefeaturerules/nvidia-pci-labels-and-taints.yaml
+++ b/nfd-operator/base/nodefeaturerules/nvidia-pci-labels-and-taints.yaml
@@ -1,0 +1,54 @@
+apiVersion: nfd.openshift.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: nvidia-pci-labels-and-taints
+spec:
+  rules:
+    - name: "NVIDIA pci-10de-<device>.present labels"
+      labelsTemplate: |
+        {{ range .pci.device }}pci-{{ .vendor }}-device={{ .device }}
+        {{ end }}
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["10de"]}
+            class: {op: In, value: ["0300", "0302"]}
+    - name: "NVIDIA nvidia-gpu.product labels (Tesla-V100-PCIE-32GB)"
+      labelsTemplate: |
+        nvidia-gpu.product=Tesla-V100-PCIE-32GB
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["10de"]}
+            class: {op: In, value: ["0302"]}
+            device: {op: In, value: ["1db6"]}
+      taints:
+        - effect: NoSchedule
+          key: nvidia.com/gpu.product
+          value: Tesla-V100-PCIE-32GB
+    - name: "NVIDIA nvidia-gpu.product labels (NVIDIA-A100-SXM4-40GB)"
+      labelsTemplate: |
+        nvidia-gpu.product=NVIDIA-A100-SXM4-40GB
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["10de"]}
+            class: {op: In, value: ["0302"]}
+            device: {op: In, value: ["20b0"]}
+      taints:
+        - effect: NoSchedule
+          key: nvidia.com/gpu.product
+          value: NVIDIA-A100-SXM4-40GB
+    - name: "NVIDIA nvidia-gpu.product labels (NVIDIA-H100-80GB-HBM3)"
+      labelsTemplate: |
+        nvidia-gpu.product=NVIDIA-H100-80GB-HBM3
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["10de"]}
+            class: {op: In, value: ["0302"]}
+            device: {op: In, value: ["2330"]}
+      taints:
+        - effect: NoSchedule
+          key: nvidia.com/gpu.product
+          value: NVIDIA-H100-80GB-HBM3

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -10,13 +10,10 @@ spec:
       default: all-disabled
       name: test-mig-parted-config
   driver:
+    enabled: false
     upgradePolicy:
       autoUpgrade: true
-    version: "580.105.08"
-    repository: "nvcr.io/nvidia"
-    image: "driver"
-    rdma:
-      enabled: true
+    useNvidiaDriverCRD: true
   daemonsets:
     tolerations:
     - effect: NoSchedule

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/clusterpolicy/clusterpolicy_patch.yaml
@@ -13,6 +13,19 @@ spec:
     enabled: false
     upgradePolicy:
       autoUpgrade: true
+      drain:
+        deleteEmptyDir: true
+        enable: true
+        force: true
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+      maxUnavailable: 25%
+      podDeletion:
+        deleteEmptyDir: true
+        force: true
+        timeoutSeconds: 300
+      waitForCompletion:
+        timeoutSeconds: 0
     useNvidiaDriverCRD: true
   daemonsets:
     tolerations:

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/ampere.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/ampere.yaml
@@ -1,0 +1,19 @@
+apiVersion: nvidia.com/v1alpha1
+kind: NVIDIADriver
+metadata:
+  name: ampere
+spec:
+  driverType: "gpu"
+  image: "driver"
+  repository: "nvcr.io/nvidia"
+  version: "580.105.08"
+  kernelModuleType: "auto"
+  rdma:
+    enabled: true
+  nodeSelector:
+    feature.node.kubernetes.io/nvidia-gpu.product: NVIDIA-A100-SXM4-40GB
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu.product
+    operator: Equal
+    value: NVIDIA-A100-SXM4-40GB

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/hopper.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/hopper.yaml
@@ -1,0 +1,19 @@
+apiVersion: nvidia.com/v1alpha1
+kind: NVIDIADriver
+metadata:
+  name: hopper
+spec:
+  driverType: "gpu"
+  image: "driver"
+  repository: "nvcr.io/nvidia"
+  version: "580.105.08"
+  kernelModuleType: "auto"
+  rdma:
+    enabled: true
+  nodeSelector:
+    feature.node.kubernetes.io/nvidia-gpu.product: NVIDIA-H100-80GB-HBM3
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu.product
+    operator: Equal
+    value: NVIDIA-H100-80GB-HBM3

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-gpu-operator
+resources:
+  - volta.yaml
+  - ampere.yaml
+  - hopper.yaml

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/volta.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/drivers/volta.yaml
@@ -1,0 +1,19 @@
+apiVersion: nvidia.com/v1alpha1
+kind: NVIDIADriver
+metadata:
+  name: volta
+spec:
+  driverType: "gpu"
+  image: "driver"
+  repository: "nvcr.io/nvidia"
+  version: "580.105.08"
+  kernelModuleType: "auto"
+  rdma:
+    enabled: false
+  nodeSelector:
+    feature.node.kubernetes.io/nvidia-gpu.product: Tesla-V100-PCIE-32GB
+  tolerations:
+  - effect: NoSchedule
+    key: nvidia.com/gpu.product
+    operator: Equal
+    value: Tesla-V100-PCIE-32GB

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: nvidia-gpu-operator
 resources:
   - ../../base
   - configmaps/mig-manager-config.yaml
+  - drivers
 patches:
   - path: clusterpolicy/clusterpolicy_patch.yaml


### PR DESCRIPTION
This disables management of the NVIDIA drivers from the clusterpolicy in order to enable managing specific settings (e.g. driver version, rdma, etc) on different classes of hardware (e.g. hopper, ampere, volta, etc.)

This patch also introduces a new NodeFeatureRule to apply custom GPU node label based on PCI ids, e.g.:

`feature.node.kubernetes.io/nvidia-gpu.product`

This NodeFeatureRule also automatically applies taints to the GPU nodes which should satisfy/close https://github.com/nerc-project/operations/issues/1190 once we deploy this same solution to the nerc-ocp-prod cluster. The NodeFeatureRule does not require the NVIDIA GPU operator to be installed and the `feature.node.kubernetes.io/nvidia-gpu.product` label is used in the NVIDIADriver's nodeSelector.