### PR TITLE
feat(nairr-dashboard): add missing b-* namespace for NAIRR250424

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
@@ -321,7 +321,7 @@ spec:
                     },
                     "label": "RHOAI Project / Namespace",
                     "name": "namespace",
-                    "query": "multi-modal-semantic-routing-for-vllm-d266df,ts-data-agent-0a0cee,b-ts-data-agent-0a0cee,efficient-memory-offloading-765cab,b-efficient-memory-offloading-765cab,model-merging-47c2fd,reliability-for-llm-agents-3fc129,mllm-interpretation-and-failure-investigation-c8fa7f,kv-cache-compression-c45372,adaptive-kv-cache-compression-for-agentic-ai-6f3c1f",
+                    "query": "multi-modal-semantic-routing-for-vllm-d266df,b-multi-modal-semantic-routing-for-vllm-d266df,ts-data-agent-0a0cee,b-ts-data-agent-0a0cee,efficient-memory-offloading-765cab,b-efficient-memory-offloading-765cab,model-merging-47c2fd,reliability-for-llm-agents-3fc129,mllm-interpretation-and-failure-investigation-c8fa7f,kv-cache-compression-c45372,adaptive-kv-cache-compression-for-agentic-ai-6f3c1f",
                     "type": "custom"
                 }
             ]


### PR DESCRIPTION
fixes https://github.com/nerc-project/operations/issues/1552

The multi-modal project was the only NAIRR namespace that had no Barcelona pair in the dashboard variable. All other projects with a b-* counterpart was already listed, but b-multi-modal-semantic-routing-for-vllm-d266df was missing, so it gives no possibility to select this namespace in the actual dashboard variable.

**Key changes:**

- add `b-multi-modal-semantic-routing-for-vllm-d266df` directly after its non-b pair in the namespace variable query string

Triggered by: nerc-project/operations#1552

Connected to: nerc-project/operations#1551