### PR TITLE
[feat] ai prism grafana viewer for group buha25

### DIFF
--- a/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
+++ b/cluster-scope/overlays/nerc-ocp-obs/kustomization.yaml
@@ -78,6 +78,7 @@ patches:
               - ocp-on-nerc/nerc-ops
               - ocp-on-nerc/nerc-logs-metrics
               - ocp-on-nerc/nerc-obs-admins
+              - ocp-on-nerc/buha25
   - patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key

--- a/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanas/grafana.yaml
@@ -24,6 +24,7 @@ spec:
         contains(groups[*], 'cluster-admins') && 'Admin' ||
         contains(groups[*], 'nerc-ops')  && 'Admin' ||
         contains(groups[*], 'nerc-logs-metrics')  && 'Admin' ||
+        contains(groups[*], 'buha25') && 'Viewer' ||
         'Deny'
       role_attribute_strict: 'true'
       auth_url: 'https://dex-dex.apps.obs.nerc.mghpcc.org/auth'


### PR DESCRIPTION
Why:
The AI-PRISM team (BU project, GitHub team buha25) needs read access to their new dashboard on the obs Grafana. Two things block them today: the cluster OAuth on obs only allows three GitHub teams to log in, and the Grafana OAuth role mapping only knows Admin or Deny.

Key changes:
- add ocp-on-nerc/buha25 to the GitHub identity provider teams list on nerc-ocp-obs; members get standard minimal cluster rights only
- add 'buha25' -> 'Viewer' to the Grafana role_attribute_path (before 'Deny'); Viewer is read-only, members can see dashboards but can not change or delete anything
- group membership is managed in the GitHub team ocp-on-nerc/buha25 (synced to the cluster by the group-sync-operator)

Connected to: nerc-project/operations#1562 nerc-project/operations#1566