### PR TITLE
fix: NAIRR dashboard - replace image!='' filter with container!='' in CPU queries

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
                 },
                 "targets": [
                     {
-                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",image!=\"\"}[5m]))",
+                        "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[5m]))",
                         "refId": "A"
                     }
                 ],
@@ -295,7 +295,7 @@ spec:
                 },
                 "targets": [
                     {
-                        "expr": "(sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",image!=\"\"}[5m])) * 15) + ((sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"}) or vector(0)) * 250)",
+                        "expr": "(sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[5m])) * 15) + ((sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"}) or vector(0)) * 250)",
                         "legendFormat": "Estimated power (W)",
                         "refId": "A"
                     }


### PR DESCRIPTION
## Problem

`docker-build` containers in cAdvisor have no `image` label set, so the filter `image!=""` silently drops all their CPU metrics. This causes the **CPU used** and **Estimated power** panels to show "No data" for namespaces running build workloads.

## Fix

Replace `image!=""` with `container!=""` in both CPU queries.

- `container!="POD"` already excludes the pause/sandbox container
- `container!=""` additionally excludes the bare node-level aggregates
- No need for `image!=""` — it only accidentally filters real workloads

Affected panels:
- CPU used (cores)
- Estimated power usage (heuristic)

Relates to nerc-project/operations#1394