### PR TITLE
Add AdminNetworkPolicy for suhruth-test namespace

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-suhruth-test-egress.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -5,21 +5,21 @@ metadata:
 spec:
   priority: 50
   subject:
-    namespaces:
-      matchLabels:
-        kubernetes.io/metadata.name: suhruth-test
-    podSelector:
-      matchLabels:
-        app: openclaw
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: suhruth-test
+      podSelector:
+        matchLabels:
+          app: openclaw
   egress:
   # Rule 1: allow DNS lookups to OpenShift DNS so pods can resolve hostnames.
   - name: "allow-dns"
     action: "Allow"
     to:
     - namespaces:
-        namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: openshift-dns
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
     ports:
     - portNumber:
         protocol: UDP
@@ -31,7 +31,7 @@ spec:
   - name: "allow-kube-api"
     action: "Allow"
     to:
-    - namespaces:
+    - pods:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: default

--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -1,0 +1,51 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: restrict-suhruth-test-egress
+spec:
+  priority: 50
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: suhruth-test
+    podSelector:
+      matchLabels:
+        app: openclaw
+  egress:
+  # Rule 1: allow DNS lookups to OpenShift DNS so pods can resolve hostnames.
+  - name: "allow-dns"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - portNumber:
+        protocol: UDP
+        port: 5353
+    - portNumber:
+        protocol: TCP
+        port: 5353
+  # Rule 2: allow HTTPS access to the Kubernetes API server for cluster API calls.
+  - name: "allow-kube-api"
+    action: "Allow"
+    to:
+    - namespaces:
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: default
+        podSelector:
+          matchLabels:
+            component: apiserver
+    ports:
+    - portNumber:
+        protocol: TCP
+        port: 443
+  # Rule 3: deny all remaining IPv4 and IPv6 egress destinations not matched above.
+  - name: "deny-all-other-egress"
+    action: "Deny"
+    to:
+    - networks:
+      - 0.0.0.0/0
+      - ::/0

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - certificates
 - machineconfigs
 - nodenetworkconfigurationpolicies
+- adminnetworkpolicies
 - feature/odf
 - feature/rhoai
 - rbac


### PR DESCRIPTION
The purpose of this policy is to allow suhruth to work with openclaw agents in the test cluster in a safe way. As he does his work we will likely need to modify this as needed for whatever his setup demands, for example access to specific endpoints. 

I am almost certain this is too restrictive. For one, as is the agent can't call out to the anthropic server to prompt claude.  Also he will likely be using the claw installer developed by Sally: https://github.com/sallyom/claw-installer. Which might require certain other permissions.