### PR TITLE
Fix TrustyAI config to use built-in PII detector

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/trustyai/orchestrator-config.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/trustyai/orchestrator-config.yaml
@@ -17,7 +17,7 @@ data:
       - anthropic-version
 
     # Chat generation service - LiteLLM proxy endpoint
-    chat_generation:
+    openai:
       service:
         hostname: localhost
         port: 4000
@@ -25,29 +25,12 @@ data:
 
     # Detector services for guardrails
     detectors:
-      # PII detector (replaces Presidio)
-      pii-detector:
+      # Built-in PII detector (regex-based, runs as sidecar)
+      # Detects: email, SSN, credit card, phone numbers, etc.
+      built-in-detector:
         type: text_contents
         service:
-          hostname: guardrails-detector-pii.suhruth-test.svc.cluster.local
-          port: 8000
+          hostname: localhost
+          port: 8080
         chunker_id: whole_doc_chunker
         default_threshold: 0.75
-
-      # HAP (Hate, Abuse, Profanity) detector
-      hap-detector:
-        type: text_contents
-        service:
-          hostname: guardrails-detector-hap.suhruth-test.svc.cluster.local
-          port: 8000
-        chunker_id: whole_doc_chunker
-        default_threshold: 0.65
-
-      # Jailbreak/prompt injection detector
-      jailbreak-detector:
-        type: text_contents
-        service:
-          hostname: guardrails-detector-jailbreak.suhruth-test.svc.cluster.local
-          port: 8000
-        chunker_id: whole_doc_chunker
-        default_threshold: 0.70


### PR DESCRIPTION
## Summary

Update TrustyAI GuardrailsOrchestrator config to use the built-in regex detector sidecar instead of non-existent external detector services.

**Fixes:** GuardrailsOrchestrator deployed but not functional due to wrong detector hostnames  
**Related:** nerc-project/operations#1564

## Changes

### Detector Configuration
- **Before:** Pointed to external services at `guardrails-detector-*.suhruth-test.svc.cluster.local:8000`
- **After:** Points to built-in sidecar at `localhost:8080`
- **Removed:** HAP and Jailbreak detector configs (require separate KServe model deployments)

### API Deprecation Fix
- Renamed `chat_generation` → `openai` (fixes deprecation warning)

## What Built-In Detector Provides

✅ **PII Detection via regex patterns:**
- Email addresses
- US Social Security Numbers (SSN)
- Credit card numbers
- Phone numbers
- Other common PII patterns

❌ **Not included (require separate deployments):**
- HAP (Hate/Abuse/Profanity) detection
- Jailbreak/Prompt injection detection

## Current Architecture

```
GuardrailsOrchestrator Pod (openclaw-guardrails)
├─ openclaw-guardrails (orchestrator) :8032
└─ openclaw-guardrails-detectors (built-in sidecar) :8080
   └─ Regex-based PII detector
```

Config now correctly points orchestrator → built-in detector on localhost:8080

## Testing

After merge, verify detector is accessible:
```bash
oc exec -n suhruth-test deployment/openclaw-guardrails -c openclaw-guardrails -- \
  curl -s http://localhost:8080/health
# Expected: "ok"
```

## Next Steps

1. Update OpenClaw LiteLLM config to use TrustyAI endpoint
2. Remove Presidio deployments
3. Test PII detection with sample inputs
4. (Optional) Deploy HAP/Jailbreak models via KServe for comprehensive protection