### PR TITLE
Allow readonly admins to dashboard.opendatahub.io resources in test

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-cluster-reader/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-cluster-reader/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: opendatahub-cluster-reader
+rules:
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - '*'
+    verbs:
+      - list
+      - get
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-cluster-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-cluster-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-nerc-ops/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-nerc-ops/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    nerc.mghpcc.org/aggregate-to-nerc-ops: "true"
+  name: opendatahub-nerc-ops
+rules:
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - '*'
+    verbs:
+      - list
+      - get
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-nerc-ops/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/opendatahub-nerc-ops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ../common
   - ../../base/rbac.authorization.k8s.io/clusterroles/allow-edit-rbac
   - ../../base/rbac.authorization.k8s.io/clusterroles/application-edit
+  - ../../base/rbac.authorization.k8s.io/clusterroles/opendatahub-cluster-reader
+  - ../../base/rbac.authorization.k8s.io/clusterroles/opendatahub-nerc-ops
   - ../../base/core/namespaces/openshift-gitops
   - ../../base/core/namespaces/dex
   - externalsecrets


### PR DESCRIPTION
In order to troubleshoot OpenShift AI model serving settings in the test
cluster, khus-hi requested access to view dashboard.opendatahub.io
resources like OdhApplications that were being blocked by missing
ClusterRoleBindings.
