### PR TITLE
fix: align nerc-ocp-test DataScienceCluster manifest with RHOAI 3.3

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/rhoai/datascienceclusters/datasciencecluster.yaml
@@ -4,35 +4,40 @@ metadata:
   name: default-dsc
 spec:
   components:
-    codeflare:
-      managementState: Managed
-    kserve:
-      managementState: Managed
-      nim:
-        managementState: Managed
-      rawDeploymentServiceConfig: Headless
-      serving:
-        ingressGateway:
-          certificate:
-            type: OpenshiftDefaultIngress
-        managementState: Managed
-        name: knative-serving
-    modelregistry:
-      managementState: Managed
-      registriesNamespace: rhoai-model-registries
-    trustyai:
-      managementState: Managed
-    ray:
-      managementState: Managed
-    kueue:
-      managementState: Managed
-    workbenches:
+    aipipelines:
       managementState: Managed
     dashboard:
       managementState: Managed
-    modelmeshserving:
+    feastoperator: {}
+    kserve:
       managementState: Managed
-    datasciencepipelines:
+      modelsAsService:
+        managementState: Removed
+      nim:
+        managementState: Managed
+      rawDeploymentServiceConfig: Headless
+    kueue:
+      defaultClusterQueueName: default
+      defaultLocalQueueName: default
+      managementState: Removed
+    llamastackoperator: {}
+    mlflowoperator:
+      managementState: Removed
+    modelregistry:
       managementState: Managed
+      registriesNamespace: rhoai-model-registries
+    ray:
+      managementState: Managed
+    trainer:
+      managementState: Removed
     trainingoperator:
       managementState: Removed
+    trustyai:
+      eval:
+        lmeval:
+          permitCodeExecution: deny
+          permitOnline: deny
+      managementState: Managed
+    workbenches:
+      managementState: Managed
+      workbenchNamespace: rhods-notebooks


### PR DESCRIPTION
## why draft?
tbd by reviewers, if we want that?

The cluster runs RHOAI 3.3.2, but the manifest still described the 2.x component layout. The datasciencecluster-v1-validator webhook rejects every ArgoCD patch attempt ("Managed is no longer supported as a managementState"), which is one of the remaining sync blockers for the cluster-scope-test application.

Align the manifest with the spec that is live on the cluster and accepted by the operator: datasciencepipelines is now aipipelines, codeflare and modelmeshserving are gone, the kserve.serving block no longer exists (gateway-based now), kueue is Removed, and the new 3.3 components (trainer, mlflowoperator, feastoperator, llamastackoperator) plus the trustyai lmeval restrictions are reflected as configured live. No change on the cluster itself.

see also
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/960