### PR TITLE
Fix Presidio network policy to use port 3000

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -60,14 +60,12 @@ spec:
               kubernetes.io/metadata.name: suhruth-test
 
     # Rule 3b: Allow Presidio services (PII detection for LiteLLM guardrails)
+    # Note: Presidio uses port 3000 by default (not 5001/5002)
     - action: Allow
       name: allow-presidio
       ports:
         - portNumber:
-            port: 5001
-            protocol: TCP
-        - portNumber:
-            port: 5002
+            port: 3000
             protocol: TCP
       to:
         - namespaces:


### PR DESCRIPTION
## Issue

PR #943 added network policy rules for ports 5001 and 5002, but Presidio's default port is **3000**, not 5001/5002.

The `APP_PORT` environment variable doesn't change Presidio's listening port.

## Changes

Updated `allow-presidio` rule in AdminNetworkPolicy to allow port **3000** instead of 5001/5002.

## Testing

After this PR merges:

```bash
# Should work after ArgoCD sync
oc exec deployment/openclaw -c gateway -n suhruth-test -- \
  curl http://presidio-analyzer:5001/health
```

(Service maps port 5001 → 3000, so external callers still use 5001)

## Followup

Once this is working, we can either:
1. Keep port 3000 in network policy and services
2. Find the correct way to configure Presidio to use 5001/5002

For now, this unblocks the PII detection guardrails.

Related: #943