### PR TITLE
fix: rename suhruth-test EgressFirewall to required name 'default'

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
@@ -1,7 +1,8 @@
 apiVersion: k8s.ovn.org/v1
 kind: EgressFirewall
 metadata:
-  name: suhruth-test-egress
+  # OVN-Kubernetes requires the EgressFirewall in a namespace to be named "default"
+  name: default
   namespace: suhruth-test
 spec:
   egress:


### PR DESCRIPTION
OVN-Kubernetes only accepts EgressFirewall objects named `default` (`metadata.name` must match `^default$`). Because of this, the `cluster-scope-test` ArgoCD application has been failing to sync this resource ever since it was added in #947 — the sync operation for the whole app reports `Failed` (see operationState: `metadata.name in body should match '^default$'`).

The EgressFirewall currently active in `suhruth-test` was applied manually with the correct name `default` on 2026-07-07; its rules are identical to this file. This change only renames the resource in the repo so GitOps matches both the API requirement and the live state, and removes one of the sync blockers for `cluster-scope-test`.

Note: two further, unrelated sync blockers remain (DataScienceCluster manifest still uses `managementState: Managed` for kueue/modelmeshserving which RHOAI 3.3 rejects, and the immutable StorageClass parameters diff). Those can be addressed separately.