### PR TITLE
feat: add 5m DCGM recording rules to bridge ACM 300s collection gap

### DIFF
--- a/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
+++ b/acm-observability/base/core/configmaps/observability-metrics-custom-allowlist/configmap.yaml
@@ -47,6 +47,10 @@ data:
       - __name__=~"^log_.*"
       - __name__=~"^gpu_operator_.*"
       - __name__=~"^DCGM_FI_.*"
+
+      # Locally pre-aggregated DCGM gauges (max/avg over 5m recording rules),
+      # so the 300s collection interval does not miss short GPU bursts:
+      - __name__=~"^nerc:dcgm_.*"
       - __name__=~"^argocd_.*"
 
       # Consolidate kube*:

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ../../base
   - configmaps/mig-manager-config.yaml
   - drivers
+  - prometheusrules/dcgm-recording-rules.yaml
 patches:
   - path: clusterpolicy/clusterpolicy_patch.yaml

--- a/nvidia-gpu-operator/overlays/nerc-ocp-test/prometheusrules/dcgm-recording-rules.yaml
+++ b/nvidia-gpu-operator/overlays/nerc-ocp-test/prometheusrules/dcgm-recording-rules.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dcgm-recording-rules
+spec:
+  groups:
+    - name: nerc-dcgm-5m-aggregations
+      # ACM Observability only forwards one point-in-time sample every 300s
+      # (observabilityAddonSpec.interval). These rules pre-aggregate the DCGM
+      # gauges locally over the same window, so the forwarded sample carries
+      # the full 5-minute history instead of an instantaneous value: max5m
+      # catches short bursts, avg5m keeps the integral correct.
+      interval: 30s
+      rules:
+        - record: nerc:dcgm_gpu_util:max5m
+          expr: max_over_time(DCGM_FI_DEV_GPU_UTIL[5m])
+        - record: nerc:dcgm_gpu_util:avg5m
+          expr: avg_over_time(DCGM_FI_DEV_GPU_UTIL[5m])
+        - record: nerc:dcgm_gr_engine_active:max5m
+          expr: max_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE[5m])
+        - record: nerc:dcgm_gr_engine_active:avg5m
+          expr: avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE[5m])
+        - record: nerc:dcgm_fb_used:max5m
+          expr: max_over_time(DCGM_FI_DEV_FB_USED[5m])
+        - record: nerc:dcgm_fb_used:avg5m
+          expr: avg_over_time(DCGM_FI_DEV_FB_USED[5m])
+        - record: nerc:dcgm_power_usage:max5m
+          expr: max_over_time(DCGM_FI_DEV_POWER_USAGE[5m])
+        - record: nerc:dcgm_power_usage:avg5m
+          expr: avg_over_time(DCGM_FI_DEV_POWER_USAGE[5m])


### PR DESCRIPTION
ACM Observability forwards only one point-in-time sample per metric every 300s (observabilityAddonSpec.interval), so short GPU bursts on gauges like DCGM_FI_DEV_GPU_UTIL can be shifted, shortened, or missed entirely in the central Grafana (see the ~8min training run on nerc-ocp-test that showed up as 5min, offset by ~5min).

Counters are unaffected (deltas between snapshots stay correct); gauges lose everything between snapshots. This change pre-aggregates the most relevant DCGM gauges locally on nerc-ocp-test via recording rules:

- nerc:dcgm_gpu_util:{max5m,avg5m}
- nerc:dcgm_gr_engine_active:{max5m,avg5m}
- nerc:dcgm_fb_used:{max5m,avg5m}
- nerc:dcgm_power_usage:{max5m,avg5m}

max5m reliably catches bursts, avg5m keeps the integral correct. The custom allowlist on the hub picks up the new series via ^nerc:dcgm_.*

Scoped to the nerc-ocp-test overlay as a trial; promote to prod/edu by moving the PrometheusRule into nvidia-gpu-operator/base.