### PR TITLE
Add EgressFirewall with DNS-based domain filtering for OpenClaw

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -25,6 +25,12 @@ spec:
         - portNumber:
             port: 5353
             protocol: TCP
+        - portNumber:
+            port: 53
+            protocol: UDP
+        - portNumber:
+            port: 53
+            protocol: TCP
       to:
         - namespaces:
             matchLabels:
@@ -72,30 +78,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: suhruth-test
 
-    # Rule 4: Allow OpenShift OAuth router (for GitHub login flow)
-    - action: Allow
-      name: allow-openshift-oauth
-      ports:
-        - portNumber:
-            port: 443
-            protocol: TCP
-      to:
-        - networks:
-            - 199.94.63.12/32  # *.apps.ocp-test.nerc.mghpcc.org (external router IP)
-            - 10.30.8.22/32    # internal cluster DNS resolution for oauth-openshift.apps
-
-    # Rule 5: Allow GitHub (for OAuth identity provider)
-    - action: Allow
-      name: allow-github
-      ports:
-        - portNumber:
-            port: 443
-            protocol: TCP
-      to:
-        - networks:
-            - 140.82.112.0/20  # GitHub
-
-    # Rule 6: Allow HTTPS egress
+    # Rule 4: Allow HTTPS egress
     # EgressFirewall (namespace-level) restricts which domains can be reached
     # AdminNetworkPolicy (pod-level) restricts which pods can make HTTPS requests
     - action: Allow
@@ -108,7 +91,7 @@ spec:
         - networks:
             - 0.0.0.0/0
 
-    # Rule 7: Deny everything else
+    # Rule 5: Deny everything else
     - action: Deny
       name: deny-all-other-egress
       to:

--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -95,17 +95,18 @@ spec:
         - networks:
             - 140.82.112.0/20  # GitHub
 
-    # Rule 6: Allow Google APIs (Vertex AI + OAuth2 for litellm)
+    # Rule 6: Allow HTTPS egress
+    # EgressFirewall (namespace-level) restricts which domains can be reached
+    # AdminNetworkPolicy (pod-level) restricts which pods can make HTTPS requests
     - action: Allow
-      name: allow-google-apis
+      name: allow-https-egress
       ports:
         - portNumber:
             port: 443
             protocol: TCP
       to:
         - networks:
-            - 216.239.32.0/22    # us-east5-aiplatform.googleapis.com (Vertex AI)
-            - 142.250.0.0/15     # oauth2.googleapis.com (Google OAuth - CORRECT IP RANGE)
+            - 0.0.0.0/0
 
     # Rule 7: Deny everything else
     - action: Deny

--- a/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - suhruth-test-egress.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
@@ -1,0 +1,60 @@
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: suhruth-test-egress
+  namespace: suhruth-test
+spec:
+  egress:
+  # Rule 1: Allow DNS to OpenShift DNS service
+  - type: Allow
+    to:
+      cidrSelector: 172.30.0.10/32
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53
+
+  # Rule 2: Allow internal pod network (for Presidio, Kubernetes API, etc.)
+  - type: Allow
+    to:
+      cidrSelector: 10.0.0.0/8
+
+  # Rule 3: Allow internal service network
+  - type: Allow
+    to:
+      cidrSelector: 172.30.0.0/16
+
+  # Rule 4: Allow OpenShift OAuth router
+  - type: Allow
+    to:
+      cidrSelector: 199.94.63.12/32
+
+  # Rule 5: Allow Google OAuth (specific domain only)
+  - type: Allow
+    to:
+      dnsName: oauth2.googleapis.com
+
+  # Rule 6: Allow Vertex AI endpoints (specific subdomain only)
+  - type: Allow
+    to:
+      dnsName: "*.aiplatform.googleapis.com"
+
+  # Rule 7: Allow Google accounts for OAuth flow
+  - type: Allow
+    to:
+      dnsName: accounts.google.com
+
+  # Rule 8: Allow GitHub for OAuth
+  - type: Allow
+    to:
+      dnsName: github.com
+
+  - type: Allow
+    to:
+      dnsName: "*.github.com"
+
+  # Rule 9: Deny everything else
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - machineconfigs
   - nodenetworkconfigurationpolicies
   - adminnetworkpolicies
+  - egressfirewalls
   - feature/odf
   - feature/rhoai
   - rbac


### PR DESCRIPTION
## Summary

Replace broad Google IP ranges (/15, /16) with DNS-based domain filtering using EgressFirewall for better security and maintainability.

**Supersedes:** #946

## Changes

### 1. Updated AdminNetworkPolicy
- **Before:** Allowed specific Google IP ranges (142.250.0.0/15, 173.194.0.0/16)
- **After:** Allow HTTPS (port 443) to 0.0.0.0/0
- **Why:** EgressFirewall now handles domain-based filtering

### 2. Added EgressFirewall (NEW)
DNS-based domain allowlist:
- `oauth2.googleapis.com`
- `*.aiplatform.googleapis.com`
- `accounts.google.com`
- `github.com`, `*.github.com`

## Security Improvement

| Metric | Before (IP Ranges) | After (EgressFirewall) |
|--------|-------------------|------------------------|
| IPs Allowed | ~200,000 | Only IPs from allowed domains |
| Attack Surface | Entire Google infrastructure | Only 3 Google domains |
| Maintainability | Manual IP updates | Auto-follows DNS |

## Defense in Depth

**Layer 1 - AdminNetworkPolicy (Pod-Level):**
- Only `app=openclaw` pods can make HTTPS requests

**Layer 2 - EgressFirewall (Namespace-Level):**
- Only specific domains allowed
- All other domains denied by default

## Files Changed

- `cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml`
- `cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml` (NEW)
- `cluster-scope/overlays/nerc-ocp-test/kustomization.yaml`

---

**Related:** nerc-project/operations#1564