### PR TITLE
Allow OpenClaw egress to Presidio services for PII detection

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -47,12 +47,27 @@ spec:
             - 10.30.8.24/32    # ctl-1
             - 10.30.8.25/32    # ctl-2
 
-    # Rule 3: Allow intra-namespace traffic
+    # Rule 3: Allow intra-namespace traffic (vLLM kube-rbac-proxy)
     - action: Allow
       name: allow-local-llm
       ports:
         - portNumber:
             port: 8443
+            protocol: TCP
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: suhruth-test
+
+    # Rule 3b: Allow Presidio services (PII detection for LiteLLM guardrails)
+    - action: Allow
+      name: allow-presidio
+      ports:
+        - portNumber:
+            port: 5001
+            protocol: TCP
+        - portNumber:
+            port: 5002
             protocol: TCP
       to:
         - namespaces:


### PR DESCRIPTION
## Summary

This PR adds a network policy rule to allow the OpenClaw pod to reach Presidio services for PII detection in LiteLLM guardrails.

## Changes

Added **Rule 3b** to `restrict-suhruth-test-egress` AdminNetworkPolicy:
- Allows egress to port **5001** (Presidio Analyzer)
- Allows egress to port **5002** (Presidio Anonymizer)
- Scope: Within `suhruth-test` namespace only

## Why This Change

OpenClaw is now using LiteLLM's built-in guardrails with Presidio integration to monitor all traffic to/from Claude Vertex AI for PII (personally identifiable information):

- **Input monitoring**: Detects PII before sending to Claude (emails, SSN, phone numbers, etc.)
- **Output monitoring**: Detects PII in Claude's responses
- **Action**: Masks sensitive data with placeholders

## Services Affected

- `presidio-analyzer.suhruth-test.svc.cluster.local:5001`
- `presidio-anonymizer.suhruth-test.svc.cluster.local:5002`

## Current Status

- ✅ Presidio services deployed and running
- ✅ OpenClaw pod updated with Presidio guardrails
- ✅ LiteLLM configured with PII detection
- ❌ Network policy blocking connectivity (this PR fixes it)

## Testing

After this PR is merged and applied:

```bash
# Test connectivity
oc exec deployment/openclaw -c gateway -n suhruth-test -- \
  curl http://presidio-analyzer.suhruth-test.svc.cluster.local:5001/health

# Should return: 200 OK
```

## Related

- Previous similar fix: PR that added `allow-local-llm` rule for vLLM connectivity
- Deployment files: `/home/svuppala/Documents/Projects/openclaw-trustyai-deployment/`

cc: @cluster-admin