### PR TITLE
feat: allow svuppala2006 to manage TrustyAI guardrails CRs in suhruth-test

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - nerc-test-people.yaml
   - nerc-test-perses.yaml
   - nerc-test-cost-management.yaml
+  - trustyai-guardrails-suhruth.yaml

--- a/cluster-scope/overlays/nerc-ocp-test/rbac/trustyai-guardrails-suhruth.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/rbac/trustyai-guardrails-suhruth.yaml
@@ -1,0 +1,44 @@
+---
+# Temporary: allow svuppala2006 to iterate on TrustyAI guardrails
+# resources with `oc apply` while developing the OpenClaw Guardrails
+# project. Scoped to the suhruth-test namespace via RoleBinding.
+# Long term this should be replaced by the standard GitOps workflow.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: trustyai-guardrails-editor
+rules:
+  - apiGroups:
+      - trustyai.opendatahub.io
+    resources:
+      - guardrailsorchestrators
+      - nemoguardrails
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - trustyai.opendatahub.io
+    resources:
+      - guardrailsorchestrators/status
+      - nemoguardrails/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trustyai-guardrails-editor-svuppala2006
+  namespace: suhruth-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-guardrails-editor
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: svuppala2006


### PR DESCRIPTION
Suhruth Vuppala (@svuppala2006, BU research intern) works on the OpenClaw Guardrails project (TrustyAI: PII/jailbreak/toxicity detection) and needs to create and update `GuardrailsOrchestrator` / `NemoGuardrails` custom resources with `oc apply` while developing, per the project requirements ("temporary capability for development and validation, ideally limited to only the project namespace").

He already has `edit` in `suhruth-test`, which covers ConfigMaps, Deployments and `TrustyAIService` (the operator aggregates an editor role into `edit` for that CRD) — but the operator ships **no** aggregated editor role for `guardrailsorchestrators` and `nemoguardrails`, so those are currently inaccessible to him.

This PR adds:
- ClusterRole `trustyai-guardrails-editor`: full verbs on `guardrailsorchestrators` and `nemoguardrails` (+ read on their `status`), nothing else
- a **namespaced RoleBinding** in `suhruth-test` binding only `svuppala2006` — the grant works in this one namespace, not cluster-wide

Deliberately **not** included: EgressFirewall and AdminNetworkPolicy rights — the egress guardrails around this namespace stay ops/GitOps-managed.

Intended as temporary delegated access for the development phase; final configuration returns to the standard GitOps workflow (and a proper least-privilege model in MOC 2.0) once stable.