### PR TITLE
fix(nairr-dashboard): filter requests to running containers only

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/nairr-pilot-project-dashboard.yaml
@@ -101,7 +101,7 @@ spec:
                 },
                 "targets": [
                     {
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\",unit=\"core\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\",unit=\"core\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}))",
                         "refId": "A"
                     }
                 ],
@@ -151,7 +151,7 @@ spec:
                 },
                 "targets": [
                     {
-                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"memory\",unit=\"byte\"})",
+                        "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"memory\",unit=\"byte\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}))",
                         "refId": "A"
                     }
                 ],


### PR DESCRIPTION
The CPU and memory request panels was showing inflated values even when no workloads are running. The problem consists from that `kube_pod_container_resource_requests` includes all pods regardless of status: so also Completed, Failed, and Succeeded pods still carry their resource requests in the sum. For me this looks like a data quality problem, not a display problem, so the fix must happen in the query.

`kube_pod_container_status_running` is not available in this Thanos setup, so the join uses `kube_pod_status_phase{phase="Running"}` with `max by(namespace,pod,cluster)` to collapse extra labels before joining. The namespace filter and `cluster` label are included to avoid unnecessary full-namespace scans in Thanos and to prevent cross-cluster pod-name collisions.

**Key changes:**

- CPU requests panel: join `kube_pod_container_resource_requests` with `max by(namespace,pod,cluster) (kube_pod_status_phase{namespace="$namespace",phase="Running"})`

- memory requests panel: same join applied

Triggered by: nerc-project/operations#1394

Connected to: n/a