### PR TITLE
fix(grafana): enforce role_attribute_strict on obs OAuth

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -25,6 +25,7 @@ spec:
         contains(groups[*], 'nerc-ops')  && 'Admin' ||
         contains(groups[*], 'nerc-logs-metrics')  && 'Admin' ||
         'Deny'
+      role_attribute_strict: 'true'
       auth_url: 'https://dex-dex.apps.obs.nerc.mghpcc.org/auth'
       scopes: openid email groups profile
     log:


### PR DESCRIPTION
Align obs overlay with infra so a non-matching role_attribute_path denies login instead of silently falling back to Viewer.

see here
https://github.com/OCP-on-NERC/nerc-ocp-config/blob/bdd12ed08927b03bcd559da1f307ff6cd6583889/grafana/overlays/nerc-ocp-infra/grafanas/grafana.yaml#L30

## Explanation

Enforce role_attribute_strict on obs Grafana OAuth

Adds role_attribute_strict: 'true' to the obs Grafana OAuth config, matching the infra overlay.

Without it, a user whose groups match none of the role_attribute_path rules silently falls back to Viewer (**dashboards only, no Explore**) instead of being denied. This hid a group-sync timing issue: a user added to nerc-logs-metrics who logged in before the group reached their token got frozen as Viewer, since Grafana only re-evaluates the role at login.

With strict mode on, an unmatched user is denied login instead of silently downgraded — role-mapping problems become visible.

Note: this tightens access. Anyone relying on silent Viewer access today will be denied login after deploy.