### PR TITLE
Allow openclaw to access local LLM service

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -42,7 +42,18 @@ spec:
     - portNumber:
         protocol: TCP
         port: 443
-  # Rule 3: deny all remaining IPv4 and IPv6 egress destinations not matched above.
+  # Rule 3: allow access to local LLM service within the same namespace.
+  - name: "allow-local-llm"
+    action: "Allow"
+    to:
+    - namespaces:
+        matchLabels:
+          kubernetes.io/metadata.name: suhruth-test
+    ports:
+    - portNumber:
+        protocol: TCP
+        port: 8443
+  # Rule 4: deny all remaining IPv4 and IPv6 egress destinations not matched above.
   - name: "deny-all-other-egress"
     action: "Deny"
     to:


### PR DESCRIPTION
## Summary
Add egress rule to AdminNetworkPolicy to allow openclaw pods to communicate with the local LLM service.

## Problem
The `restrict-suhruth-test-egress` AdminNetworkPolicy currently blocks all egress traffic except DNS and Kubernetes API access. This prevents the openclaw pod from connecting to the `suhruth-slm-predictor` service on port 8443, which is needed for local GPU-based LLM inference.

## Solution
Added a new egress rule (Rule 3) that allows traffic from openclaw pods to any service within the `suhruth-test` namespace on port 8443.

## Changes
- Added `allow-local-llm` rule to permit TCP traffic on port 8443 to services within the same namespace
- Renumbered the final deny rule from Rule 3 to Rule 4

## Testing
After this change is applied, openclaw should be able to successfully connect to the local LLM service at `https://suhruth-slm-predictor.suhruth-test.svc.cluster.local:8443/v1`

## Related
This enables openclaw to function with a local GPU-based model instead of requiring external model providers.