### PR TITLE
feat(nerc-backup-wasabi): cutover to dedicated wasabi-bu user

### DIFF
--- a/nerc-backup-wasabi/README.md
+++ b/nerc-backup-wasabi/README.md
@@ -5,16 +5,16 @@ cluster via rclone CronJobs. Avoids slow external uplinks; runs at datacenter
 bandwidth.
 
 ## What gets backed up (rclone `copy`, NOT `sync`; keeps deleted objects)
-- **nerc-metrics-backup/** from acm-metrics, acm-metrics-hypershift2,
+- **nerc-metrics-backup-bu/** from acm-metrics, acm-metrics-hypershift2,
   acm-metrics-test, open-telemetry, open-telemetry-test (each as a prefix).
-- **nerc-loki-backup/** from loki-logs, loki-logs-test.
+- **nerc-loki-backup-bu/** from loki-logs, loki-logs-test.
 - Target region: Wasabi us-east-1 (s3.wasabisys.com).
 
 ## Structure
 - `base/namespace.yaml`; namespace `nerc-backup-wasabi`.
 - `base/externalsecrets/`; pulls both key pairs from Vault
   (`$ENV/$CLUSTER/loki-thanos-object-storage` for NERC;
-  `$ENV/$CLUSTER/wasabi-backup` for Wasabi). The overlay sets the concrete path.
+  `$ENV/$CLUSTER/wasabi-backup-bu` for Wasabi). The overlay sets the concrete path.
 - `base/cronjobs/`; two CronJobs (backup-metrics 02:00, backup-loki 02:30 UTC).
   Each builds the rclone.conf at runtime from the secrets; no static key material.
 

--- a/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-loki.yaml
@@ -69,7 +69,7 @@ spec:
               RC
               # loki-logs is a LIVE bucket (audit/ rotates, grows). copy not sync,
               # one pass per job (no wrapper loop -> no runaway). high --transfers.
-              DST=wasabi-us:nerc-loki-backup
+              DST=wasabi-us:nerc-loki-backup-bu
               RC=0
               for B in loki-logs loki-logs-test; do
                 echo ">>> $B -> $DST/$B/ ($(date -u +%FT%TZ))"

--- a/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
+++ b/nerc-backup-wasabi/base/cronjobs/backup-metrics.yaml
@@ -67,7 +67,7 @@ spec:
               secret_access_key = ${WASABI_SK}
               no_check_bucket = true
               RC
-              DST=wasabi-us:nerc-metrics-backup
+              DST=wasabi-us:nerc-metrics-backup-bu
               RC=0
               for B in acm-metrics acm-metrics-hypershift2 acm-metrics-test open-telemetry open-telemetry-test; do
                 echo ">>> $B -> $DST/$B/ ($(date -u +%FT%TZ))"

--- a/nerc-backup-wasabi/base/externalsecrets/wasabi-creds.yaml
+++ b/nerc-backup-wasabi/base/externalsecrets/wasabi-creds.yaml
@@ -12,4 +12,4 @@ spec:
   dataFrom:
     # Wasabi backup target keys; fields: access_key_id, secret_access_key
     - extract:
-        key: $ENV/$CLUSTER/wasabi-backup
+        key: $ENV/$CLUSTER/wasabi-backup-bu

--- a/nerc-backup-wasabi/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/nerc-backup-wasabi/overlays/nerc-ocp-obs/kustomization.yaml
@@ -21,4 +21,4 @@ patches:
       spec:
         dataFrom:
           - extract:
-              key: nerc/nerc-ocp-obs/wasabi-backup
+              key: nerc/nerc-ocp-obs/wasabi-backup-bu


### PR DESCRIPTION
### Why this change was necessary:
Until now the backup wrote into the old buckets (nerc-metrics-backup, nerc-loki-backup) with an old user that had too broad permissions, and on a test wasabi.
Now it exists a new, dedicated least-privilege wasabi user (only List/Get/Put, no Delete, only own buckets) with own -bu buckets, final wasabi account, and own vault path.
This was tested complete in a separate namespace: first run (metrics 1,027 TiB, loki 4,677 TiB) and incremental re-run (metrics 116s, loki 78min), both were successful.
This cutover switches the productive GitOps backup to the new user/buckets, so we depend not anymore from the old, more broadly permissioned user, and the test wasabi.

Key changes:

- point both CronJobs (backup-metrics, backup-loki) DST to the new -bu buckets (nerc-metrics-backup-bu, nerc-loki-backup-bu)

- point the wasabi-creds ExternalSecret to the new Vault path (base: $ENV/$CLUSTER/wasabi-backup-bu; overlay nerc-ocp-obs: nerc/nerc-ocp-obs/wasabi-backup-bu)

- update README bucket names and Vault path

- no_check_bucket=true is already in place from a previous fix, is needed for the least-privilege user because it not allowed to do a HeadBucket check

- no app change is needed: the app-of-apps entry in nerc-ocp-apps only points on the config path and pulls HEAD, so it picks up this change automatic on merge

Fixes: https://github.com/CCI-MOC/ops-issues/issues/1788

Triggered by: n/a

Connected to:
- OCP-on-NERC/nerc-ocp-config#954
- OCP-on-NERC/nerc-ocp-apps#81