### PR TITLE
fix: align ceph-rbd StorageClass imageFeatures with live cluster state

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/feature/odf/storageclasses/ocs-external-storagecluster-ceph-rbd_patch.yaml
@@ -12,6 +12,6 @@ parameters:
   csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
-  imageFeatures: layering
+  imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
   imageFormat: "2"
   pool: nerc_ocp_test_1_rbd


### PR DESCRIPTION
## why draft?
tbd by reviewers, if we want that?

Kubernetes forbids updating parameters on an existing StorageClass, so ArgoCD's attempt to patch ocs-external-storagecluster-ceph-rbd on nerc-ocp-test fails on every sync ("parameters: Forbidden: updates to parameters are forbidden") and keeps the cluster-scope-test application in a failed sync state.

The live StorageClass has imageFeatures
layering,deep-flatten,exclusive-lock,object-map,fast-diff while the repo only listed layering. Aligning the repo with the live value removes the diff, so no patch is attempted and the sync error goes away. No change on the cluster itself.

see also
- https://github.com/OCP-on-NERC/nerc-ocp-config/pull/959