### PR TITLE
Fix TrustyAI Guardrails ports in AdminNetworkPolicy

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/adminnetworkpolicies/restrict-suhruth-test-egress.yaml
@@ -70,10 +70,13 @@ spec:
       name: allow-trustyai-guardrails
       ports:
         - portNumber:
-            port: 8033
+            port: 8032
             protocol: TCP
         - portNumber:
-            port: 8000
+            port: 8034
+            protocol: TCP
+        - portNumber:
+            port: 8080
             protocol: TCP
       to:
         - namespaces:


### PR DESCRIPTION
## Problem

OpenClaw requests hang indefinitely when TrustyAI guardrails are enabled. LiteLLM times out trying to connect to TrustyAI Orchestrator.

**Root cause:** AdminNetworkPolicy was allowing the wrong ports.

## What Was Wrong

| Service | Actual Port | ANP Allowed | Result |
|---------|------------|-------------|--------|
| TrustyAI Orchestrator | 8032 | 8033 ❌ | Blocked |
| TrustyAI Health | 8034 | 8033 ❌ | Blocked |
| Built-in Detector | 8080 | 8000 ❌ | Blocked |

## Changes

Updated `allow-trustyai-guardrails` rule to allow correct ports:
- **8032** - Guardrails server (HTTPS)
- **8034** - Health check server  
- **8080** - Built-in detector sidecar

## Testing

After merge, OpenClaw should be able to connect to TrustyAI:
```bash
# Verify network connectivity
oc logs -n suhruth-test deployment/openclaw -c litellm --tail=50 | grep -i "IBM Orchestrator"
# Should see successful requests instead of timeout errors
```

## Related

- Epic: nerc-project/operations#1564
- Previous PRs: #948 (TrustyAI deployment), #951 (built-in detector config)