### PR TITLE
Add nerc-backup-wasabi: off-site S3 backup to Wasabi via rclone CronJobs

### DIFF
--- a/nerc-backup-wasabi/README.md
+++ b/nerc-backup-wasabi/README.md
@@ -1,0 +1,37 @@
+# nerc-backup-wasabi
+
+Off-site backup of the NERC S3 buckets to Wasabi (us-east-1), directly in the
+cluster via rclone CronJobs. Avoids slow external uplinks; runs at datacenter
+bandwidth.
+
+## What gets backed up (rclone `copy`, NOT `sync`; keeps deleted objects)
+- **nerc-metrics-backup/** from acm-metrics, acm-metrics-hypershift2,
+  acm-metrics-test, open-telemetry, open-telemetry-test (each as a prefix).
+- **nerc-loki-backup/** from loki-logs, loki-logs-test.
+- Target region: Wasabi us-east-1 (s3.wasabisys.com).
+
+## Structure
+- `base/namespace.yaml`; namespace `nerc-backup-wasabi`.
+- `base/externalsecrets/`; pulls both key pairs from Vault
+  (`$ENV/$CLUSTER/loki-thanos-object-storage` for NERC;
+  `$ENV/$CLUSTER/wasabi-backup` for Wasabi). The overlay sets the concrete path.
+- `base/cronjobs/`; two CronJobs (backup-metrics 02:00, backup-loki 02:30 UTC).
+  Each builds the rclone.conf at runtime from the secrets; no static key material.
+
+## Deploy
+Via ArgoCD/kustomize like the other components; `overlays/nerc-ocp-obs`
+references the base and patches the Vault paths.
+
+## Manual ad-hoc run (outside the schedule)
+```sh
+oc create job --from=cronjob/backup-metrics backup-metrics-manual -n nerc-backup-wasabi
+oc create job --from=cronjob/backup-loki    backup-loki-manual    -n nerc-backup-wasabi
+```
+
+## Notes
+- loki is a LIVE bucket (audit/ rotates and grows). Use `copy` not `sync`; one
+  pass per job (no wrapper loop, otherwise runaway). A 100% snapshot of a live
+  loki is not possible; occasional transient 404s are expected.
+- rclone `copy` is incremental; a daily run transfers only the delta (metrics
+  seconds, loki ~1h, most of it comparing the ~3.3M objects).
+- Address Wasabi buckets via the endpoint of THEIR region (mismatch gives 403).

--- a/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-loki
+spec:
+  schedule: "30 2 * * *"          # daily 02:30 UTC (after metrics)
+  concurrencyPolicy: Forbid       # no parallel run (loki takes ~1h)
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 43200   # 12h
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: rclone
+            image: rclone/rclone:latest
+            # NERC and Wasabi keys from Vault (ExternalSecrets nerc-s3-creds + wasabi-creds).
+            # rclone.conf is built at runtime; no static key material.
+            env:
+            - name: NERC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: endpoint
+            - name: NERC_AK
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: access_key_id
+            - name: NERC_SK
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: access_key_secret
+            - name: WASABI_AK
+              valueFrom:
+                secretKeyRef:
+                  name: wasabi-creds
+                  key: access_key_id
+            - name: WASABI_SK
+              valueFrom:
+                secretKeyRef:
+                  name: wasabi-creds
+                  key: secret_access_key
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -u
+              CFG=/tmp/rclone.conf
+              cat > "$CFG" <<RC
+              [nerc]
+              type = s3
+              provider = Other
+              endpoint = ${NERC_ENDPOINT}
+              access_key_id = ${NERC_AK}
+              secret_access_key = ${NERC_SK}
+
+              [wasabi-us]
+              type = s3
+              provider = Wasabi
+              endpoint = s3.wasabisys.com
+              region = us-east-1
+              access_key_id = ${WASABI_AK}
+              secret_access_key = ${WASABI_SK}
+              RC
+              # loki-logs is a LIVE bucket (audit/ rotates, grows). copy not sync,
+              # one pass per job (no wrapper loop -> no runaway). high --transfers.
+              DST=wasabi-us:nerc-loki-backup
+              RC=0
+              for B in loki-logs loki-logs-test; do
+                echo ">>> $B -> $DST/$B/ ($(date -u +%FT%TZ))"
+                rclone copy "nerc:$B" "$DST/$B" \
+                  --config "$CFG" \
+                  --transfers 64 --checkers 96 --fast-list \
+                  --retries 3 --low-level-retries 10 \
+                  --stats 300s --stats-one-line -v 2>&1 | tail -15
+                rc=$?
+                [ $rc -ne 0 ] && { echo "WARN: $B rc=$rc"; RC=1; }
+              done
+              echo "===== nerc-loki-backup ====="
+              rclone size "$DST" --config "$CFG" 2>&1 | tail -2
+              echo "Status: $([ $RC -eq 0 ] && echo ALLE OK || echo mit WARNUNGEN)"
+              rm -f "$CFG"
+              exit $RC

--- a/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
@@ -65,6 +65,7 @@ spec:
               region = us-east-1
               access_key_id = ${WASABI_AK}
               secret_access_key = ${WASABI_SK}
+              no_check_bucket = true
               RC
               # loki-logs is a LIVE bucket (audit/ rotates, grows). copy not sync,
               # one pass per job (no wrapper loop -> no runaway). high --transfers.

--- a/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: backup-metrics
+spec:
+  schedule: "0 2 * * *"          # daily 02:00 UTC
+  concurrencyPolicy: Forbid       # no parallel run
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 21600   # 6h
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: rclone
+            image: rclone/rclone:latest
+            # NERC and Wasabi keys from Vault (ExternalSecrets nerc-s3-creds + wasabi-creds).
+            # rclone.conf is built at runtime; no static key material.
+            env:
+            - name: NERC_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: endpoint
+            - name: NERC_AK
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: access_key_id
+            - name: NERC_SK
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-s3-creds
+                  key: access_key_secret
+            - name: WASABI_AK
+              valueFrom:
+                secretKeyRef:
+                  name: wasabi-creds
+                  key: access_key_id
+            - name: WASABI_SK
+              valueFrom:
+                secretKeyRef:
+                  name: wasabi-creds
+                  key: secret_access_key
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -u
+              CFG=/tmp/rclone.conf
+              cat > "$CFG" <<RC
+              [nerc]
+              type = s3
+              provider = Other
+              endpoint = ${NERC_ENDPOINT}
+              access_key_id = ${NERC_AK}
+              secret_access_key = ${NERC_SK}
+
+              [wasabi-us]
+              type = s3
+              provider = Wasabi
+              endpoint = s3.wasabisys.com
+              region = us-east-1
+              access_key_id = ${WASABI_AK}
+              secret_access_key = ${WASABI_SK}
+              RC
+              DST=wasabi-us:nerc-metrics-backup
+              RC=0
+              for B in acm-metrics acm-metrics-hypershift2 acm-metrics-test open-telemetry open-telemetry-test; do
+                echo ">>> $B -> $DST/$B/ ($(date -u +%FT%TZ))"
+                rclone copy "nerc:$B" "$DST/$B" \
+                  --config "$CFG" \
+                  --transfers 16 --checkers 32 --fast-list \
+                  --retries 3 --low-level-retries 10 \
+                  --stats 60s --stats-one-line -v 2>&1 | tail -10
+                rc=$?
+                [ $rc -ne 0 ] && { echo "WARN: $B rc=$rc"; RC=1; }
+              done
+              echo "===== nerc-metrics-backup ====="
+              rclone size "$DST" --config "$CFG" 2>&1 | tail -2
+              echo "Status: $([ $RC -eq 0 ] && echo ALLE OK || echo mit WARNUNGEN)"
+              rm -f "$CFG"
+              exit $RC

--- a/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
@@ -65,6 +65,7 @@ spec:
               region = us-east-1
               access_key_id = ${WASABI_AK}
               secret_access_key = ${WASABI_SK}
+              no_check_bucket = true
               RC
               DST=wasabi-us:nerc-metrics-backup
               RC=0

--- a/nerc-backup-wasabi/base/cronjobs/kustomization.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backup-metrics.yaml
+  - backup-loki.yaml

--- a/nerc-backup-wasabi/base/externalsecrets/kustomization.yaml
+++ b/nerc-backup-wasabi/base/externalsecrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nerc-s3-creds.yaml
+  - wasabi-creds.yaml

--- a/nerc-backup-wasabi/base/externalsecrets/nerc-s3-creds.yaml
+++ b/nerc-backup-wasabi/base/externalsecrets/nerc-s3-creds.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nerc-s3-creds
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: nerc-s3-creds
+  dataFrom:
+    # same source Loki uses for the NERC S3 store
+    - extract:
+        key: $ENV/$CLUSTER/loki-thanos-object-storage

--- a/nerc-backup-wasabi/base/externalsecrets/wasabi-creds.yaml
+++ b/nerc-backup-wasabi/base/externalsecrets/wasabi-creds.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: wasabi-creds
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: wasabi-creds
+  dataFrom:
+    # Wasabi backup target keys; fields: access_key_id, secret_access_key
+    - extract:
+        key: $ENV/$CLUSTER/wasabi-backup

--- a/nerc-backup-wasabi/base/kustomization.yaml
+++ b/nerc-backup-wasabi/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nerc-backup-wasabi
+resources:
+  - namespace.yaml
+  - externalsecrets
+  - cronjobs
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: nerc-backup-wasabi
+      app.kubernetes.io/part-of: nerc-s3-offsite-backup

--- a/nerc-backup-wasabi/base/namespace.yaml
+++ b/nerc-backup-wasabi/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nerc-backup-wasabi

--- a/nerc-backup-wasabi/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/nerc-backup-wasabi/overlays/nerc-ocp-obs/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  # pin the Vault paths to this cluster ($ENV/$CLUSTER -> nerc/nerc-ocp-obs)
+  - patch: |
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: nerc-s3-creds
+      spec:
+        dataFrom:
+          - extract:
+              key: nerc/nerc-ocp-obs/loki-thanos-object-storage
+  - patch: |
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: wasabi-creds
+      spec:
+        dataFrom:
+          - extract:
+              key: nerc/nerc-ocp-obs/wasabi-backup


### PR DESCRIPTION
connected with:
- https://github.com/OCP-on-NERC/nerc-ocp-apps/pull/81

## Why this change was necessary:
Until now it gives no automated off-site backup for the S3 buckets (acm-metrics, loki-logs etc.).
Backups run only manual per `oc apply`, or from a local machine wiht slow cable uplink (~5.8 MiB/s).
Directly in the cluster the transfer becomes ~305 MiB/s, because the datacenter bandwidth is not the bottleneck there. 
This component makes the backup declarative over GitOps and automated with a daily CronJob, so we not depend anymore from a manual step that is easy to forget.

## Key changes:

- add new component `nerc-backup-wasabi/` with base/overlays structure, consists from same pattern as loki/ and vault/backup-job/

- add base/namespace.yaml for the new namespace `nerc-backup-wasabi`

- add base/externalsecrets/ with two ExternalSecrets that pull both key-pairs from Vault (NERC keys from $ENV/$CLUSTER/loki-thanos-object-storage, Wasabi keys from $ENV/$CLUSTER/wasabi-backup); no static key material in the repo

- add base/cronjobs/ with two CronJobs (backup-metrics daily at 02:00 UTC, backup-loki at 02:30 UTC), each builds the rclone.conf at runtime from the mounted secrets (metrics takes about 15minutes, logs about 1 hour incremental, logs mostly check against exisiting backup 2mio+ objects!)

- add overlays/nerc-ocp-obs/ that pins the Vault paths to nerc/nerc-ocp-obs

- use rclone `copy` instead of `sync`, so that nothing gets deleted on the destination side if objects on the source disappear becuase of retention

- add README.md that describes the component

## Links

Fixes: maybe? https://github.com/CCI-MOC/ops-issues/issues/1788

Triggered by: https://github.com/CCI-MOC/ops-issues/issues/1788

Connected to: https://github.com/OCP-on-NERC/nerc-ocp-apps/pull/81

## Notes

- manual runs with oc deploy were succesful over the last few days, see comments below