### PR TITLE
fix: allow OTEL collector to forward traces to Tempo distributor

### DIFF
--- a/opentelemetry/base/kustomization.yaml
+++ b/opentelemetry/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - opentelemetry-tempostack.yaml
   - opentelemetry-collector.yaml
   - opentelemetry-instrumentation.yaml
+  - tempo-distributor-allow-collector.yaml
 labels:
   - includeSelectors: true
     pairs:

--- a/opentelemetry/base/tempo-distributor-allow-collector.yaml
+++ b/opentelemetry/base/tempo-distributor-allow-collector.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tempo-distributor-allow-collector
+  namespace: opentelemetry
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: distributor
+      app.kubernetes.io/instance: opentelemetry
+      app.kubernetes.io/managed-by: tempo-operator
+      app.kubernetes.io/name: tempo
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opentelemetry-collector
+              app.kubernetes.io/managed-by: opentelemetry-operator
+      ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a NetworkPolicy allowing the OTEL collector to reach the Tempo distributor on OTLP ports (4317/4318)
- The Tempo operator's auto-generated NetworkPolicy on the distributor only allows ingress from gateway-labeled pods, which blocks the collector from forwarding traces
- Since Kubernetes NetworkPolicies are additive, this works alongside the operator-generated policy without conflicting

## Context

The OTEL collector receives traces from application pods across namespaces but cannot forward them to the Tempo distributor — every connection times out because the distributor's NetworkPolicy only allows ingress from `app.kubernetes.io/component: gateway` pods. The collector logs show:

```
Exporting failed. Dropping data. error: "no more retries left: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 172.30.158.177:4317: i/o timeout\""
```

## Test plan

- [ ] Verify the NetworkPolicy is created in the `opentelemetry` namespace after ArgoCD sync
- [ ] Check that OTEL collector logs no longer show timeout errors to the distributor
- [ ] Confirm traces appear in Tempo via the query API

🤖 Generated with [Claude Code](https://claude.com/claude-code)