### PR TITLE
feat(ai-prism-dashboard): v2 with workload row and corrected GPU coun…

### DIFF
--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/ai-prism-project-dashboard-v2.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/ai-prism-project-dashboard-v2.yaml
@@ -1,0 +1,1057 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: ai-prism-project-dashboard-v2
+  namespace: grafana
+  labels:
+    app: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: AI-PRISM
+  json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "graphTooltip": 1,
+      "panels": [
+        {
+          "type": "row",
+          "title": "Workload - What is actually running",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "panels": []
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "type": "table",
+          "title": "Pods with GPU requests",
+          "description": "Every pod that requests GPUs, with phase and start time. Succeeded = finished, holds no GPUs anymore (but still counts in the no-join control numbers).",
+          "gridPos": {
+            "x": 0,
+            "y": 1,
+            "w": 10,
+            "h": 9
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "refId": "A",
+              "instant": true,
+              "format": "table",
+              "expr": "sum by(pod) (kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"nvidia_com_gpu\"})"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "refId": "B",
+              "instant": true,
+              "format": "table",
+              "expr": "max by(pod, phase) (kube_pod_status_phase{namespace=\"$namespace\"} > 0)"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "refId": "C",
+              "instant": true,
+              "format": "table",
+              "expr": "max by(pod) (kube_pod_start_time{namespace=\"$namespace\"}) * 1000"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "pod",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Time 3": true,
+                  "Value #B": true
+                },
+                "renameByName": {
+                  "pod": "Pod",
+                  "phase": "Phase",
+                  "Value #A": "GPUs",
+                  "Value #C": "Started"
+                }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Started"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "dateTimeAsIso"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Pod"
+              }
+            ]
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "type": "stat",
+          "title": "CPU cores in use (3h window)",
+          "description": "Real CPU usage, robust against the sparse Barcelona samples. Near 0 while GPUs are allocated = pods likely idle (e.g. sleep infinity). Tens of cores = real training work.",
+          "gridPos": {
+            "x": 10,
+            "y": 1,
+            "w": 7,
+            "h": 5
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[3h]))",
+              "refId": "A",
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "type": "stat",
+          "title": "GPUs held by Running pods",
+          "description": "GPU requests of pods that are actually Running (2h join window). This is the number that blocks hardware.",
+          "gridPos": {
+            "x": 17,
+            "y": 1,
+            "w": 7,
+            "h": 5
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))",
+              "refId": "A",
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "type": "stat",
+          "title": "Cluster GPU capacity (barcelona)",
+          "description": "Total GPUs in the Barcelona cluster. If 'requested incl. finished' is higher than this, finished pods are inflating the numbers.",
+          "gridPos": {
+            "x": 10,
+            "y": 6,
+            "w": 7,
+            "h": 4
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "expr": "sum(kube_node_status_capacity{resource=\"nvidia_com_gpu\",cluster=\"barcelona\"})",
+              "refId": "A",
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "type": "stat",
+          "title": "GPUs requested incl. finished pods [control]",
+          "description": "Plain sum of GPU requests, no phase join - finished (Succeeded) pods are still counted here. Compare with 'GPUs held by Running pods'.",
+          "gridPos": {
+            "x": 17,
+            "y": 6,
+            "w": 7,
+            "h": 4
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"})",
+              "refId": "A",
+              "legendFormat": "__auto"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "title": "",
+          "gridPos": {
+            "x": 0,
+            "y": 10,
+            "w": 24,
+            "h": 5
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "**Reading the GPU numbers (20 / 40 / 60):**\n\n- **20** = GPUs held by **Running** pods. This is the number that really blocks hardware (the Barcelona cluster has 20 GPUs in total).\n- **40** = requests **including finished pods**. Succeeded pods (e.g. a completed pilot run) still report their GPU requests in the metrics, but they hold no GPUs anymore. Deleting finished StatefulSets/pods cleans this up.\n- **60** = short spikes during **restarts**: old and new pods overlap for a few minutes and both report requests.\n\nPanels with a Running join only count Running pods (2h window, because Barcelona sends only ~1 sample per hour). The `[control]` panels count everything on purpose - a gap between the two numbers is the signal that finished pods or scrape gaps are inflating the values."
+          },
+          "transparent": false
+        },
+        {
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "id": 1,
+          "title": "Allocated vs used",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 99,
+          "options": {
+            "content": "**Note for Barcelona projects (`b-*` namespaces):**\n\nThese projects run on the `beta-test` cluster, which does not have a DCGM exporter deployed.\n\nAs a result, GPU memory metrics (VRAM) are unavailable for `b-*` namespaces - the panel will show `0`.\n\nAll other metrics (CPU, RAM, storage, network, GPU count) are fully available.\n\n---\n\n**Note on CPU vs. GPU metrics:**\n\nCPU and GPU panels use different measurement approaches - this is not a bug, but a limitation of available metrics:\n\n- **CPU**: measured in cores (absolute consumption via cAdvisor). No pod-level utilization-% is available in this setup.\n- **GPU**: measured in utilization % (via DCGM_FI_DEV_GPU_UTIL, node-level approximation). No pod-level core count metric is available from DCGM.\n\n---\n\n**Note on GPU hours used and GPU utilization %:**\n\nGPU hours are computed as utilization (0-100%) × time, normalized to hours at 100% load:\n\n- 100% utilization for 1 hour = 1.0 GPU-hour\n- 50% utilization for 1 hour = 0.5 GPU-hours\n- 1% utilization for 1 hour = 0.01 GPU-hours\n\n⚠️ Node-level approximation: DCGM_FI_DEV_GPU_UTIL reports per GPU device on the node. The utilization % shown reflects the **node as a whole**, not individual pod allocations. If 6 GPUs are allocated but the panel shows 100%, this means the node's GPUs are fully utilized - it does not tell you which pods or how many GPUs are at 100%. If multiple namespaces share a GPU node, each namespace sees the full node utilization - values may be overestimated.",
+            "mode": "markdown"
+          },
+          "title": "",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cores"
+            }
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 21,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\",unit=\"core\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU allocated (requests, cores)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 21,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))",
+              "legendFormat": "GPUs allocated",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU allocated (requests, count)",
+          "type": "timeseries",
+          "description": "Counts only Running pods (2h join window for the sparse Barcelona samples) - finished (Succeeded) pods still report requests but hold no GPUs."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 21,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"memory\",unit=\"byte\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory allocated (requests)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 21,
+            "w": 6,
+            "h": 8
+          },
+          "id": 222,
+          "targets": [
+            {
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+              "legendFormat": "Storage allocated (requests)",
+              "refId": "A"
+            }
+          ],
+          "title": "Storage allocated (requests)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cores"
+            }
+          },
+          "gridPos": {
+            "x": 0,
+            "y": 29,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[5m]))",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU used (cores)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 29,
+            "w": 6,
+            "h": 8
+          },
+          "id": 223,
+          "targets": [
+            {
+              "expr": "sum(label_replace(DCGM_FI_DEV_GPU_UTIL, \"node\", \"$1\", \"Hostname\", \"(.+)\") * on(node) group_left() max by(node) (kube_pod_info{namespace=\"$namespace\"})) / 100",
+              "legendFormat": "GPU utilization [node-level approx]",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU utilization (%) [node-level approx]",
+          "description": "GPU utilization via DCGM_FI_DEV_GPU_UTIL (0-100%). Node-level approximation - same caveat as GPU hours used panel. Not available for b-* namespaces.",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {
+            "x": 12,
+            "y": 29,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"POD\",image!=\"\"})",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory used",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {
+            "x": 18,
+            "y": 29,
+            "w": 6,
+            "h": 8
+          },
+          "targets": [
+            {
+              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"})",
+              "refId": "A"
+            }
+          ],
+          "title": "Storage (PVC) used",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "decgbytes"
+            }
+          },
+          "gridPos": {
+            "x": 6,
+            "y": 37,
+            "w": 6,
+            "h": 8
+          },
+          "id": 20,
+          "options": {
+            "noValue": "N/A (no GPU data)"
+          },
+          "targets": [
+            {
+              "expr": "(sum by (node) (label_replace(DCGM_FI_DEV_FB_USED, \"node\", \"$1\", \"Hostname\", \"(.+)\") * on(node) group_left() max by (node) (kube_pod_info{namespace=\"$namespace\"})) / 1024) or (0 * absent(kube_pod_info{namespace=\"$namespace\", cluster=\"nerc-ocp-prod\"}))",
+              "legendFormat": "GPU memory used (GiB) [0 = no DCGM data]",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU memory used (GiB) [node-level approx]",
+          "description": "GPU VRAM usage via DCGM exporter (node-level approximation).\n\nDCGM_FI_DEV_FB_USED is node/GPU-level - if multiple namespaces share a GPU node, each will show the full node VRAM. No pod-level VRAM metric is available from DCGM.\n\n⚠️ Not available for Barcelona projects (b-* namespaces) - the beta-test cluster does not run a DCGM exporter.",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 240,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "Bps"
+                }
+              },
+              "gridPos": {
+                "x": 0,
+                "y": 31,
+                "w": 12,
+                "h": 8
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\"}[5m]) + rate(container_network_transmit_bytes_total{namespace=\"$namespace\"}[5m]))",
+                  "refId": "A"
+                }
+              ],
+              "title": "Network throughput (Rx + Tx)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "watt"
+                }
+              },
+              "gridPos": {
+                "x": 12,
+                "y": 31,
+                "w": 12,
+                "h": 8
+              },
+              "targets": [
+                {
+                  "expr": "(sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[5m])) * 15) + ((sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\",namespace=\"$namespace\"}) or vector(0)) * 250)",
+                  "legendFormat": "Estimated power (W)",
+                  "refId": "A"
+                }
+              ],
+              "title": "Estimated power usage (heuristic)",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Other Metrics",
+          "type": "row"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 53
+          },
+          "id": 220,
+          "title": "CPU Hours",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "CPU core-hours used (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 62
+          },
+          "id": 203,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\",container!=\"POD\",container!=\"\"}[5m]))[$__range:5m]) * 5 / 60",
+              "legendFormat": "CPU core-hours used",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU core-hours used (selected period)",
+          "description": "Total CPU core-hours actually consumed over the selected time range.",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "CPU core-hours allocated (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 62
+          },
+          "id": 201,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\",unit=\"core\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))[$__range:5m]) * 5 / 60",
+              "legendFormat": "CPU core-hours allocated",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU core-hours allocated (requests) [selected period]",
+          "description": "Total allocated CPU core-hours for running pods over the selected time range.",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "CPU core-hours allocated no-join (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 62
+          },
+          "id": 211,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\",unit=\"core\"})[$__range:5m]) * 5 / 60",
+              "legendFormat": "CPU core-hours allocated (no join)",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU core-hours allocated (requests, no join) [control]",
+          "description": "Control panel: CPU core-hours from requests without phase join. Compare with 'CPU core-hours allocated' above to check for scrape gaps.",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "GPU hours used (selected period)"
+            }
+          },
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 68
+          },
+          "id": 221,
+          "title": "GPU Hours",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "GPU hours used (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 69
+          },
+          "id": 204,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(label_replace(DCGM_FI_DEV_GPU_UTIL, \"node\", \"$1\", \"Hostname\", \"(.+)\") * on(node) group_left() max by(node) (kube_pod_info{namespace=\"$namespace\"}))[$__range:5m]) / 100 * 5 / 60",
+              "legendFormat": "GPU hours used",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU hours used (selected period) [node-level approx]",
+          "description": "GPU-hours used based on DCGM_FI_DEV_GPU_UTIL (0-100%) × allocated GPUs × time. Node-level approximation - same caveat as GPU memory panel. Not available for b-* namespaces.",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "GPU hours allocated (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 69
+          },
+          "id": 202,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"nvidia_com_gpu\"} * on(namespace,pod,cluster) group_left() max by(namespace,pod,cluster) (last_over_time(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"}[2h])))[$__range:5m]) * 5 / 60",
+              "legendFormat": "GPU hours allocated",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU hours allocated (requests) [selected period]",
+          "description": "Total allocated GPU-hours for running pods over the selected time range.",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "a0fa9d88-8932-41f7-af80-6f678d4fb1e7"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "decimals": 1,
+              "displayName": "GPU hours allocated no-join (selected period)"
+            }
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 69
+          },
+          "id": 212,
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "orientation": "auto",
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "expr": "sum_over_time(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"nvidia_com_gpu\"})[$__range:5m]) * 5 / 60",
+              "legendFormat": "GPU hours allocated (no join)",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU hours allocated (requests, no join) [control]",
+          "description": "Control panel: GPU hours from requests without phase join. Compare with 'GPU hours allocated' above to check for scrape gaps.",
+          "type": "stat"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 39,
+      "style": "dark",
+      "tags": [
+        "ai-prism",
+        "rhoai"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "b-prism",
+              "value": "b-prism"
+            },
+            "label": "RHOAI Project / Namespace",
+            "name": "namespace",
+            "query": "b-prism",
+            "type": "custom"
+          }
+        ]
+      },
+      "time": {
+        "from": "now/M",
+        "to": "now"
+      },
+      "timepicker": {
+        "quick_ranges": [
+          {
+            "display": "This month",
+            "from": "now/M",
+            "to": "now"
+          },
+          {
+            "display": "Last month",
+            "from": "now-1M/M",
+            "to": "now-1M/M+1M"
+          },
+          {
+            "display": "Last 30 days",
+            "from": "now-30d",
+            "to": "now"
+          },
+          {
+            "display": "Last 90 days",
+            "from": "now-90d",
+            "to": "now"
+          },
+          {
+            "display": "Last 6 months",
+            "from": "now-6M",
+            "to": "now"
+          },
+          {
+            "display": "Last 1 year",
+            "from": "now-1y",
+            "to": "now"
+          }
+        ]
+      },
+      "timezone": "browser",
+      "title": "AI-PRISM Project Dashboard v2",
+      "uid": "ai-prism-project-v2",
+      "version": 0
+    }

--- a/grafana/overlays/nerc-ocp-obs/grafanadashboards/kustomization.yaml
+++ b/grafana/overlays/nerc-ocp-obs/grafanadashboards/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - kueue-metrics-dashboard.yaml
   - nairr-pilot-project-dashboard.yaml
   - ai-prism-project-dashboard.yaml
+  - ai-prism-project-dashboard-v2.yaml


### PR DESCRIPTION
Why:
The v1 dashboard showed 40 allocated GPUs while the Barcelona cluster only has 20. Finished (Succeeded) StatefulSet pods still report their GPU requests, and the sparse Barcelona metrics (~1 sample per hour) made the Running-join panels undercount. It was also not visible whether allocated GPUs actually compute. v1 stays untouched, v2 is added next to it in the same folder.

Key changes:
- new file ai-prism-project-dashboard-v2.yaml (own CR, uid ai-prism-project-v2, folder AI-PRISM), added to kustomization
- new top row 'Workload - What is actually running': table of GPU pods (phase, start time), CPU cores in use (3h window, works as idle detector), GPUs held by Running pods, cluster GPU capacity, and a no-join control stat incl. finished pods
- text panel explaining the 20 / 40 / 60 GPU readings (Running, incl. finished pods, restart overlap)
- widen all Running-join windows from 10m to 2h so the sparse Barcelona phase samples are bridged (fixes ~30% undercount in the GPU/CPU hours allocated panels)
- rename row 'AI-PRISM - Per Project (Namespace)' to 'Allocated vs used'

Triggered by: 40 vs 20 GPU allocation question from the team
Connected to: nerc-project/operations#1562 nerc-project/operations#1566