### PR TITLE
ocp-test: upgrade NVIDIA GPU operator to v26.3

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -146,7 +146,7 @@ patches:
   patch: |
     - op: replace
       path: /spec/channel
-      value: v25.10
+      value: v26.3
 - target:
     kind: Subscription
     name: strimzi-kafka-operator


### PR DESCRIPTION
This upgrades the NVIDIA GPU operator to v26.3 to match the nerc-ocp-prod cluster.