### PR TITLE
Add TrustyAI Guardrails for OpenClaw

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -15,7 +15,7 @@ spec:
         matchLabels:
           app: openclaw
   egress:
-    # Rule 1: Allow DNS
+    # Allow DNS
     - action: Allow
       name: allow-dns
       ports:
@@ -36,7 +36,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: openshift-dns
 
-    # Rule 2: Allow Kubernetes API (FIXED — use control plane node IPs + port 6443)
+    # Allow Kubernetes API (control plane node IPs + port 6443)
     - action: Allow
       name: allow-kube-api
       ports:
@@ -53,7 +53,7 @@ spec:
             - 10.30.8.24/32    # ctl-1
             - 10.30.8.25/32    # ctl-2
 
-    # Rule 3: Allow intra-namespace traffic (vLLM kube-rbac-proxy)
+    # Allow intra-namespace traffic (vLLM kube-rbac-proxy)
     - action: Allow
       name: allow-local-llm
       ports:
@@ -65,20 +65,22 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: suhruth-test
 
-    # Rule 3b: Allow Presidio services (PII detection for LiteLLM guardrails)
-    # Note: Presidio uses port 3000 by default (not 5001/5002)
+    # Allow TrustyAI Guardrails Orchestrator and detector services
     - action: Allow
-      name: allow-presidio
+      name: allow-trustyai-guardrails
       ports:
         - portNumber:
-            port: 3000
+            port: 8033
+            protocol: TCP
+        - portNumber:
+            port: 8000
             protocol: TCP
       to:
         - namespaces:
             matchLabels:
               kubernetes.io/metadata.name: suhruth-test
 
-    # Rule 4: Allow HTTPS egress
+    # Allow HTTPS egress
     # EgressFirewall (namespace-level) restricts which domains can be reached
     # AdminNetworkPolicy (pod-level) restricts which pods can make HTTPS requests
     - action: Allow
@@ -91,7 +93,7 @@ spec:
         - networks:
             - 0.0.0.0/0
 
-    # Rule 5: Deny everything else
+    # Deny everything else
     - action: Deny
       name: deny-all-other-egress
       to:

--- a/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: suhruth-test
 spec:
   egress:
-  # Rule 1: Allow DNS to OpenShift DNS service
+  # Allow DNS to OpenShift DNS service
   - type: Allow
     to:
       cidrSelector: 172.30.0.10/32
@@ -15,37 +15,37 @@ spec:
       - protocol: TCP
         port: 53
 
-  # Rule 2: Allow internal pod network (for Presidio, Kubernetes API, etc.)
+  # Allow internal pod network (for TrustyAI, Kubernetes API, etc.)
   - type: Allow
     to:
       cidrSelector: 10.0.0.0/8
 
-  # Rule 3: Allow internal service network
+  # Allow internal service network
   - type: Allow
     to:
       cidrSelector: 172.30.0.0/16
 
-  # Rule 4: Allow OpenShift OAuth router
+  # Allow OpenShift OAuth router
   - type: Allow
     to:
       cidrSelector: 199.94.63.12/32
 
-  # Rule 5: Allow Google OAuth (specific domain only)
+  # Allow Google OAuth (specific domain only)
   - type: Allow
     to:
       dnsName: oauth2.googleapis.com
 
-  # Rule 6: Allow Vertex AI endpoints (specific subdomain only)
+  # Allow Vertex AI endpoints (specific subdomain only)
   - type: Allow
     to:
       dnsName: "*.aiplatform.googleapis.com"
 
-  # Rule 7: Allow Google accounts for OAuth flow
+  # Allow Google accounts for OAuth flow
   - type: Allow
     to:
       dnsName: accounts.google.com
 
-  # Rule 8: Allow GitHub for OAuth
+  # Allow GitHub for OAuth
   - type: Allow
     to:
       dnsName: github.com
@@ -54,7 +54,7 @@ spec:
     to:
       dnsName: "*.github.com"
 
-  # Rule 9: Deny everything else
+  # Deny everything else
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0

--- a/namespaces/suhruth-test/trustyai/guardrails-orchestrator.yaml
+++ b/namespaces/suhruth-test/trustyai/guardrails-orchestrator.yaml
@@ -1,0 +1,31 @@
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: GuardrailsOrchestrator
+metadata:
+  name: openclaw-guardrails
+  namespace: suhruth-test
+  labels:
+    app: trustyai-orchestrator
+    component: openclaw-monitoring
+spec:
+  # Reference to the ConfigMap containing orchestrator configuration
+  orchestratorConfig: trustyai-orchestrator-config
+
+  # Enable built-in detectors (IBM HAP, PII detection, etc.)
+  enableBuiltInDetectors: true
+
+  # Resource requests and limits
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
+
+  # Number of replicas for high availability
+  replicas: 1
+
+  # Service configuration
+  serviceConfig:
+    type: ClusterIP
+    port: 8033

--- a/namespaces/suhruth-test/trustyai/kustomization.yaml
+++ b/namespaces/suhruth-test/trustyai/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - orchestrator-config.yaml
+  - guardrails-orchestrator.yaml

--- a/namespaces/suhruth-test/trustyai/orchestrator-config.yaml
+++ b/namespaces/suhruth-test/trustyai/orchestrator-config.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trustyai-orchestrator-config
+  namespace: suhruth-test
+  labels:
+    app: trustyai-orchestrator
+data:
+  config.yaml: |
+    # TrustyAI Guardrails Orchestrator Configuration for OpenClaw
+    # Monitors Claude Vertex AI calls via LiteLLM proxy
+
+    # Passthrough headers for Claude API authentication
+    passthrough_headers:
+      - authorization
+      - x-api-key
+      - anthropic-version
+
+    # Chat generation service - LiteLLM proxy endpoint
+    chat_generation:
+      service:
+        hostname: localhost
+        port: 4000
+        # LiteLLM runs as sidecar in OpenClaw pod
+
+    # Detector services for guardrails
+    detectors:
+      # PII detector (replaces Presidio)
+      pii-detector:
+        type: text_contents
+        service:
+          hostname: guardrails-detector-pii.suhruth-test.svc.cluster.local
+          port: 8000
+        chunker_id: whole_doc_chunker
+        default_threshold: 0.75
+
+      # HAP (Hate, Abuse, Profanity) detector
+      hap-detector:
+        type: text_contents
+        service:
+          hostname: guardrails-detector-hap.suhruth-test.svc.cluster.local
+          port: 8000
+        chunker_id: whole_doc_chunker
+        default_threshold: 0.65
+
+      # Jailbreak/prompt injection detector
+      jailbreak-detector:
+        type: text_contents
+        service:
+          hostname: guardrails-detector-jailbreak.suhruth-test.svc.cluster.local
+          port: 8000
+        chunker_id: whole_doc_chunker
+        default_threshold: 0.70


### PR DESCRIPTION
## Summary

Deploy TrustyAI Guardrails Orchestrator for comprehensive LLM protection: PII + HAP (toxicity) + Jailbreak detection.

**Replaces:** Presidio (PII only)  
**Related:** nerc-project/operations#1564

## Changes

### New Resources
- `namespaces/suhruth-test/trustyai/`: GuardrailsOrchestrator CR + ConfigMap
- Configures 3 detectors: PII, HAP, Jailbreak (all on port 8000)

### Network Policy Updates
- AdminNetworkPolicy: Added `allow-trustyai-guardrails` rule for ports 8033 (orchestrator) and 8000 (detectors)
- Removed rule numbers from comments in both AdminNetworkPolicy and EgressFirewall

## Architecture

```
User → OpenClaw → TrustyAI Orchestrator (8033) → LiteLLM → Claude Vertex AI
                   ├─ PII detector (8000)
                   ├─ HAP detector (8000)
                   └─ Jailbreak detector (8000)
```

## Why TrustyAI over Presidio?

| Feature | Presidio | TrustyAI |
|---------|----------|----------|
| PII Detection | ✅ | ✅ |
| HAP/Toxicity | ❌ | ✅ |
| Jailbreak/Prompt Injection | ❌ | ✅ |
| OpenShift AI Native | ❌ | ✅ |

## Next Steps

After merge, update OpenClaw LiteLLM config to use TrustyAI endpoint and remove Presidio deployments.