### PR TITLE
fix: replace wildcard DNS rules in EgressFirewall with explicit subdomains

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/egressfirewalls/suhruth-test-egress.yaml
@@ -36,24 +36,24 @@ spec:
     to:
       dnsName: oauth2.googleapis.com
 
-  # Allow Vertex AI endpoints (specific subdomain only)
+  # Allow Vertex AI endpoint for us-east5 region
   - type: Allow
     to:
-      dnsName: "*.aiplatform.googleapis.com"
+      dnsName: us-east5-aiplatform.googleapis.com
 
   # Allow Google accounts for OAuth flow
   - type: Allow
     to:
       dnsName: accounts.google.com
 
-  # Allow GitHub for OAuth
+  # Allow GitHub for OAuth and API access
   - type: Allow
     to:
       dnsName: github.com
 
   - type: Allow
     to:
-      dnsName: "*.github.com"
+      dnsName: api.github.com
 
   # Deny everything else
   - type: Deny


### PR DESCRIPTION
## Summary

- Replace `*.aiplatform.googleapis.com` with `us-east5-aiplatform.googleapis.com` (the Vertex AI region configured in LiteLLM)
- Replace `*.github.com` with `api.github.com` (the subdomain needed for GitHub OAuth/API access)

## Problem

OVN-Kubernetes EgressFirewall does not support wildcard DNS entries. Both wildcard rules were **silently failing** on every node:

```
wrk-3: EgressFirewall Rules not correctly applied: [cannot create EgressFirewall
Rule to destination for namespace suhruth-test: wildcard dns name is not supported
as rule destination, *.aiplatform.googleapis.com, cannot create EgressFirewall
Rule to destination for namespace suhruth-test: wildcard dns name is not supported
as rule destination, *.github.com]
```

This meant these destinations were not being gated by the EgressFirewall at all — traffic was only allowed because the AdminNetworkPolicy has a broad `allow-https-egress` rule to `0.0.0.0/0:443`.

## Test plan

- [ ] Verify `oc get egressfirewall default -n suhruth-test -o yaml` shows no error messages in `.status.messages` after ArgoCD syncs
- [ ] Verify OpenClaw can still reach Vertex AI (`us-east5-aiplatform.googleapis.com`) for LLM inference
- [ ] Verify GitHub OAuth flow still works through `github.com` + `api.github.com`
- [ ] Confirm no other `*.aiplatform.googleapis.com` or `*.github.com` subdomains are needed (LiteLLM config only uses `us-east5` region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)