### PR TITLE
Fix Google OAuth IP range for OpenClaw Vertex AI authentication

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -105,7 +105,7 @@ spec:
       to:
         - networks:
             - 216.239.32.0/22    # us-east5-aiplatform.googleapis.com (Vertex AI)
-            - 192.178.0.0/15     # oauth2.googleapis.com (Google OAuth)
+            - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth - CORRECT IP RANGE)
 
     # Rule 7: Deny everything else
     - action: Deny


### PR DESCRIPTION
## Problem

OpenClaw's LiteLLM is experiencing network errors when trying to authenticate with Google Vertex AI:

```
Failed to load vertex credentials... oauth2.googleapis.com... Network is unreachable
```

This causes all Claude API requests to hang indefinitely.

## Root Cause

The AdminNetworkPolicy `restrict-suhruth-test-egress` had an incorrect IP range for Google OAuth:
- **Old (incorrect):** `192.178.0.0/15`
- **Actual IP:** `142.251.127.95` (from `host oauth2.googleapis.com`)
- **Correct range:** `142.250.0.0/15` (from `whois 142.251.127.95`)

## Solution

Updated Rule 6 to use the correct IP range:

```yaml
# Rule 6: Allow Google APIs (Vertex AI + OAuth2 for litellm)
- action: Allow
  name: allow-google-apis
  ports:
    - portNumber:
        port: 443
        protocol: TCP
  to:
    - networks:
        - 216.239.32.0/22    # us-east5-aiplatform.googleapis.com (Vertex AI)
        - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth - CORRECT IP RANGE)
```

## Impact

- ✅ Allows OpenClaw to authenticate with Google Vertex AI
- ✅ Unblocks all Claude API requests through OpenClaw
- ✅ No impact on other network policies

## Testing

After merge and ArgoCD sync:

```bash
# Test OAuth connectivity
oc exec deployment/openclaw -c litellm -n suhruth-test --   python3 -c "import urllib.request; urllib.request.urlopen('https://oauth2.googleapis.com/.well-known/openid-configuration')"

# Test full flow with OpenClaw
curl -X POST https://openclaw-suhruth-test.apps.ocp-test.nerc.mghpcc.org/v1/chat/completions   -H "Authorization: Bearer $TOKEN"   -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "test"}]}'
```

## Related PRs

- PR #943 - Initial Presidio network policy (merged)
- PR #944 - Fixed Presidio port from 5001/5002 to 3000 (merged)
- This PR - Fixes Google OAuth IP range

## Files Changed

- `cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml`

---

**Priority:** High - OpenClaw is currently non-functional due to this issue  
**Risk:** Low - Only updating an IP address in an existing rule