### PR TITLE
Add second Google OAuth IP range for OpenClaw (173.194.0.0/16)

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -105,7 +105,8 @@ spec:
       to:
         - networks:
             - 216.239.32.0/22    # us-east5-aiplatform.googleapis.com (Vertex AI)
-            - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth - CORRECT IP RANGE)
+            - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth range 1)
+            - 173.194.0.0/16     # oauth2.googleapis.com (Google OAuth range 2 - resolves from pod)
 
     # Rule 7: Deny everything else
     - action: Deny


### PR DESCRIPTION
## Problem

After PR #945 was merged, OpenClaw still cannot authenticate with Google Vertex AI. Testing revealed that `oauth2.googleapis.com` resolves to **different IPs** depending on where the DNS query originates.

## Root Cause Discovery

DNS resolution varies by location:

**External (my machine):**
```bash
$ host oauth2.googleapis.com
oauth2.googleapis.com has address 142.251.127.95
```

**Internal (from OpenClaw pod):**
```bash
$ oc exec deployment/openclaw -c gateway -- node -e "require('dns').resolve4('oauth2.googleapis.com', (err, addrs) => console.log(err || addrs))"
[ '173.194.45.95' ]
```

PR #945 only added `142.250.0.0/15`, but the pod actually needs `173.194.0.0/16`.

## Solution

Add the second IP range to Rule 6:

```yaml
# Rule 6: Allow Google APIs (Vertex AI + OAuth2 for litellm)
- action: Allow
  name: allow-google-apis
  ports:
    - portNumber:
        port: 443
        protocol: TCP
  to:
    - networks:
        - 216.239.32.0/22    # us-east5-aiplatform.googleapis.com (Vertex AI)
        - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth range 1)
        - 173.194.0.0/16     # oauth2.googleapis.com (Google OAuth range 2 - resolves from pod)
```

## Verification

```bash
$ whois 173.194.45.95 | grep CIDR
CIDR: 173.194.0.0/16
```

## Impact

- ✅ Allows OpenClaw to authenticate with Google Vertex AI
- ✅ Unblocks all Claude API requests through OpenClaw  
- ✅ No security impact - still restricted to HTTPS on port 443

## Testing

After merge and ArgoCD sync:

```bash
# Test from inside pod
oc exec deployment/openclaw -c gateway -n suhruth-test -- \
  curl -I --connect-timeout 5 https://oauth2.googleapis.com

# Should succeed instead of timing out
```

## Related PRs

- PR #943 - Initial Presidio network policy (merged)
- PR #944 - Fixed Presidio port to 3000 (merged)
- PR #945 - Added first Google OAuth range 142.250.0.0/15 (merged)
- This PR - Adds second Google OAuth range 173.194.0.0/16

---

**Priority:** High - OpenClaw is non-functional  
**Risk:** Low - Only adding one more IP range to existing allow rule