### PR TITLE
Enable OTEL tracing for guardrails orchestrator

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-test/trustyai/guardrails-orchestrator.yaml
+++ b/cluster-scope/overlays/nerc-ocp-test/trustyai/guardrails-orchestrator.yaml
@@ -25,6 +25,12 @@ spec:
   # Number of replicas for high availability
   replicas: 1
 
+  # OpenTelemetry tracing configuration
+  otelExporter:
+    otlpProtocol: grpc
+    enableTraces: true
+    otlpTracesEndpoint: http://opentelemetry-collector.opentelemetry.svc:4317
+
   # Service configuration
   serviceConfig:
     type: ClusterIP


### PR DESCRIPTION
## Summary

- Enable OpenTelemetry trace export from the TrustyAI GuardrailsOrchestrator in `suhruth-test`
- Traces are sent via gRPC to the cluster-wide OTEL Collector (`opentelemetry-collector.opentelemetry.svc:4317`), which forwards them to the Tempo backend

## Changes

Added `otelExporter` config to the GuardrailsOrchestrator CR:
- `enableTraces: true`
- `otlpProtocol: grpc`
- `otlpTracesEndpoint: http://opentelemetry-collector.opentelemetry.svc:4317`

## Test plan

- [ ] ArgoCD syncs the updated CR
- [ ] Guardrails orchestrator pod restarts with OTEL env vars set
- [ ] Send a request through OpenClaw and verify traces appear in Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)